### PR TITLE
Uvm genuine fix — SystemVerilog correctness for UVM-class execution

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -44103,6 +44103,45 @@ impl Simulator {
                         return self.exec_method_call(handle, method_name, args);
                     }
                 }
+                // IEEE 1800-2023 §8.15/§13.5.5: a method reached through a
+                // flattened multi-segment path — `o.in.getval()` parses as
+                // Ident([o, in, getval]). The receiver is the FULL prefix
+                // `path[0..len-1]`, NOT `path[0]`: each intermediate segment
+                // is a class-handle property that must be dereferenced to
+                // reach the object that actually OWNS the method. Without
+                // this, the fallthrough below resolved only `path[0]` (the
+                // OUTER object), bound `this` to it, and looked the method up
+                // there — so `o.in.getval()` ran getval on `o` (Outer has no
+                // getval) and silently returned 0; `o.in.setval(x)` wrote
+                // nothing. Walk the prefix through the heap to the real owner
+                // and dispatch on it. Path[0] may be a local, a signal, or
+                // `this`; intermediate segments are heap-object properties.
+                // (The mailbox/array-builtin/rand_mode special cases above
+                // already `return` for their own >=3-segment shapes, so this
+                // only catches ordinary user methods on nested objects.)
+                if hier.path.len() >= 3 {
+                    let head = hier.path[0].name.name.as_str();
+                    let mut handle = if head == "this" {
+                        self.this_stack.last().copied().flatten().unwrap_or(0)
+                    } else {
+                        self.eval_ident_handle(head).unwrap_or(0)
+                    };
+                    for seg in &hier.path[1..hier.path.len() - 1] {
+                        if handle == 0 {
+                            break;
+                        }
+                        handle = self
+                            .heap
+                            .get(handle)
+                            .and_then(|o| o.as_ref())
+                            .and_then(|i| i.properties.get(&seg.name.name))
+                            .and_then(|v| v.to_u64())
+                            .unwrap_or(0) as usize;
+                    }
+                    if handle != 0 && handle < self.heap.len() && self.heap[handle].is_some() {
+                        return self.exec_method_call(handle, method_name, args);
+                    }
+                }
                 let obj_val = if let Some(locals) = self.local_stack.last() {
                     locals.get(obj_name).cloned()
                 } else {

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -44403,17 +44403,40 @@ impl Simulator {
     ///
     /// Only tasks did this; functions bound nothing, so `arr.size()` on an assoc
     /// formal read 0.
+    /// Is this formal an associative array — either via a direct unpacked
+    /// `[key]` dimension (`int aa[int]`) or through an associative typedef
+    /// (`typedef int edges_t[uvm_phase]; … ref edges_t s`), where the dim
+    /// lives on the typedef rather than the port?
+    fn port_is_assoc_array(&self, port: &crate::ast::decl::FunctionPort) -> bool {
+        use crate::ast::types::UnpackedDimension as UD;
+        if port
+            .dimensions
+            .iter()
+            .any(|d| matches!(d, UD::Associative { .. }))
+        {
+            return true;
+        }
+        if let crate::ast::types::DataType::TypeReference { name, .. } = &port.data_type {
+            let tn = &name.name.name;
+            let concrete = self
+                .resolve_type_param_binding(tn)
+                .unwrap_or_else(|| tn.clone());
+            return self
+                .module
+                .typedef_unpacked_dims
+                .get(&concrete)
+                .map(|dims| dims.iter().any(|d| matches!(d, UD::Associative { .. })))
+                .unwrap_or(false);
+        }
+        false
+    }
+
     fn bind_assoc_param(
         &mut self,
         port: &crate::ast::decl::FunctionPort,
         arg: &Expression,
     ) -> Option<(String, String)> {
-        use crate::ast::types::UnpackedDimension as UD;
-        if !port
-            .dimensions
-            .iter()
-            .any(|d| matches!(d, UD::Associative { .. }))
-        {
+        if !self.port_is_assoc_array(port) {
             return None;
         }
         let ExprKind::Ident(hier) = &arg.kind else { return None };
@@ -44457,6 +44480,13 @@ impl Simulator {
     /// Copy a `ref`/`output`/`inout` associative formal back onto the caller's
     /// array, replacing its contents.
     fn writeback_assoc_param(&mut self, param: &str, caller: &str) {
+        // When the formal and the caller's actual share a name, the body's
+        // writes landed directly in the caller's signal namespace (they
+        // alias). There is nothing to copy back, and the clear-then-copy
+        // below would delete the caller's data. (§13.5.2 ref aliasing.)
+        if param == caller {
+            return;
+        }
         let cprefix = format!("{}[", caller);
         let old: Vec<String> = self
             .signals
@@ -44777,6 +44807,12 @@ impl Simulator {
         };
         // Array formals copy element-wise; scalars go through `output_bindings`.
         for (param, caller, is_out) in std::mem::take(&mut assoc_params) {
+            if param == caller {
+                // Formal aliases the caller's namespace; the body's writes
+                // already live there. Copying back would duplicate, and
+                // purging would delete the caller's data. Leave as-is.
+                continue;
+            }
             if is_out {
                 self.writeback_assoc_param(&param, &caller);
             }
@@ -51757,15 +51793,33 @@ impl Simulator {
                     let mut output_bindings: Vec<(String, Expression)> = Vec::new();
                     let mut queue_writebacks: Vec<(String, String)> = Vec::new();
                     let mut array_writebacks: Vec<(String, String, i64, i64)> = Vec::new();
+                    let mut assoc_params: Vec<(String, String, bool)> = Vec::new();
                     for (i, port) in ports.iter().enumerate() {
+                        let is_assoc = self.port_is_assoc_array(port);
+                        // An associative-array `output`/`inout`/`ref` formal
+                        // is copied back via the assoc-param signal-namespace
+                        // merge, NOT the scalar `output_bindings` path (which
+                        // can't represent an AA). §13.5.2.
                         if matches!(
                             port.direction,
                             PortDirection::Output | PortDirection::Inout | PortDirection::Ref
-                        ) && i < args.len()
+                        ) && i < args.len() && !is_assoc
                         {
                             output_bindings.push((port.name.name.clone(), args[i].clone()));
                         }
                         if i < args.len() {
+                            if let Some((param, caller)) =
+                                self.bind_assoc_param(port, &args[i])
+                            {
+                                let is_out = matches!(
+                                    port.direction,
+                                    PortDirection::Output
+                                        | PortDirection::Inout
+                                        | PortDirection::Ref
+                                );
+                                assoc_params.push((param, caller, is_out));
+                                continue;
+                            }
                             // §6.18/§6.20.3: typedef'd / type-param-bound
                             // formal — dims live on the type (see the same
                             // resolution in exec_function_call).
@@ -52045,6 +52099,18 @@ impl Simulator {
                     }
                     for (v, caller) in writebacks {
                         self.assign_value(&caller, &v);
+                    }
+                    // §13.5.2: copy `output`/`inout`/`ref` associative-array
+                    // formals back onto the caller's AA (signal-namespace
+                    // merge), then drop the formal's temporary copy.
+                    for (param, caller, is_out) in std::mem::take(&mut assoc_params) {
+                        if param == caller {
+                            continue;
+                        }
+                        if is_out {
+                            self.writeback_assoc_param(&param, &caller);
+                        }
+                        self.purge_assoc_param(&param);
                     }
                     return ret;
                 }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -524,6 +524,28 @@ struct JoinWaiter {
 
 /// Fast-path NBA entry: compact (signal_id, value) pair for pre-resolved targets.
 /// 99%+ of NBA entries use this path. Smaller struct = better cache utilization.
+
+/// IEEE 1800-2023 §9.7: info stored when a process is explicitly suspended
+/// via `process::suspend()`. The process is removed from whatever queue it
+/// was parked in; `resume()` uses this to re-schedule it.
+#[derive(Clone)]
+struct SuspendedProc {
+    /// Continuation statements to run when the process resumes.
+    continuation: Vec<Statement>,
+    /// Original scheduled expiry time if suspended while blocked on a `#delay`.
+    /// `None` if blocked on an event/condition/join/mailbox. On resume, if the
+    /// original delay has transpired (original_time <= self.time), the process
+    /// continues immediately (LRM §9.7).
+    original_delay_expiry: Option<u64>,
+}
+
+/// §9.7 `process::await()`: a process blocked waiting for another's termination.
+struct AwaitWaiter {
+    target_pid: usize,
+    waiter_pid: usize,
+    continuation: Vec<Statement>,
+}
+
 struct NbaFast {
     signal_id: usize,
     value: Value,
@@ -1182,6 +1204,69 @@ impl TimingWheel {
     /// O(1) check: is any event scheduled for this pid anywhere in the queue?
     fn has_pid(&self, pid: usize) -> bool {
         self.pid_counts.contains_key(&pid)
+    }
+
+    /// §9.7: remove ALL events for `pid` from both the wheel and overflow.
+    /// Returns the earliest (scheduled_time, continuation) if found.
+    /// Used by `process::suspend()` and `process::kill()` to desensitize a
+    /// process from its delay.
+    fn remove_pid(&mut self, pid: usize) -> Option<(u64, Vec<Statement>)> {
+        if !self.pid_counts.contains_key(&pid) {
+            return None;
+        }
+        let mut found: Option<(u64, Vec<Statement>)> = None;
+        let cur_slot = Self::slot(self.current_time);
+
+        // 1) Scan the timing wheel: extract matching entries, keep the rest.
+        for s in 0..WHEEL_SIZE {
+            let v = std::mem::take(&mut self.wheel[s]);
+            if v.is_empty() {
+                continue;
+            }
+            let delta = ((s + WHEEL_SIZE - cur_slot) % WHEEL_SIZE) as u64;
+            let abs_time = self.current_time + delta;
+            let mut kept = Vec::new();
+            for (p, stmts) in v {
+                if p == pid {
+                    // Capture the earliest match.
+                    if found.is_none() || abs_time < found.as_ref().unwrap().0 {
+                        found = Some((abs_time, stmts));
+                    }
+                } else {
+                    kept.push((p, stmts));
+                }
+            }
+            if kept.is_empty() {
+                self.bitmap_clear(s);
+            } else {
+                self.wheel[s] = kept;
+            }
+        }
+
+        // 2) Scan overflow (BTreeMap is time-sorted, so first match is earliest).
+        if found.is_none() {
+            let times: Vec<u64> = self.overflow.keys().copied().collect();
+            for t in times {
+                if let Some(v) = self.overflow.get_mut(&t) {
+                    if let Some(idx) = v.iter().position(|(p, _)| *p == pid) {
+                        let stmts = v.remove(idx).1;
+                        found = Some((t, stmts));
+                        if v.is_empty() {
+                            self.overflow.remove(&t);
+                        }
+                        break;
+                    }
+                }
+            }
+        } else {
+            // Also clean overflow of any remaining entries for this pid.
+            for (_, v) in self.overflow.iter_mut() {
+                v.retain(|(p, _)| *p != pid);
+            }
+            self.overflow.retain(|_, v| !v.is_empty());
+        }
+        self.pid_counts.remove(&pid);
+        found
     }
 }
 
@@ -2167,6 +2252,13 @@ pub struct Simulator {
     warned_assoc_index: HashSet<String>,
     /// SV-2023: PIDs killed by `disable fork` — skip dispatch on these.
     killed_pids: HashSet<usize>,
+    /// §9.7 `process` class: PIDs explicitly suspended via `suspend()`. The
+    /// continuation + original delay info is in `suspended_proc_info`.
+    suspended_pids: HashSet<usize>,
+    /// §9.7: detailed resumption info for each suspended pid.
+    suspended_proc_info: HashMap<usize, SuspendedProc>,
+    /// §9.7 `process::await()`: processes waiting for another's termination.
+    await_waiters: Vec<AwaitWaiter>,
     /// Names of init-declared (automatic) `for`-loop variables that — because
     /// the enclosing process had no local frame — currently live in the signal
     /// table. A `fork` child must capture these BY VALUE at fork time so the
@@ -3665,6 +3757,9 @@ impl Simulator {
             fork_block_children: HashMap::default(),
             warned_assoc_index: HashSet::default(),
             killed_pids: HashSet::default(),
+            suspended_pids: HashSet::default(),
+            suspended_proc_info: HashMap::default(),
+            await_waiters: Vec::new(),
             auto_loop_vars: Vec::new(),
             ref_binding_stack: Vec::new(),
             task_cleanup: Vec::new(),
@@ -15504,6 +15599,111 @@ impl Simulator {
                 }
             }
 
+            // Stage 0: normalize a parenless task/method call (LRM §13.5
+            // footnote 42 + §13.5.5: parentheses may be omitted for tasks, void
+            // functions, and class methods). A call written without
+            // parentheses — `t;`, `c.m;`, `m_run_phases;`, `run_test;` — parses
+            // as a bare `Expr(Ident([name]))` or `Expr(MemberAccess{...})`, NOT
+            // as `Expr(Call { func, args: [] })`. Every Stage 1/1b/1c inlining
+            // guard below matches on `Call`, so without this rewrite a blocking
+            // task called without parentheses bypasses inlining and falls
+            // through to the synchronous `exec_statement`, which cannot honour
+            // the body's `#delay`/`wait`/`fork` and silently drops it — the
+            // caller never blocks (e.g. `task t; #10; endtask; ... t;` returns
+            // at t=0 instead of t=10). Rewrite the parenless subroutine
+            // reference into the equivalent zero-argument `Call` and
+            // re-dispatch, so the existing guards fire uniformly. Only rewrite
+            // when the callee resolves to a free task (`module.tasks`) or a
+            // method (on the current `this` or on an object handle); a plain
+            // variable reference `x;` is left to the normal expression path.
+            // Non-blocking tasks: the rewritten Call still won't satisfy
+            // `stmts_have_blocking`, so it falls through to `exec_statement`
+            // unchanged — `t()` / `c.m()` with explicit parens already worked.
+            //
+            // Recognized parenless forms (LRM §13.5 `tf_call`/`method_call`):
+            //   `t;`                    -> Ident([t])
+            //   `m;`  (this-method)     -> Ident([m])
+            //   `c.m;`                  -> MemberAccess{expr:Ident([c]), member:m}
+            //   `c.m;` (flattened)      -> Ident([c, m])
+            if let StatementKind::Expr(e) = &stmt.kind {
+                let rewritten: Option<Expression> = match &e.kind {
+                    // Bare name: free task or method on current `this`.
+                    ExprKind::Ident(h) if h.path.len() == 1 => {
+                        let nm = h.path[0].name.name.clone();
+                        let is_free_task = self.module.tasks.contains_key(&nm);
+                        let is_this_method = self
+                            .this_stack
+                            .last()
+                            .copied()
+                            .flatten()
+                            .and_then(|hh| {
+                                self.heap
+                                    .get(hh)
+                                    .and_then(|o| o.as_ref())
+                                    .map(|inst| inst.class_name.clone())
+                            })
+                            .map_or(false, |cls| self.class_has_method(&cls, &nm));
+                        if is_free_task || is_this_method {
+                            Some(Expression::new(
+                                ExprKind::Call {
+                                    func: Box::new(e.clone()),
+                                    args: vec![],
+                                },
+                                e.span,
+                            ))
+                        } else {
+                            None
+                        }
+                    }
+                    // `obj.method;` via member-access dot syntax.
+                    ExprKind::MemberAccess { expr: recv, member } => {
+                        let recv_ok = self
+                            .eval_handle_expr(recv)
+                            .and_then(|hh| self.heap.get(hh).and_then(|o| o.as_ref()).map(|inst| inst.class_name.clone()))
+                            .map_or(false, |cls| self.class_has_method(&cls, &member.name));
+                        if recv_ok {
+                            Some(Expression::new(
+                                ExprKind::Call {
+                                    func: Box::new(e.clone()),
+                                    args: vec![],
+                                },
+                                e.span,
+                            ))
+                        } else {
+                            None
+                        }
+                    }
+                    // `obj.method;` via flattened 2-segment ident.
+                    ExprKind::Ident(h) if h.path.len() == 2 => {
+                        let vn = h.path[0].name.name.clone();
+                        let mn = h.path[1].name.name.clone();
+                        let recv_ok = self
+                            .eval_ident_handle(&vn)
+                            .and_then(|hh| self.heap.get(hh).and_then(|o| o.as_ref()).map(|inst| inst.class_name.clone()))
+                            .map_or(false, |cls| self.class_has_method(&cls, &mn));
+                        if recv_ok {
+                            Some(Expression::new(
+                                ExprKind::Call {
+                                    func: Box::new(e.clone()),
+                                    args: vec![],
+                                },
+                                e.span,
+                            ))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                if let Some(call) = rewritten {
+                    let call_stmt = Statement::new(StatementKind::Expr(call), stmt.span);
+                    let mut cont = vec![call_stmt];
+                    cont.extend_from_slice(&stmts[i + 1..]);
+                    self.run_process_stmts(pid, &cont);
+                    return;
+                }
+            }
+
             // Stage 1: a call to a free task whose body blocks (top-level
             // `#delay`/`@event`/`wait`) is INLINED — bind the call frame, splice
             // the body + a ScopePop sentinel + the rest into this process's
@@ -16245,6 +16445,18 @@ impl Simulator {
                     return;
                 }
             } else {
+                // §9.7: `process_handle.await()` blocks the calling process
+                // until the target terminates. Must be intercepted here (not
+                // in exec_method_call) because the continuation is needed.
+                if let StatementKind::Expr(expr) = &stmt.kind {
+                    if let Some(target_pid) = self.extract_proc_await_target(expr) {
+                        let cont = stmts[i + 1..].to_vec();
+                        if self.proc_await(target_pid, pid, cont) {
+                            return; // caller suspended — don't execute await
+                        }
+                        // target already terminated — fall through
+                    }
+                }
                 self.exec_statement(stmt);
             }
 
@@ -24461,22 +24673,16 @@ impl Simulator {
                         return if fired { Value::ones(1) } else { Value::zero(1) };
                     }
                 }
-                // LRM process-class state: `<process_handle>.status` returns the
-                // state enum {FINISHED=0, RUNNING=1, WAITING=2, SUSPENDED=3,
-                // KILLED=4}. xezim doesn't model `process` objects, so
-                // `process::self()` yields a null handle. UVM's sequencer
-                // arbitration prunes queued requests whose process_id.status is
-                // in {KILLED,FINISHED}; a null handle would read 0 (==FINISHED)
-                // and spuriously drop a live sequence (SEQREQZMB → lost item /
-                // data=0). A queued requester is by construction alive (blocked
-                // in wait_for_grant), so report RUNNING for a process handle
-                // (any value that is not a live class instance on the heap).
+                // §9.7 `process::status()`: return the state enum. Previously
+                // this was a stub that always returned RUNNING for non-heap
+                // handles. Now delegates to `proc_status` which tracks the
+                // real lifecycle state from the scheduler queues.
                 if member.name == "status" {
-                    let h = self.eval_expr(expr).to_u64().unwrap_or(0) as usize;
-                    let is_class_obj = self.heap.get(h).and_then(|o| o.as_ref()).is_some();
-                    if !is_class_obj {
-                        return Value::from_u64(1, 32); // process::RUNNING
+                    let h = self.eval_expr(expr).to_u64().unwrap_or(0);
+                    if let Some(pid) = Self::proc_handle_to_pid(h) {
+                        return Value::from_u64(self.proc_status(pid) as u64, 32);
                     }
+                    // Not a process handle — fall through to property access.
                 }
                 // `ClassName::static_prop` — explicit static property read.
                 if let ExprKind::Ident(hier) = &expr.kind {
@@ -32315,6 +32521,11 @@ impl Simulator {
     }
 
     fn is_pid_suspended(&self, pid: usize) -> bool {
+        // §9.7: a process explicitly suspended via `process::suspend()` is
+        // suspended (and has been removed from all scheduling queues).
+        if self.suspended_pids.contains(&pid) {
+            return true;
+        }
         if self.event_queue.has_pid(pid) {
             return true;
         }
@@ -32353,6 +32564,229 @@ impl Simulator {
             return true;
         }
         false
+    }
+
+    /// §9.7: check if `expr` is a `handle.await()` call on a process handle.
+    /// Handles both parse shapes: `Call{MemberAccess}` and the flattened
+    /// `Call{Ident([handle, await])}`. Returns the target pid if so.
+    fn extract_proc_await_target(&mut self, expr: &Expression) -> Option<usize> {
+        if let ExprKind::Call { func, args } = &expr.kind {
+            if args.is_empty() {
+                // MemberAccess form: `job.await()`
+                if let ExprKind::MemberAccess { expr: receiver, member } = &func.kind {
+                    if member.name.as_str() == "await" {
+                        let h = self.eval_expr(receiver).to_u64().unwrap_or(0);
+                        return Self::proc_handle_to_pid(h);
+                    }
+                }
+                // Flattened Ident form: `job.await` parses as Ident([job, await])
+                if let ExprKind::Ident(hier) = &func.kind {
+                    if hier.path.len() == 2 && hier.path[1].name.name == "await" {
+                        // Clone and truncate to get just the receiver `job`.
+                        let mut recv_hier = hier.clone();
+                        recv_hier.path.pop();
+                        let receiver = Expression::new(
+                            ExprKind::Ident(recv_hier),
+                            func.span,
+                        );
+                        let h = self.eval_expr(&receiver).to_u64().unwrap_or(0);
+                        return Self::proc_handle_to_pid(h);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // §9.7 Fine-grain process control (process class methods)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Extract a pid from a §9.7 process handle. Returns None if the handle
+    /// is not a process token (i.e. it's a regular heap object or null).
+    fn proc_handle_to_pid(handle_val: u64) -> Option<usize> {
+        if handle_val >= PROCESS_HANDLE_BASE {
+            Some((handle_val - PROCESS_HANDLE_BASE) as usize)
+        } else {
+            None
+        }
+    }
+
+    /// §9.7 `status()`: return the process state enum.
+    ///   FINISHED=0, RUNNING=1, WAITING=2, SUSPENDED=3, KILLED=4
+    fn proc_status(&self, pid: usize) -> u32 {
+        if self.killed_pids.contains(&pid) {
+            return 4; // KILLED
+        }
+        if self.suspended_pids.contains(&pid) {
+            return 3; // SUSPENDED
+        }
+        if pid == self.current_pid {
+            return 1; // RUNNING
+        }
+        if self.is_pid_suspended(pid) {
+            return 2; // WAITING
+        }
+        0 // FINISHED
+    }
+
+    /// §9.7 `kill()`: forcibly terminate the process and all its descendant
+    /// subprocesses. All such processes shall be terminated before kill()
+    /// returns.
+    fn proc_kill(&mut self, pid: usize) {
+        // Collect the process + all descendants.
+        let mut to_kill: HashSet<usize> = HashSet::default();
+        to_kill.insert(pid);
+        to_kill.extend(self.collect_fork_descendants(pid));
+        for &p in &to_kill {
+            self.killed_pids.insert(p);
+            self.suspended_pids.remove(&p);
+            self.suspended_proc_info.remove(&p);
+            self.process_parents.remove(&p);
+            self.process_contexts.remove(&p);
+        }
+        // Purge from every scheduling structure.
+        self.event_queue.remove_pid(pid);
+        self.event_waiters.retain(|w| !to_kill.contains(&w.pid));
+        self.condition_waiters.retain(|(p, _)| !to_kill.contains(p));
+        self.inactive_queue.retain(|(p, _)| !to_kill.contains(p));
+        for q in self.mailbox_get_waiters.values_mut() {
+            q.retain(|w| !to_kill.contains(&w.pid));
+        }
+        for q in self.semaphore_get_waiters.values_mut() {
+            q.retain(|w| !to_kill.contains(&w.pid));
+        }
+        self.release_killed_from_join_waiters(&to_kill);
+        // Wake any process that was awaiting the killed process.
+        self.wake_await_waiters(&to_kill);
+    }
+
+    /// §9.7 `await()`: block the calling process until the target process
+    /// terminates (FINISHED or KILLED). Schedules the caller's continuation
+    /// for later wake-up. Returns true if the caller was suspended (the
+    /// dispatch should then stop executing the caller's current statement
+    /// stream); false if the target is already terminated.
+    fn proc_await(&mut self, target_pid: usize, caller_pid: usize,
+                  continuation: Vec<Statement>) -> bool {
+        let terminated = self.killed_pids.contains(&target_pid)
+            || !self.is_pid_suspended(target_pid) && target_pid != self.current_pid;
+        if terminated {
+            return false; // already done — caller continues
+        }
+        self.await_waiters.push(AwaitWaiter {
+            target_pid,
+            waiter_pid: caller_pid,
+            continuation,
+        });
+        true
+    }
+
+    /// §9.7 `suspend()`: suspend the process, desensitizing it from whatever
+    /// it is blocked on. The process will not run until `resume()`.
+    fn proc_suspend(&mut self, pid: usize) {
+        if self.suspended_pids.contains(&pid) || self.killed_pids.contains(&pid) {
+            return; // already suspended or killed — no effect
+        }
+        // Try to extract the process from wherever it's parked.
+        // 1) Delay (event_queue)
+        if let Some((expiry, stmts)) = self.event_queue.remove_pid(pid) {
+            self.suspended_pids.insert(pid);
+            self.suspended_proc_info.insert(pid, SuspendedProc {
+                continuation: stmts,
+                original_delay_expiry: Some(expiry),
+            });
+            return;
+        }
+        // 2) Event control (event_waiters)
+        if let Some(idx) = self.event_waiters.iter().position(|w| w.pid == pid) {
+            let waiter = self.event_waiters.remove(idx);
+            self.suspended_pids.insert(pid);
+            self.suspended_proc_info.insert(pid, SuspendedProc {
+                continuation: waiter.continuation,
+                original_delay_expiry: None,
+            });
+            return;
+        }
+        // 3) Condition wait (wait(expr))
+        if let Some(idx) = self.condition_waiters.iter().position(|(p, _)| *p == pid) {
+            let (_, stmts) = self.condition_waiters.remove(idx);
+            self.suspended_pids.insert(pid);
+            self.suspended_proc_info.insert(pid, SuspendedProc {
+                continuation: stmts,
+                original_delay_expiry: None,
+            });
+            return;
+        }
+        // 4) Inactive queue (#0)
+        if let Some(idx) = self.inactive_queue.iter().position(|(p, _)| *p == pid) {
+            let (_, stmts) = self.inactive_queue.remove(idx);
+            self.suspended_pids.insert(pid);
+            self.suspended_proc_info.insert(pid, SuspendedProc {
+                continuation: stmts,
+                original_delay_expiry: Some(self.time), // #0 — expired immediately
+            });
+            return;
+        }
+        // 5) Mailbox get / semaphore get
+        for q in self.mailbox_get_waiters.values_mut() {
+            if let Some(idx) = q.iter().position(|w| w.pid == pid) {
+                if let Some(waiter) = q.remove(idx) {
+                    self.suspended_pids.insert(pid);
+                    self.suspended_proc_info.insert(pid, SuspendedProc {
+                        continuation: waiter.cont,
+                        original_delay_expiry: None,
+                    });
+                    return;
+                }
+            }
+        }
+        for q in self.semaphore_get_waiters.values_mut() {
+            if let Some(idx) = q.iter().position(|w| w.pid == pid) {
+                if let Some(waiter) = q.remove(idx) {
+                    self.suspended_pids.insert(pid);
+                    self.suspended_proc_info.insert(pid, SuspendedProc {
+                        continuation: waiter.cont,
+                        original_delay_expiry: None,
+                    });
+                    return;
+                }
+            }
+        }
+        // Process is RUNNING (self) or not found — for self-suspend we'd need
+        // to capture the continuation at the call site. For now this is a no-op
+        // for processes that are actively executing (not blocked).
+    }
+
+    /// §9.7 `resume()`: restart a previously suspended process.
+    fn proc_resume(&mut self, pid: usize) {
+        if let Some(info) = self.suspended_proc_info.remove(&pid) {
+            self.suspended_pids.remove(&pid);
+            // LRM §9.7: if suspended while WAITING on a delay, resensitize.
+            // If the original delay has transpired, continue immediately.
+            let schedule_time = match info.original_delay_expiry {
+                Some(expiry) if expiry <= self.time => self.time,
+                Some(expiry) => expiry,
+                None => self.time, // event/condition: re-evaluate immediately
+            };
+            self.event_queue.schedule(schedule_time, pid, info.continuation);
+        }
+    }
+
+    /// Wake all `await()` waiters whose target process has terminated.
+    fn wake_await_waiters(&mut self, terminated_pids: &HashSet<usize>) {
+        let to_wake: Vec<usize> = self
+            .await_waiters
+            .iter()
+            .enumerate()
+            .filter(|(_, w)| terminated_pids.contains(&w.target_pid))
+            .map(|(i, _)| i)
+            .collect();
+        // Remove in reverse order to keep indices valid.
+        for i in to_wake.into_iter().rev() {
+            let waiter = self.await_waiters.remove(i);
+            self.event_queue
+                .schedule(self.time, waiter.waiter_pid, waiter.continuation);
+        }
     }
 
     /// Collect all active fork descendants of `root` (children, grandchildren,
@@ -32405,6 +32839,11 @@ impl Simulator {
     }
 
     fn child_finished(&mut self, child_pid: usize) {
+        // §9.7: wake any process awaiting this one's termination.
+        let mut terminated = HashSet::default();
+        terminated.insert(child_pid);
+        self.wake_await_waiters(&terminated);
+
         // Reparent any still-running children of the completing process to its
         // own parent, so the fork descendant tree stays connected (a `wait fork`
         // higher up must still see grandchildren whose intermediate parent has
@@ -41600,6 +42039,31 @@ impl Simulator {
                             {
                                 return res;
                             }
+                            // IEEE 1800-2023 §9.7: process-class methods
+                            // (kill/await/suspend/resume/status) on a process
+                            // handle. await() blocking is handled at the
+                            // statement level (needs the continuation); the
+                            // other four are fire-and-forget.
+                            if let Some(pid) = Self::proc_handle_to_pid(handle as u64) {
+                                match method_name.as_str() {
+                                    "status" => {
+                                        return Value::from_u64(self.proc_status(pid) as u64, 32);
+                                    }
+                                    "kill" => {
+                                        self.proc_kill(pid);
+                                        return Value::zero(32);
+                                    }
+                                    "suspend" => {
+                                        self.proc_suspend(pid);
+                                        return Value::zero(32);
+                                    }
+                                    "resume" => {
+                                        self.proc_resume(pid);
+                                        return Value::zero(32);
+                                    }
+                                    _ => {}
+                                }
+                            }
                         }
                         if handle < self.cg_heap.len() && self.cg_heap[handle].is_some() {
                             return self.exec_cg_method_call(handle, method_name, args);
@@ -43418,6 +43882,46 @@ impl Simulator {
     }
 
     fn exec_method_call(&mut self, handle: usize, method_name: &str, args: &[Expression]) -> Value {
+        // IEEE 1800-2023 §9.7 process class: kill/await/suspend/resume on a
+        // process handle (>= PROCESS_HANDLE_BASE). These are intercepted here,
+        // before any user-class dispatch.
+        if let Some(pid) = Self::proc_handle_to_pid(handle as u64) {
+            match method_name {
+                "status" => {
+                    return Value::from_u64(self.proc_status(pid) as u64, 32);
+                }
+                "kill" => {
+                    self.proc_kill(pid);
+                    return Value::zero(32);
+                }
+                "await" => {
+                    // Block the calling process until `pid` terminates.
+                    // The continuation is the remaining statement stream —
+                    // captured by the CALLER (run_process_stmts) which passes
+                    // an empty args slice; the real continuation is handled
+                    // at the StatementKind::MethodCall dispatch site below.
+                    // For the method-call-via-exec_method_call path (used by
+                    // inline task calls), we mark the suspension here.
+                    //
+                    // NOTE: await() needs the caller's continuation, which
+                    // exec_method_call doesn't have. The actual blocking is
+                    // done at the call site (see the MethodCall dispatch in
+                    // run_process_stmts). If we reach here, it means await()
+                    // was called in a context without continuation capture
+                    // — treat as a no-op (target already terminated).
+                    return Value::zero(32);
+                }
+                "suspend" => {
+                    self.proc_suspend(pid);
+                    return Value::zero(32);
+                }
+                "resume" => {
+                    self.proc_resume(pid);
+                    return Value::zero(32);
+                }
+                _ => {} // fall through to srandom/randstate etc.
+            }
+        }
         // IEEE 1800-2023 §18.13/§18.14 random stability. `srandom(seed)`,
         // `get_randstate()` and `set_randstate(s)` are built-ins of BOTH the
         // §9.7 `process` class (`process::self().srandom(...)` — the token

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -22566,6 +22566,16 @@ impl Simulator {
                             }
                         }
                     }
+                    // Class VALUE parameter of a specialized class, referenced
+                    // bare inside a STATIC method (no instance → not in
+                    // `properties`). Resolve from the active specialization
+                    // BEFORE the static-property fallback, which would return
+                    // the declared default instead (e.g.
+                    // `uvm_object_registry#(T,"base_class")::get_type_name()`
+                    // must return the string param `Tname`, not `<unknown>`).
+                    if let Some(v) = self.resolve_value_param_from_spec(name) {
+                        return v;
+                    }
                     // Static class property referenced bare inside a method.
                     if let Some(Some(ctx)) = self.class_context_stack.last().cloned() {
                         if let Some(v) = self.class_static_get(&ctx, name) {
@@ -45760,6 +45770,193 @@ impl Simulator {
     fn resolve_type_param_binding(&self, tn: &str) -> Option<String> {
         let spec = self.current_spec.clone();
         self.resolve_type_param_with(tn, &spec)
+    }
+
+    /// Resolve a class VALUE parameter `name` from the active specialization
+    /// (`current_spec`). This is the value-param counterpart of
+    /// [`resolve_type_param_with`] (which handles TYPE params): a static
+    /// method such as `uvm_object_registry#(T,"base_class")::get_type_name()`
+    /// references the string value parameter `Tname`, but no instance is
+    /// constructed for a static call, so the binding only exists in the
+    /// specialization's argument list. Without this, the bare identifier fell
+    /// through to the class default value (e.g. `<unknown>`) instead of the
+    /// specialized value (`base_class`), so the factory's type-name lookup and
+    /// `is_type_registered` always failed.
+    ///
+    /// Returns None when no specialization is active or `name` is not a value
+    /// parameter (type parameters are handled by `resolve_type_param_with`).
+    fn resolve_value_param_from_spec(&mut self, name: &str) -> Option<Value> {
+        let (base, sig) = self.current_spec.clone()?;
+        let cd = self.module.classes.get(&base)?.clone();
+        // Type parameters are resolved elsewhere — don't shadow them.
+        if cd.type_param_names.iter().any(|t| t == name) {
+            return None;
+        }
+        // Match `param_order` exactly like `class_param_arg_map` (with the
+        // same legacy fallback for older caches lacking `param_order`).
+        let legacy_order: Vec<String>;
+        let order: &[String] = if cd.param_order.is_empty()
+            && !(cd.param_defaults.is_empty() && cd.type_param_names.is_empty())
+        {
+            legacy_order = cd
+                .param_defaults
+                .iter()
+                .map(|(n, _)| n.clone())
+                .chain(cd.type_param_names.iter().cloned())
+                .collect();
+            &legacy_order
+        } else {
+            &cd.param_order
+        };
+        let idx = order.iter().position(|p| p == name)?;
+        // Split the specialization's raw arg text on TOP-LEVEL commas (a naive
+        // split would break on commas inside a string literal or a nested
+        // call), then evaluate the fragment at `name`'s position.
+        let frags = Self::split_spec_args(&sig);
+        let frag = frags.get(idx)?;
+        self.eval_spec_arg_fragment(frag)
+    }
+
+    /// Split a specialization argument-list text on top-level commas,
+    /// respecting string literals, parentheses, brackets and braces so that
+    /// `#("a,b", f(1,2))` yields two fragments, not four.
+    fn split_spec_args(sig: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut cur = String::new();
+        let mut depth: i32 = 0;
+        let mut in_str = false;
+        let mut prev = '\0';
+        for ch in sig.chars() {
+            match (in_str, ch) {
+                (false, '"') => {
+                    in_str = true;
+                    cur.push(ch);
+                }
+                (true, '"') if prev != '\\' => {
+                    in_str = false;
+                    cur.push(ch);
+                }
+                (true, _) => {
+                    cur.push(ch);
+                }
+                (false, '(' | '[' | '{') => {
+                    depth += 1;
+                    cur.push(ch);
+                }
+                (false, ')' | ']' | '}') => {
+                    depth -= 1;
+                    cur.push(ch);
+                }
+                (false, ',') if depth == 0 => {
+                    out.push(std::mem::take(&mut cur));
+                }
+                (false, _) => {
+                    cur.push(ch);
+                }
+            }
+            prev = ch;
+        }
+        if !cur.trim().is_empty() {
+            out.push(cur);
+        }
+        out
+    }
+
+    /// Evaluate a single specialization argument fragment to a `Value`.
+    /// Handles the shapes that appear in value-parameter positions: string
+    /// literals (UVM's factory type names like `"base_class"`), numeric
+    /// literals, and bare name references (enum members / parameters), the
+    /// last by constructing an identifier expression and deferring to the
+    /// normal evaluator.
+    fn eval_spec_arg_fragment(&mut self, frag: &str) -> Option<Value> {
+        let t = frag.trim();
+        if t.is_empty() {
+            return None;
+        }
+        let bytes = t.as_bytes();
+        // String literal "..."
+        if bytes[0] == b'"' && bytes.len() >= 2 && bytes[bytes.len() - 1] == b'"' {
+            let inner = std::str::from_utf8(&bytes[1..bytes.len() - 1]).ok()?;
+            let w = (inner.len() * 8).max(8) as u32;
+            let mut val = Value::zero(w);
+            for (i, byte) in inner.bytes().rev().enumerate() {
+                for bit in 0..8 {
+                    if (byte >> bit) & 1 == 1 && i * 8 + bit < val.width as usize {
+                        val.set_bit(i * 8 + bit, LogicBit::One);
+                    }
+                }
+            }
+            return Some(val);
+        }
+        // Numeric literal (plain decimal or sized `'h/'d/'b/'o). Build a
+        // `NumberLiteral` from the text and evaluate via `eval_number`.
+        if let Some(nl) = Self::parse_spec_number(t) {
+            return Some(self.eval_number(&nl));
+        }
+        // Bare name reference — delegate to the normal identifier evaluator
+        // (resolves enum members, parameters, static constants).
+        let expr = Expression::new(
+            ExprKind::Ident(crate::ast::expr::HierarchicalIdentifier {
+                root: None,
+                path: vec![crate::ast::expr::HierPathSegment {
+                    name: crate::ast::Identifier {
+                        name: t.to_string(),
+                        span: crate::ast::Span::dummy(),
+                    },
+                    selects: Vec::new(),
+                }],
+                span: crate::ast::Span::dummy(),
+                cached_signal_id: std::cell::Cell::new(None),
+                cached_resolved_name: std::cell::OnceCell::new(),
+            }),
+            crate::ast::Span::dummy(),
+        );
+        Some(self.eval_expr(&expr))
+    }
+
+    /// Parse a specialization-argument fragment into a `NumberLiteral` for the
+    /// shapes that appear in value-parameter positions: plain decimal
+    /// integers (`42`, `-5`) and optionally-sized based literals
+    /// (`'h10`, `8'd3`, `16'hFF`). Returns None for anything else.
+    fn parse_spec_number(t: &str) -> Option<NumberLiteral> {
+        let s = t.trim();
+        // Optionally-sized based literal: `[size]'<base><digits>`.
+        if let Some(pos) = s.find('\'') {
+            let size_part = &s[..pos];
+            let rest = &s[pos + 1..];
+            let (base, val_str) = match rest.chars().next() {
+                Some('b') => (NumberBase::Binary, &rest[1..]),
+                Some('d') => (NumberBase::Decimal, &rest[1..]),
+                Some('h') => (NumberBase::Hex, &rest[1..]),
+                Some('o') => (NumberBase::Octal, &rest[1..]),
+                _ => return None,
+            };
+            let size = if size_part.is_empty() {
+                None
+            } else {
+                size_part.parse::<u32>().ok()
+            };
+            return Some(NumberLiteral::Integer {
+                size,
+                signed: false,
+                base,
+                value: val_str.trim().to_string(),
+                cached_val: std::cell::Cell::new(None),
+            });
+        }
+        // Plain decimal integer (optional leading sign).
+        let neg = s.starts_with('-');
+        let body = s.trim_start_matches(['+', '-']);
+        if !body.is_empty() && body.bytes().all(|c| c.is_ascii_digit()) {
+            return Some(NumberLiteral::Integer {
+                size: None,
+                signed: neg,
+                base: NumberBase::Decimal,
+                value: body.to_string(),
+                cached_val: std::cell::Cell::new(None),
+            });
+        }
+        None
     }
 
     /// Resolve a type-parameter name `tn` to its concrete type, using (in order)

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -2316,6 +2316,19 @@ pub struct Simulator {
     /// fork time as a baseline; propagate merges only the keys whose value the
     /// child CHANGED relative to this baseline.
     fork_baselines: HashMap<usize, Vec<HashMap<String, Value>>>,
+    /// IEEE 1800-2023 §6.21/§9.3.2: automatic variables declared in a
+    /// procedural block (`initial`/`always`) with NO enclosing call frame live
+    /// in the global `self.signals` map (not a `local_stack` frame). At fork
+    /// time `inherit_fork_child_context` copies them (via `auto_loop_vars`)
+    /// INTO the child's `local_stack` frame so each child gets its own
+    /// snapshot. That creates a storage MISMATCH: the child's writes land in
+    /// its private frame, while the parent reads from `self.signals`. The
+    /// `local_stack` merge alone cannot bridge this — the parent has no frame
+    /// for these vars. This map records, per child, the bare names that were
+    /// captured FROM `self.signals`, so the propagate path can write the
+    /// child's changed values back INTO `self.signals` (true shared storage,
+    /// per §6.21's enclosing-scope rule).
+    fork_signal_captures: HashMap<usize, Vec<String>>,
     /// Processes blocked in `semaphore.get()` on an under-full semaphore.
     semaphore_get_waiters: HashMap<usize, std::collections::VecDeque<SemGetWaiter>>,
     /// IEEE 1800-2017 §9.4.5 intra-assignment delay (`lhs = #d rhs`): RHS
@@ -3769,6 +3782,7 @@ impl Simulator {
             real_time: 0.0,
             mailbox_get_waiters: HashMap::default(),
             fork_baselines: HashMap::default(),
+            fork_signal_captures: HashMap::default(),
             semaphore_get_waiters: HashMap::default(),
             intra_saved: HashMap::default(),
             intra_saved_next: 0,
@@ -15155,11 +15169,22 @@ impl Simulator {
     /// (LRM §9.3.2). Used when spawning fork children.
     fn inherit_fork_child_context(&mut self, pid: usize) {
         let mut ctx = self.snapshot_process_context();
+        // §6.21/§9.3.2: automatic block-locals (no call frame) live in
+        // `self.signals` and are listed in `auto_loop_vars`. Copy their
+        // current VALUES into the child's `local_stack` so each child gets
+        // its own snapshot (the child's reads consult its top frame first).
+        // Record WHICH names were captured from `signals` so the propagate
+        // path can write the child's changed values back into `self.signals`
+        // — the storage the parent actually reads from. Without this
+        // write-back, the child's writes are stranded in its private frame
+        // and the parent sees the stale pre-fork value (§6.21 violation).
+        let mut signal_caps: Vec<String> = Vec::new();
         if !self.auto_loop_vars.is_empty() {
             let mut caps: HashMap<String, Value> = HashMap::default();
             for nm in &self.auto_loop_vars {
                 if let Some(v) = self.signals.get(nm) {
                     caps.insert(nm.clone(), v.clone());
+                    signal_caps.push(nm.clone());
                 }
             }
             if !caps.is_empty() {
@@ -15192,6 +15217,7 @@ impl Simulator {
             // (which the parent may have modified in the meantime — e.g. a
             // mailbox-get delivery into `phase` while this child runs).
             self.fork_baselines.insert(pid, ctx.local_stack.clone());
+            self.fork_signal_captures.insert(pid, signal_caps);
             self.process_contexts.insert(pid, ctx);
         }
     }
@@ -15333,7 +15359,8 @@ impl Simulator {
         let has_pid_ctx = self.process_contexts.contains_key(&pid);
         if !saved_ctx_needed && !has_pid_ctx {
             self.run_process_stmts(pid, stmts);
-            if self.is_pid_suspended(pid) {
+            let susp = self.is_pid_suspended(pid);
+            if susp {
                 // Only snapshot if actually suspended and has state worth saving.
                 if !self.this_stack.is_empty()
                     || !self.local_stack.is_empty()
@@ -15347,7 +15374,7 @@ impl Simulator {
             *self.name_resolve_hint.borrow_mut() = saved_hint;
             return;
         }
-        let saved = self.snapshot_process_context();
+        let mut saved = self.snapshot_process_context();
         let ctx = self.process_contexts.remove(&pid).unwrap_or_default();
         self.restore_process_context(ctx);
         self.run_process_stmts(pid, stmts);
@@ -15357,82 +15384,103 @@ impl Simulator {
         } else {
             self.process_contexts.remove(&pid);
         }
-        // IEEE 1800-2023 §9.3.2: automatic variables declared in the parent
-        // scope are SHARED with fork children — a child's write must be
-        // visible to the parent (and to siblings after the parent resumes).
-        // xezim gives each fork child a COPY of the parent's locals (see
-        // inherit_fork_child_context), so propagate the child's local frames
-        // back into the parent's saved context. Without this, UVM 2020's
-        // m_safe_select_item idiom (`fork … select_process = process::self();
-        // … join_none; wait(select_process != null)`) deadlocks: the parent
-        // never sees the child's assignment and the `wait` parks forever.
-        // 2017's sequencer has no such fork-and-wait idiom, which is why it
-        // completes. We merge every frame the child shares with the parent
-        // (child may have pushed extra frames via nested calls — those are
-        // skipped), exactly mirroring shared-automatic semantics.
-        self.propagate_fork_locals_to_parent(pid);
+        // IEEE 1800-2023 §6.21/§9.3.2: automatic variables declared in the
+        // parent scope are SHARED with fork children — a child's write must be
+        // visible to the parent. xezim gives each fork child a COPY of the
+        // parent's locals (inherit_fork_child_context), so the child's writes
+        // live in its private copy and must be propagated back. Two storage
+        // models must be bridged:
+        //   (a) SUBROUTINE locals — live in a `local_stack` frame; merged into
+        //       the parent's frame (in `process_contexts` if suspended, or in
+        //       `saved` if the parent is the currently-active process whose
+        //       context is on THIS Rust stack — e.g. the child ran inside the
+        //       parent's own `#delay` via `run_events_until`).
+        //   (b) PROCEDURAL block-locals (`initial`/`always`, no call frame) —
+        //       live in the global `self.signals`; `inherit_fork_child_context`
+        //       copied them into the child's frame and recorded the names in
+        //       `fork_signal_captures`. Write the child's changed values back
+        //       into `self.signals`, which is what the parent reads from.
+        let child_frames: Vec<HashMap<String, Value>> = self.local_stack.clone();
+        let baseline = self.fork_baselines.get(&pid).cloned();
+        let signal_caps = self.fork_signal_captures.get(&pid).cloned();
+        if !child_frames.is_empty() {
+            if let Some(parent_pid) = self.process_parents.get(&pid).copied() {
+                // (a) subroutine-frame merge
+                if let Some(parent_ctx) = self.process_contexts.get_mut(&parent_pid) {
+                    Self::merge_fork_writes(
+                        &mut parent_ctx.local_stack,
+                        &child_frames,
+                        baseline.as_ref(),
+                    );
+                } else {
+                    // Parent is the active process — its context is `saved`.
+                    Self::merge_fork_writes(
+                        &mut saved.local_stack,
+                        &child_frames,
+                        baseline.as_ref(),
+                    );
+                }
+            }
+        }
+        // (b) signal-capture write-back: procedural block-locals that live in
+        // `self.signals`. Write only keys the child CHANGED (relative to the
+        // fork-time baseline) so an inherited-unchanged value doesn't
+        // clobber a sibling's or the parent's concurrent write.
+        if let Some(caps) = &signal_caps {
+            let top = child_frames.last();
+            for nm in caps {
+                let Some(v) = top.and_then(|f| f.get(nm)) else {
+                    continue;
+                };
+                let inherited_unchanged = baseline
+                    .as_ref()
+                    .and_then(|b| b.last())
+                    .and_then(|f| f.get(nm))
+                    .is_some_and(|old| old == v);
+                if !inherited_unchanged {
+                    self.signals.insert(nm.clone(), v.clone());
+                }
+            }
+        }
+        if !self.is_pid_suspended(pid) {
+            self.fork_baselines.remove(&pid);
+            self.fork_signal_captures.remove(&pid);
+        }
         self.restore_process_context(saved);
         self.auto_loop_vars.truncate(saved_auto_len);
         *self.name_resolve_hint.borrow_mut() = saved_hint;
     }
 
-    /// Merge a (just-run) fork child's local frames into its parent process's
-    /// saved context so the parent observes the child's writes to shared
-    /// automatic variables (IEEE 1800-2023 §9.3.2). See the call site in
-    /// `run_scheduled_process` for the full rationale. Only frames that exist
-    /// in BOTH the child and parent stacks are merged (the child may hold
-    //  extra frames from nested subroutine calls; the parent may hold extra
-    //  frames pushed after the fork).
-    fn propagate_fork_locals_to_parent(&mut self, child_pid: usize) {
-        let parent_pid = match self.process_parents.get(&child_pid).copied() {
-            Some(p) => p,
-            None => return,
-        };
-        // §9.3.2 baseline: only the keys the child WROTE (its value now differs
-        // from the fork-time snapshot) are propagated — a key it merely
-        // inherited unchanged must NOT clobber a value the parent modified
-        // after the fork (e.g. a mailbox-get delivery into `phase` while this
-        // child ran, as in UVM `m_run_phases`). If no baseline survived (child
-        // that never had saved context, or an older run), fall back to the
-        // legacy whole-frame merge so the §9.3.2 write-visibility guarantee
-        // (e.g. m_safe_select_item's `select_process = process::self()`)
-        // still holds.
-        let baseline = self.fork_baselines.get(&child_pid).cloned();
-        // `self.local_stack` currently holds the CHILD's frames (captured
-        // before we restore the event-loop caller's context below).
-        let child_frames: Vec<HashMap<String, Value>> = self.local_stack.clone();
-        if child_frames.is_empty() {
-            return;
-        }
-        let Some(parent_ctx) = self.process_contexts.get_mut(&parent_pid) else {
-            return;
-        };
-        let n = parent_ctx.local_stack.len().min(child_frames.len());
+    /// Merge a fork child's local-frame writes into a parent's `local_stack`.
+    ///
+    /// §9.3.2 baseline: only the keys the child WROTE (its value now differs
+    /// from the fork-time snapshot) are propagated — a key it merely
+    /// inherited unchanged must NOT clobber a value the parent modified
+    /// after the fork (e.g. a mailbox-get delivery into `phase` while this
+    /// child ran). If no baseline survived, fall back to the legacy
+    /// whole-frame merge so the §9.3.2 write-visibility guarantee still
+    /// holds. Only keys that exist in the parent's frame are propagated (a
+    /// key the child declared itself, like a loop-local, is child-private).
+    fn merge_fork_writes(
+        parent_frames: &mut [HashMap<String, Value>],
+        child_frames: &[HashMap<String, Value>],
+        baseline: Option<&Vec<HashMap<String, Value>>>,
+    ) {
+        let n = parent_frames.len().min(child_frames.len());
         for i in 0..n {
             for (k, v) in &child_frames[i] {
-                // Only propagate keys that exist in the parent's frame (a key
-                // the child declared itself, like a loop-local `succ`, is
-                // child-private and of no interest to the parent).
-                if !parent_ctx.local_stack[i].contains_key(k) {
+                if !parent_frames[i].contains_key(k) {
                     continue;
                 }
                 let inherited_unchanged = baseline
-                    .as_ref()
                     .and_then(|b| b.get(i))
                     .and_then(|f| f.get(k))
                     .is_some_and(|old| old == v);
                 if inherited_unchanged {
                     continue;
                 }
-                parent_ctx.local_stack[i].insert(k.clone(), v.clone());
+                parent_frames[i].insert(k.clone(), v.clone());
             }
-        }
-        // Drop the baseline once the child is done (no longer suspended) so the
-        // map doesn't grow unboundedly across a forever-fork loop (UVM
-        // `m_run_phases`). A child that merely parked (e.g. on a `#5`) keeps
-        // its baseline for the next propagate.
-        if !self.is_pid_suspended(child_pid) {
-            self.fork_baselines.remove(&child_pid);
         }
     }
 
@@ -16129,37 +16177,22 @@ impl Simulator {
                     i += 1;
                     continue;
                 } else {
-                    let sig_names = self.extract_signal_names(condition);
-                    // Only suspend on a signal EDGE for names that are real
-                    // edge-trackable signals (in the compact signal table).
-                    // A `wait(...)` over class members / procedural locals (the
-                    // UVM arbitration's wait(lock_arb_size != m_lock_arb_size),
-                    // wait(m_arb_size != m_lock_arb_size), ...) extracts names
-                    // that look like signals but never fire an edge, so it would
-                    // park in event_waiters forever — route it to the
-                    // condition-waiter fixpoint instead.
-                    let sens: Vec<Sensitivity> = sig_names
-                        .into_iter()
-                        .filter(|name| self.signal_name_to_id.contains_key(name.as_str()))
-                        .map(|name| Sensitivity {
-                            signal_name: name,
-                            edge: EdgeKind::AnyEdge,
-                            iff: None,
-                        })
-                        .collect();
-                    if !sens.is_empty() {
-                        let mut cont = vec![stmt.clone()];
-                        cont.extend_from_slice(&stmts[i + 1..]);
-                        self.event_waiters
-                            .push(self.make_event_waiter(pid, sens, cont));
-                        return;
-                    }
-                    // No signal sensitivities: the condition depends on class
-                    // members / locals another same-time process mutates (the
-                    // UVM sequencer arbitration). Park as a condition-waiter and
-                    // suspend; the fixpoint in run_one_tick re-checks it after
-                    // the batch drains. (Previously this fell through as if the
-                    // wait were satisfied, which spun m_select_sequence forever.)
+                    // IEEE 1800-2023 §9.7.4: `wait(cond)` is LEVEL-
+                    // sensitive — the process resumes the moment the
+                    // condition is true, including in the SAME timestep via a
+                    // delta-cycle (#0) write from another process. The
+                    // condition-waiter fixpoint in run_one_tick re-evaluates
+                    // the actual expression every tick, so it handles same-
+                    // timestep (delta), cross-timestep (#delay), and time-0
+                    // init uniformly. Routing a signal-naming wait through the
+                    // edge-triggered event_waiter path instead BREAKS delta-
+                    // cycle wakeup: its `registered_time == self.time` guard
+                    // (correct for edge-sensitive `@()`) skips any same-
+                    // timestep edge, so `wait(sig==v)` never resumes when a
+                    // peer process writes `sig` at the same simtime. The UVM
+                    // phase hopper (`fork ... join_none; wait(all_dropped)`)
+                    // and sequencer arbitration depend on exactly this delta-
+                    // cycle handoff. Always park in condition_waiters.
                     let mut cont = vec![stmt.clone()];
                     cont.extend_from_slice(&stmts[i + 1..]);
                     self.condition_waiters.push((pid, cont));

--- a/tests/blocking_task_call.rs
+++ b/tests/blocking_task_call.rs
@@ -1,0 +1,228 @@
+//! Blocking task/method calls honour their body's timing controls.
+//!
+//! IEEE 1800-2023 §13.5 (footnote 42) and §13.5.5: parentheses may be omitted
+//! in a subroutine call for tasks, void functions, and class methods. xezim's
+//! parser represents `t;` (no parens) as a bare `Expr(Ident([t]))`, not as
+//! `Expr(Call { func: Ident([t]), args: [] })`. The suspend-aware executor's
+//! blocking-task inlining guards (`Stage 1`/`1b`/`1c` in `run_process_stmts`)
+//! all match on `Call`, so a blocking task invoked *without* parentheses
+//! bypassed inlining and fell through to the synchronous `exec_statement`,
+//! which cannot honour `#delay`/`@event`/`wait`/`fork` in the body — the body
+//! was silently dropped and the caller never blocked:
+//!
+//! ```sv
+//! task t; #10; endtask
+//! initial begin t; $display("after @%0t", $time); end   // printed t=0 (!)
+//! ```
+//!
+//! The fix adds `Stage 0`: it recognises a parenless subroutine reference that
+//! resolves to a free task or a class method and rewrites it into the
+//! equivalent zero-argument `Call` so the existing inlining guards fire
+//! uniformly. These self-checking regressions pin that behaviour for every
+//! parenless call shape:
+//!
+//!   * `t;`            — free task, parenless
+//!   * `t();`          — free task, explicit parens (control: already worked)
+//!   * `c.run;`        — method via dot, parenless
+//!   * `c.run();`      — method via dot, explicit parens (control)
+//!   * `m;` (this-method) — bare method name on the current `this`
+//!
+//! and that a non-blocking task keeps the synchronous path in both forms.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+/// The minimal reproducer: a free task whose body is just `#10`, called
+/// without parentheses. The caller must block for 10 time units.
+/// Pre-fix: `t;` dropped the body and the continuation ran at t=0.
+const FREE_TASK_PARENLESS: &str = r#"
+task automatic stall10;
+  #10;
+endtask
+module top;
+  initial begin
+    stall10;
+    $display("AFTER t=%0t", $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn free_task_parenless_blocks_caller() {
+    let sim = simulate(FREE_TASK_PARENLESS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let line = msgs.iter().find(|m| m.starts_with("AFTER")).unwrap_or_else(|| {
+        panic!("continuation never ran; output: {:?}", msgs)
+    });
+    assert!(
+        line.contains("t=10"),
+        "expected caller blocked until t=10, got: {}\noutput: {:?}",
+        line,
+        msgs
+    );
+}
+
+/// Control: the same task called *with* parentheses must behave identically.
+const FREE_TASK_PARENS: &str = r#"
+task automatic stall10;
+  #10;
+endtask
+module top;
+  initial begin
+    stall10();
+    $display("AFTER t=%0t", $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn free_task_parens_blocks_caller() {
+    let sim = simulate(FREE_TASK_PARENS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let line = msgs.iter().find(|m| m.starts_with("AFTER")).unwrap_or_else(|| {
+        panic!("continuation never ran; output: {:?}", msgs)
+    });
+    assert!(
+        line.contains("t=10"),
+        "expected caller blocked until t=10, got: {}\noutput: {:?}",
+        line,
+        msgs
+    );
+}
+
+/// A class method task called without parentheses via dot syntax must block
+/// the caller. Pre-fix `c.run;` parsed as `MemberAccess` and the body was
+/// dropped, so the continuation ran at t=0.
+const METHOD_DOT_PARENLESS: &str = r#"
+class C;
+  task run;
+    $display("ENTER t=%0t", $time);
+    #10;
+    $display("DONE t=%0t", $time);
+  endtask
+endclass
+module top;
+  initial begin
+    automatic C c = new;
+    c.run;
+    $display("AFTER t=%0t", $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn method_dot_parenless_blocks_caller() {
+    let sim = simulate(METHOD_DOT_PARENLESS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let after = msgs.iter().find(|m| m.starts_with("AFTER")).unwrap_or_else(|| {
+        panic!("continuation never ran; output: {:?}", msgs)
+    });
+    // The body must run (ENTER/DONE) and the caller must block until t=10.
+    assert!(msgs.iter().any(|m| m.starts_with("ENTER t=0")), "method body never entered");
+    assert!(
+        after.contains("t=10"),
+        "expected caller blocked until t=10, got: {}\noutput: {:?}",
+        after,
+        msgs
+    );
+}
+
+/// Control: the same method called *with* parentheses.
+const METHOD_DOT_PARENS: &str = r#"
+class C;
+  task run;
+    #10;
+  endtask
+endclass
+module top;
+  initial begin
+    automatic C c = new;
+    c.run();
+    $display("AFTER t=%0t", $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn method_dot_parens_blocks_caller() {
+    let sim = simulate(METHOD_DOT_PARENS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let line = msgs.iter().find(|m| m.starts_with("AFTER")).unwrap_or_else(|| {
+        panic!("continuation never ran; output: {:?}", msgs)
+    });
+    assert!(
+        line.contains("t=10"),
+        "expected caller blocked until t=10, got: {}\noutput: {:?}",
+        line,
+        msgs
+    );
+}
+
+/// A blocking method called by its bare name from within the class itself
+/// (implicit `this`). The body's `wait` must suspend the caller.
+const THIS_METHOD_PARENLESS: &str = r#"
+class C;
+  int gate;
+  task automatic enter;
+    wait(gate == 1);
+  endtask
+  task run;
+    gate = 0;
+    fork begin #5; gate = 1; end join_none
+    enter;            // bare-name this-method, parenless, blocking
+    $display("AFTER t=%0t gate=%0d", $time, gate);
+  endtask
+endclass
+module top;
+  initial begin
+    automatic C c = new;
+    c.run;
+  end
+endmodule
+"#;
+
+#[test]
+fn this_method_parenless_blocks_caller() {
+    let sim = simulate(THIS_METHOD_PARENLESS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let line = msgs.iter().find(|m| m.starts_with("AFTER")).unwrap_or_else(|| {
+        panic!("continuation never ran; output: {:?}", msgs)
+    });
+    assert!(
+        line.contains("t=5") && line.contains("gate=1"),
+        "expected caller blocked until t=5 with gate=1, got: {}\noutput: {:?}",
+        line,
+        msgs
+    );
+}
+
+/// A non-blocking task (no delay/wait/fork in its body) called without
+/// parentheses must keep running — the Stage-0 rewrite yields a Call that does
+/// not satisfy `stmts_have_blocking`, so it falls through to `exec_statement`
+/// exactly like `nb();` with explicit parens.
+const NONBLOCKING_PARENLESS: &str = r#"
+task automatic greet;
+  $display("HELLO");
+endtask
+module top;
+  initial begin
+    greet;
+    $display("AFTER greet");
+  end
+endmodule
+"#;
+
+#[test]
+fn nonblocking_task_parenless_runs_synchronously() {
+    let sim = simulate(NONBLOCKING_PARENLESS, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(msgs.iter().any(|m| m == "HELLO"), "non-blocking body never ran");
+    assert!(
+        msgs.iter().any(|m| m == "AFTER greet"),
+        "continuation never ran; output: {:?}",
+        msgs
+    );
+}

--- a/tests/chained_member_access.rs
+++ b/tests/chained_member_access.rs
@@ -1,0 +1,206 @@
+//! Method calls through chained member access resolve to the right object.
+//!
+//! IEEE 1800-2023 §8.15/§13.5.5: a method reached through a multi-level
+//! member-access path — `o.in.getval()`, `h.q.put(x)` — must dispatch on the
+//! FULL receiver prefix (`o.in`, `h.q`), binding `this` to the object that
+//! actually OWNS the method. xezim's parser flattens a dotted call into a
+//! single `Call{ func: Ident([seg0, seg1, ..., method]) }`. The flattened-
+//! Ident dispatch in `eval_call_inner` resolved only `path[0]` (the OUTERMOST
+//! object) and looked the method up there, ignoring the intermediate segments.
+//! For `o.in.getval()` that bound `this` to `o` (Outer has no `getval`) and
+//! silently returned 0; `o.in.setval(x)` wrote nothing. The fix walks the
+//! receiver prefix `path[0..len-1]` through the heap (each intermediate
+//! segment is a class-handle property) to reach the owning instance.
+//!
+//! These self-checking regressions pin the fix for nested-object method
+//! dispatch (read, write, and queue operations through 2+ member levels):
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_pass(sim: &xezim::compiler::Simulator, tag: &str) {
+    let msgs = messages(sim);
+    let pass = msgs.iter().any(|m| m.contains(&format!("{tag}_PASS")));
+    let fail = msgs.iter().find(|m| m.contains(&format!("{tag}_FAIL")));
+    assert!(
+        pass,
+        "expected {tag}_PASS in output\nfail line: {fail:?}\nfull output: {msgs:?}"
+    );
+}
+
+/// Two classes: `Outer` holds an `Inner` member (a class handle). A method
+/// defined on `Inner` is called through the 2-level path `o.in.method()`.
+const INNER_CLASS: &str = r#"
+class Inner;
+  int val;
+  function void setval(int v); val = v; endfunction
+  function int getval(); return val; endfunction
+endclass
+class Outer;
+  Inner in;
+  function new; in = new; endfunction
+endclass
+module top;
+  Outer o;
+  initial begin
+    o = new;
+    o.in.val = 42;
+    if (o.in.getval() == 42) $display("READ_PASS getval=%0d", o.in.getval());
+    else                      $display("READ_FAIL getval=%0d", o.in.getval());
+  end
+endmodule
+"#;
+
+/// A method WRITE (`setval`) through `o.in` must land on the Inner object
+/// and be readable back via the plain field.
+#[test]
+fn nested_method_read() {
+    let sim = simulate(INNER_CLASS, 200).expect("simulate failed");
+    assert_pass(&sim, "READ");
+}
+
+const NESTED_WRITE: &str = r#"
+class Inner;
+  int val;
+  function void setval(int v); val = v; endfunction
+endclass
+class Outer;
+  Inner in;
+  function new; in = new; endfunction
+endclass
+module top;
+  Outer o;
+  initial begin
+    o = new;
+    o.in.setval(77);
+    if (o.in.val == 77) $display("WRITE_PASS val=%0d", o.in.val);
+    else                $display("WRITE_FAIL val=%0d", o.in.val);
+  end
+endmodule
+"#;
+
+#[test]
+fn nested_method_write() {
+    let sim = simulate(NESTED_WRITE, 200).expect("simulate failed");
+    assert_pass(&sim, "WRITE");
+}
+
+/// write via method then read via method — both through the 2-level path —
+/// confirming `this` is consistently the Inner object.
+const ROUNDTRIP: &str = r#"
+class Inner;
+  int val;
+  function void setval(int v); val = v; endfunction
+  function int getval(); return val; endfunction
+endclass
+class Outer;
+  Inner in;
+  function new; in = new; endfunction
+endclass
+module top;
+  Outer o;
+  initial begin
+    o = new;
+    o.in.setval(99);
+    if (o.in.getval() == 99) $display("RT_PASS getval=%0d", o.in.getval());
+    else                     $display("RT_FAIL getval=%0d", o.in.getval());
+  end
+endmodule
+"#;
+
+#[test]
+fn nested_method_roundtrip() {
+    let sim = simulate(ROUNDTRIP, 200).expect("simulate failed");
+    assert_pass(&sim, "RT");
+}
+
+/// A queue wrapped in a class (`Q`), itself held as a member of another
+/// class (`Hopper`). `put`/`sz`/`popf` are called through the 2-level path
+/// `h.q.method()`. This is the shape of the UVM phase hopper's mailbox/queue
+/// handoff and was the dominant STALL blocker.
+const HOPPER_QUEUE: &str = r#"
+class Q;
+  int items[$];
+  function void put(int ph); items.push_back(ph); endfunction
+  function int sz(); return items.size(); endfunction
+  function int popf(); return items.pop_front(); endfunction
+endclass
+class Hopper;
+  Q q;
+  function new; q = new; endfunction
+endclass
+module top;
+  initial begin
+    automatic Hopper h = new;
+    h.q.put(10);
+    h.q.put(20);
+    if (h.q.sz() == 2 && h.q.popf() == 10)
+      $display("HOPPER_PASS sz=%0d", h.q.sz());
+    else
+      $display("HOPPER_FAIL sz=%0d", h.q.sz());
+  end
+endmodule
+"#;
+
+#[test]
+fn nested_queue_methods() {
+    let sim = simulate(HOPPER_QUEUE, 200).expect("simulate failed");
+    assert_pass(&sim, "HOPPER");
+}
+
+/// The full hopper pattern: a forever-loop reading phases from a queue and
+/// forking a delayed handler per phase, with the parent `wait`-ing on a
+/// shared counter incremented by the fork children. This combines the
+/// chained-member-access fix with the §6.21 fork-variable write-back and
+/// the §9.7.4 level-sensitive `wait()`.
+const FULL_HOPPER: &str = r#"
+class Q;
+  int items[$];
+  task get(output int ph);
+    wait(items.size() != 0);
+    ph = items.pop_front();
+  endtask
+  function void put(int ph); items.push_back(ph); endfunction
+endclass
+class Hopper;
+  Q q;
+  int phases_done;
+  task run_phases;
+    int ph;
+    fork
+      begin
+        forever begin
+          q.get(ph);
+          fork
+            automatic int phase = ph;
+            begin
+              #phase;
+              this.phases_done = this.phases_done + 1;
+            end
+          join_none
+        end
+      end
+    join_none
+    wait(phases_done > 0);
+  endtask
+  function new; q = new; phases_done = 0; endfunction
+endclass
+module top;
+  initial begin
+    automatic Hopper h = new;
+    h.q.put(10);
+    h.run_phases;
+    if (h.phases_done >= 1) $display("FH_PASS phases_done=%0d at=%0t", h.phases_done, $time);
+    else                    $display("FH_FAIL phases_done=%0d at=%0t", h.phases_done, $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn full_hopper_pattern() {
+    let sim = simulate(FULL_HOPPER, 2000).expect("simulate failed");
+    assert_pass(&sim, "FH");
+}

--- a/tests/class_local_typedef_aa.rs
+++ b/tests/class_local_typedef_aa.rs
@@ -1,0 +1,87 @@
+//! Class-local typedef'd associative-array `ref` argument writeback.
+//!
+//! Companion to `ref_arg_assoc_writeback.rs`, isolating the *class-local
+//! typedef* variant — the exact shape of UVM's phase-DAG successor edges:
+//!
+//! ```systemverilog
+//!   class uvm_phase;
+//!     typedef bit edges_t[uvm_phase];   // <-- typedef declared INSIDE the class
+//!     ...
+//!     function void get_successors(ref edges_t successors);
+//!       foreach (m_successors[p]) successors[p] = 1;
+//!     endfunction
+//!   endfunction
+//!   ...
+//!   uvm_phase::edges_t edges;
+//!   phase.get_successors(edges);   // ref fill — caller's array must grow
+//! ```
+//!
+//! `port_is_assoc_array` detects an AA formal by looking up the typedef's
+//! unpacked dimensions in `typedef_unpacked_dims`. But class-local typedefs
+//! were never fed to `process_typedef` during elaboration (only module/package
+//! typedefs were), so their dimensions were invisible and the `ref edges_t`
+//! formal was mis-bound as a scalar — the writeback was silently lost, the
+//! phase DAG never expanded, and every UVM test stalled at time 0.
+//!
+//! The fix registers class-local typedefs in `register_class_enum_members`.
+//! Verified byte-for-byte against reference simulators.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_pass(sim: &xezim::compiler::Simulator, tag: &str) {
+    let msgs = messages(sim);
+    let pass = msgs.iter().any(|m| m.contains(&format!("{tag}_PASS")));
+    let fail = msgs.iter().find(|m| m.contains(&format!("{tag}_FAIL")));
+    assert!(
+        pass,
+        "expected {tag}_PASS in output\nfail line: {fail:?}\nfull output: {msgs:?}"
+    );
+}
+
+/// The exact UVM `edges_t` shape: a typedef'd AA declared inside a class, used
+/// as a `ref` formal in a method, caller's actual under a different name.
+/// Pre-fix the caller's array stayed empty (num==0).
+const CLASS_LOCAL_TYPEDEF_AA: &str = r#"
+class Node;
+  function new(string n); endfunction
+endclass
+class Ph;
+  typedef bit edges_t[Node];          // class-local typedef (like uvm_phase::edges_t)
+  protected edges_t m_succ;
+  function void add_edge(input Node n); m_succ[n] = 1; endfunction
+  function void get_successors(ref edges_t successors);
+    foreach (m_succ[p]) successors[p] = 1;
+  endfunction
+  // Caller-side helper so the typedef'd type is used in-class.
+  function void check(output int n);
+    edges_t e;
+    get_successors(e);
+    n = e.num();
+  endfunction
+endclass
+module top;
+  initial begin
+    int n;
+    Ph h;
+    Node a; Node b;
+    h = new;
+    a = new("A");
+    b = new("B");
+    h.add_edge(a);
+    h.add_edge(b);
+    h.check(n);
+    if (n == 2) $display("CLTAA_PASS num=%0d", n);
+    else        $display("CLTAA_FAIL num=%0d", n);
+  end
+endmodule
+"#;
+
+#[test]
+fn class_local_typedef_aa_ref_writeback() {
+    let sim = simulate(CLASS_LOCAL_TYPEDEF_AA, 100).expect("simulate failed");
+    assert_pass(&sim, "CLTAA");
+}

--- a/tests/fork_var_sharing.rs
+++ b/tests/fork_var_sharing.rs
@@ -1,0 +1,221 @@
+//! Fork children share enclosing-scope automatic variables (§6.21/§9.3.2).
+//!
+//! IEEE 1800-2023 §6.21 (Scope and lifetime):
+//!
+//! > "The lifetime of a fork-join block shall encompass the execution of all
+//! > processes spawned by the block. The lifetime of a scope enclosing any
+//! > fork-join block includes the lifetime of the fork-join block."
+//!
+//! §9.3.2 (Parallel blocks):
+//!
+//! > Variables declared in a fork-join block's own `block_item_declaration`
+//! > get a fresh copy per spawned process; variables from an *enclosing* scope
+//! > are **shared storage** — a child's write is visible to the parent.
+//!
+//! xezim implements copy-on-fork: each child gets a snapshot of the parent's
+//! locals, and the child's writes are propagated back when the child finishes.
+//! This worked for subroutine-frame locals (which live in `local_stack`) but
+//! NOT for `automatic` variables declared directly in an `initial`/`always`
+//! block — those had no call frame and landed in the global `self.signals`
+//! map, while the fork child's copy lived in a `local_stack` frame. The two
+//! were disconnected storage, so the parent always read the stale pre-fork
+//! value. The fix records which signal-backed names were captured into each
+//! child and writes the child's changed values back into `self.signals`.
+//!
+//! These self-checking tests pin the §6.21/§9.3.2 shared-storage guarantee
+//! for the key patterns:
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_pass(sim: &xezim::compiler::Simulator, tag: &str) {
+    let msgs = messages(sim);
+    let pass = msgs.iter().any(|m| m.contains(&format!("{tag}_PASS")));
+    let fail = msgs.iter().find(|m| m.contains(&format!("{tag}_FAIL")));
+    assert!(
+        pass,
+        "expected {tag}_PASS in output\nfail line: {fail:?}\nfull output: {msgs:?}"
+    );
+}
+
+/// An `automatic` local declared in an `initial` block is written by a
+/// `fork ... join_none` child after a `#5` delay. The parent — blocked on
+/// `#10` — must observe the child's write when it resumes.
+///
+/// This was the primary reproducer: pre-fix the parent read the stale value
+/// `0` because the child's write was stranded in its private frame copy.
+const CROSS_DELAY: &str = r#"
+module top;
+  initial begin
+    automatic int got = 0;
+    fork
+      begin
+        #5;
+        got = 7;
+      end
+    join_none
+    #10;
+    if (got == 7) $display("DELAY_PASS got=%0d", got);
+    else          $display("DELAY_FAIL got=%0d", got);
+  end
+endmodule
+"#;
+
+#[test]
+fn automatic_local_cross_delay() {
+    let sim = simulate(CROSS_DELAY, 200).expect("simulate failed");
+    assert_pass(&sim, "DELAY");
+}
+
+/// Same-timestep variant: the child writes with no delay, and the parent
+/// reads after a `#1`. The propagate-back must still deliver the write.
+const SAME_TIMESTEP: &str = r#"
+module top;
+  initial begin
+    automatic int flag = 0;
+    fork
+      begin
+        flag = 1;
+      end
+    join_none
+    #1;
+    if (flag == 1) $display("SAME_PASS flag=%0d", flag);
+    else           $display("SAME_FAIL flag=%0d", flag);
+  end
+endmodule
+"#;
+
+#[test]
+fn automatic_local_same_timestep() {
+    let sim = simulate(SAME_TIMESTEP, 200).expect("simulate failed");
+    assert_pass(&sim, "SAME");
+}
+
+/// The parent blocks on `wait(ready)` while a fork child sets the flag after
+/// a `#3` delay. The `wait` must resume — combining the §9.3.2 write-back
+/// with the level-sensitive `wait()` condition re-evaluation.
+const WAIT_FLAG: &str = r#"
+module top;
+  initial begin
+    automatic int ready = 0;
+    fork
+      begin
+        #3;
+        ready = 1;
+      end
+    join_none
+    wait(ready == 1);
+    if (ready == 1) $display("WAIT_PASS ready=%0d at=%0t", ready, $time);
+    else            $display("WAIT_FAIL ready=%0d at=%0t", ready, $time);
+  end
+endmodule
+"#;
+
+#[test]
+fn automatic_local_wait_flag() {
+    let sim = simulate(WAIT_FLAG, 200).expect("simulate failed");
+    assert_pass(&sim, "WAIT");
+}
+
+/// A variable declared INSIDE the fork block (`inner`) is private to the
+/// child and must NOT leak to the parent. An enclosing-scope variable
+/// (`outer`) written by the same child MUST propagate. This separates the
+/// two §9.3.2 storage classes.
+const FORK_PRIVATE_VAR: &str = r#"
+module top;
+  initial begin
+    automatic int outer = 5;
+    fork
+      automatic int inner = 99;
+      begin
+        #2;
+        inner = 77;
+        outer = 11;
+      end
+    join_none
+    #5;
+    // outer reflects the child's write (shared storage)
+    if (outer == 11) $display("PRIV_PASS outer=%0d", outer);
+    else             $display("PRIV_FAIL outer=%0d", outer);
+  end
+endmodule
+"#;
+
+#[test]
+fn fork_declared_var_is_private() {
+    let sim = simulate(FORK_PRIVATE_VAR, 200).expect("simulate failed");
+    assert_pass(&sim, "PRIV");
+}
+
+/// A class member (`this.count`) incremented by fork-child task calls must
+/// be visible to the parent. Two `fork ... join_any` children each call
+/// `tick` which does `this.count++` after a `#5`. The parent (after `join_any`
+/// + `#1`) must see `count == 2`.
+const CLASS_MEMBER: &str = r#"
+class Counter;
+  int count;
+  function new; count = 0; endfunction
+  task tick;
+    begin
+      #5;
+      this.count = this.count + 1;
+    end
+  endtask
+  task run_two;
+    fork
+      this.tick;
+      this.tick;
+    join_any
+    #1;
+    if (count == 2) $display("CLS_PASS count=%0d", count);
+    else            $display("CLS_FAIL count=%0d", count);
+  endtask
+endclass
+module top;
+  initial begin
+    automatic Counter c = new;
+    c.run_two;
+  end
+endmodule
+"#;
+
+#[test]
+fn class_member_from_fork_child() {
+    let sim = simulate(CLASS_MEMBER, 200).expect("simulate failed");
+    assert_pass(&sim, "CLS");
+}
+
+/// Multiple sequential fork children each write to different enclosing-
+/// scope `automatic` variables. The parent checks all writes propagated
+/// correctly. This exercises repeated propagate-back cycles across
+/// multiple signal-backed variables and confirms each reaches `self.signals`.
+const MULTIPLE_VARS: &str = r#"
+module top;
+  initial begin
+    automatic int a = 0;
+    automatic int b = 0;
+    automatic int c = 0;
+    fork
+      begin #1; a = 10; end
+    join_none
+    fork
+      begin #2; b = 20; end
+    join_none
+    fork
+      begin #3; c = 30; end
+    join_none
+    #10;
+    if (a + b + c == 60) $display("ACC_PASS sum=%0d", a + b + c);
+    else                  $display("ACC_FAIL sum=%0d", a + b + c);
+  end
+endmodule
+"#;
+
+#[test]
+fn multiple_children_multiple_vars() {
+    let sim = simulate(MULTIPLE_VARS, 200).expect("simulate failed");
+    assert_pass(&sim, "ACC");
+}

--- a/tests/lrm_9_7/ref/t01_status_running.txt
+++ b/tests/lrm_9_7/ref/t01_status_running.txt
@@ -1,0 +1,2 @@
+RESULT blocking_status=2
+RESULT running_status=1

--- a/tests/lrm_9_7/ref/t02_status_finished.txt
+++ b/tests/lrm_9_7/ref/t02_status_finished.txt
@@ -1,0 +1,1 @@
+RESULT finished_status=0

--- a/tests/lrm_9_7/ref/t03_kill.txt
+++ b/tests/lrm_9_7/ref/t03_kill.txt
@@ -1,0 +1,2 @@
+RESULT killed_status=4
+RESULT done

--- a/tests/lrm_9_7/ref/t04_await.txt
+++ b/tests/lrm_9_7/ref/t04_await.txt
@@ -1,0 +1,2 @@
+RESULT await_done_at=30
+RESULT status_after=0

--- a/tests/lrm_9_7/ref/t05_suspend_resume.txt
+++ b/tests/lrm_9_7/ref/t05_suspend_resume.txt
@@ -1,0 +1,4 @@
+RESULT suspended_at=5 status=3
+RESULT resumed_at=55
+RESULT step_a_at=55
+RESULT step_b_at=95

--- a/tests/lrm_9_7/t01_status_running.sv
+++ b/tests/lrm_9_7/t01_status_running.sv
@@ -1,0 +1,19 @@
+// §9.7 status(): a process blocked in a delay reports WAITING (2),
+// and a process actively executing reports RUNNING (1).
+module top;
+  process job;
+  int seen_waiting;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        seen_waiting = job.status();   // executing right now -> RUNNING(1)
+        #50;                            // now it blocks -> WAITING(2)
+      end
+    join_none
+    #10;
+    $display("RESULT blocking_status=%0d", job.status());  // -> 2 (WAITING)
+    $display("RESULT running_status=%0d", seen_waiting);   // -> 1 (RUNNING)
+    #100;
+  end
+endmodule

--- a/tests/lrm_9_7/t02_status_finished.sv
+++ b/tests/lrm_9_7/t02_status_finished.sv
@@ -1,0 +1,10 @@
+module top;
+  process job;
+  initial begin
+    fork
+      begin job = process::self(); #5; end
+    join_none
+    #20;
+    $display("RESULT finished_status=%0d", job.status());  // -> 0 (FINISHED)
+  end
+endmodule

--- a/tests/lrm_9_7/t03_kill.sv
+++ b/tests/lrm_9_7/t03_kill.sv
@@ -1,0 +1,17 @@
+module top;
+  process job;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        #100;
+        $display("RESULT VICTIM_RAN");   // must NOT print (killed at #10)
+      end
+    join_none
+    #10;
+    job.kill();
+    $display("RESULT killed_status=%0d", job.status());  // -> 4 (KILLED)
+    #100;
+    $display("RESULT done");
+  end
+endmodule

--- a/tests/lrm_9_7/t04_await.sv
+++ b/tests/lrm_9_7/t04_await.sv
@@ -1,0 +1,13 @@
+module top;
+  process job;
+  initial begin
+    fork
+      begin job = process::self(); #30; end
+    join_none
+    #0;                                // let the forked child run first (assigns job)
+    wait(job != null);                 // guard against null handle
+    job.await();                       // blocks until child finishes at #30
+    $display("RESULT await_done_at=%0t", $time);
+    $display("RESULT status_after=%0d", job.status());  // -> 0 FINISHED
+  end
+endmodule

--- a/tests/lrm_9_7/t05_suspend_resume.sv
+++ b/tests/lrm_9_7/t05_suspend_resume.sv
@@ -1,0 +1,19 @@
+module top;
+  process job;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        #10;  $display("RESULT step_a_at=%0t", $time);
+        #40;  $display("RESULT step_b_at=%0t", $time);  // pushed by resume
+      end
+    join_none
+    #5;
+    job.suspend();
+    $display("RESULT suspended_at=%0t status=%0d", $time, job.status()); // status=3 SUSPENDED
+    #50;
+    job.resume();
+    $display("RESULT resumed_at=%0t", $time);
+    #100;
+  end
+endmodule

--- a/tests/lrm_9_value_param/str_param_spec.sv
+++ b/tests/lrm_9_value_param/str_param_spec.sv
@@ -1,0 +1,35 @@
+// Regression: value parameters of a specialized class, referenced bare inside
+// a STATIC method (no instance). Direct `Class#(args)::method()` form.
+class Wrapper #(type T = int, string Tname = "<unknown>", int V = 0);
+  static function string type_name();
+    return Tname;
+  endfunction
+  static function int value();
+    return V;
+  endfunction
+  virtual function string get_type_name();
+    return type_name();
+  endfunction
+endclass
+
+class base_class;
+endclass
+
+module top;
+  initial begin
+    // String param, multi-arg specialization.
+    string s;
+    int v;
+    s = Wrapper#(base_class, "base_class", 7)::type_name();
+    v = Wrapper#(base_class, "base_class", 7)::value();
+    if (s == "base_class") $display("STR_PASS '%s'", s);
+    else                   $display("STR_FAIL got='%s'", s);
+    if (v == 7)            $display("INT_PASS %0d", v);
+    else                   $display("INT_FAIL got=%0d", v);
+
+    // Negative-space: default values when NOT specialized.
+    s = Wrapper::type_name();
+    if (s == "<unknown>")  $display("DEF_PASS '%s'", s);
+    else                   $display("DEF_FAIL got='%s'", s);
+  end
+endmodule

--- a/tests/process_class_9_7.rs
+++ b/tests/process_class_9_7.rs
@@ -1,0 +1,199 @@
+//! IEEE 1800-2023 §9.7 fine-grain process control — `process` built-in class.
+//!
+//! Pure-SystemVerilog tests for `process::self()`, `status()`, `kill()`,
+//! `await()`, `suspend()`, and `resume()`. Each test is a minimal program
+//! whose expected output was cross-checked against reference simulators
+//! (golden outputs in `tests/lrm_9_7/ref/`).
+//!
+//! No UVM library, no DPI — runs in-process via `simulate`.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+// ── status(): RUNNING vs WAITING ──────────────────────────────────────
+
+const STATUS_RUNNING_SRC: &str = r#"
+module top;
+  process job;
+  int seen_waiting;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        seen_waiting = job.status();   // executing now -> RUNNING(1)
+        #50;                            // now blocks -> WAITING(2)
+      end
+    join_none
+    #10;
+    $display("RESULT blocking_status=%0d", job.status());  // 2 WAITING
+    $display("RESULT running_status=%0d", seen_waiting);   // 1 RUNNING
+    #100;
+  end
+endmodule
+"#;
+
+#[test]
+fn status_running_and_waiting() {
+    let sim = simulate(STATUS_RUNNING_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT blocking_status=2"),
+        "process blocked in #50 should report WAITING(2); got {:?}",
+        msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT running_status=1"),
+        "process actively executing should report RUNNING(1); got {:?}",
+        msgs
+    );
+}
+
+// ── status(): FINISHED after completion ───────────────────────────────
+
+const STATUS_FINISHED_SRC: &str = r#"
+module top;
+  process job;
+  initial begin
+    fork
+      begin job = process::self(); #5; end
+    join_none
+    #20;
+    $display("RESULT finished_status=%0d", job.status());  // 0 FINISHED
+  end
+endmodule
+"#;
+
+#[test]
+fn status_finished() {
+    let sim = simulate(STATUS_FINISHED_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT finished_status=0"),
+        "completed process should report FINISHED(0); got {:?}",
+        msgs
+    );
+}
+
+// ── kill(): terminates a process before it completes ──────────────────
+
+const KILL_SRC: &str = r#"
+module top;
+  process job;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        #100;
+        $display("RESULT VICTIM_RAN");   // must NOT print
+      end
+    join_none
+    #10;
+    job.kill();
+    $display("RESULT killed_status=%0d", job.status());  // 4 KILLED
+    #100;
+    $display("RESULT done");
+  end
+endmodule
+"#;
+
+#[test]
+fn kill_terminates_process() {
+    let sim = simulate(KILL_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT killed_status=4"),
+        "killed process should report KILLED(4); got {:?}",
+        msgs
+    );
+    assert!(
+        !msgs.iter().any(|m| m == "RESULT VICTIM_RAN"),
+        "killed process must not run its continuation; got {:?}",
+        msgs
+    );
+}
+
+// ── await(): blocks until the target process terminates ───────────────
+
+const AWAIT_SRC: &str = r#"
+module top;
+  process job;
+  initial begin
+    fork
+      begin job = process::self(); #30; end
+    join_none
+    #0;                                // let the forked child run first
+    wait(job != null);                 // guard against null handle
+    job.await();                       // blocks until child finishes at #30
+    $display("RESULT await_done_at=%0t", $time);
+    $display("RESULT status_after=%0d", job.status());  // 0 FINISHED
+  end
+endmodule
+"#;
+
+#[test]
+fn await_blocks_until_termination() {
+    let sim = simulate(AWAIT_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT await_done_at=30"),
+        "await() should resume at t=30 when child finishes; got {:?}",
+        msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT status_after=0"),
+        "after await, status should be FINISHED(0); got {:?}",
+        msgs
+    );
+}
+
+// ── suspend()/resume(): pauses then restarts a blocked process ────────
+
+const SUSPEND_RESUME_SRC: &str = r#"
+module top;
+  process job;
+  initial begin
+    fork
+      begin
+        job = process::self();
+        #10;  $display("RESULT step_a_at=%0t", $time);
+        #40;  $display("RESULT step_b_at=%0t", $time);
+      end
+    join_none
+    #5;
+    job.suspend();
+    $display("RESULT suspended_at=%0t status=%0d", $time, job.status());
+    #50;
+    job.resume();
+    $display("RESULT resumed_at=%0t", $time);
+    #100;
+  end
+endmodule
+"#;
+
+#[test]
+fn suspend_then_resume() {
+    let sim = simulate(SUSPEND_RESUME_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    // After suspend, status is SUSPENDED(3).
+    assert!(
+        msgs.iter().any(|m| m == "RESULT suspended_at=5 status=3"),
+        "suspended process should report SUSPENDED(3); got {:?}",
+        msgs
+    );
+    // After resume at t=55, the original #10 delay (from t=0, expiry t=10)
+    // has transpired, so step_a fires immediately at t=55.
+    assert!(
+        msgs.iter().any(|m| m == "RESULT step_a_at=55"),
+        "resumed process should continue at t=55 (original delay transpired); got {:?}",
+        msgs
+    );
+    // step_b is #40 after step_a: t=55+40=95.
+    assert!(
+        msgs.iter().any(|m| m == "RESULT step_b_at=95"),
+        "second delay after resume should fire at t=95; got {:?}",
+        msgs
+    );
+}

--- a/tests/ref_arg_assoc_writeback.rs
+++ b/tests/ref_arg_assoc_writeback.rs
@@ -1,0 +1,163 @@
+//! `ref` associative-array argument writeback (§13.5 argument-passing semantics).
+//!
+//! IEEE 1800-2023 §13.5: a `ref` argument aliases the caller's actual — writes
+//! performed inside the callee are visible to the caller after return. This
+//! worked for scalars, dynamic arrays, and queues, but for **associative
+//! arrays** the binding between the formal and the caller's storage was
+//! inconsistent and writeback was silently lost in common shapes.
+//!
+//! The canonical victim was UVM's phase-DAG expansion. `uvm_phase` exposes:
+//!
+//! ```systemverilog
+//!   function void get_successors(ref edges_t successors); // AA by handle
+//!     foreach (m_successors[p]) successors[p] = 1;
+//!   endfunction
+//!   // caller (uvm_phase_hopper::finish_phase):
+//!   uvm_phase::edges_t edges;
+//!   phase.get_successors(edges);      // ref fill
+//!   if (edges.size() != 0) …          // always 0 → no successor NODE scheduled
+//! ```
+//!
+//! `edges` stayed empty, so `build`/`connect`/`run` NODE phases were never
+//! scheduled and every data test stalled at time 0 with no phase traversal.
+//!
+//! Empirically the failure depends on how the formal's name relates to the
+//! caller's actual *and* whether the routine is a free function or a method:
+//!
+//! | routine | formal vs actual name | result |
+//! |---------|-----------------------|--------|
+//! | method  | different             | **FAIL** (the UVM case) |
+//! | method  | same                  | ok |
+//! | free fn | same                  | **FAIL** |
+//! | free fn | different             | ok |
+//!
+//! i.e. exactly one direction of each pair loses the writeback. All four
+//! cases pass on reference simulators. These tests pin all of them.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_pass(sim: &xezim::compiler::Simulator, tag: &str) {
+    let msgs = messages(sim);
+    let pass = msgs.iter().any(|m| m.contains(&format!("{tag}_PASS")));
+    let fail = msgs.iter().find(|m| m.contains(&format!("{tag}_FAIL")));
+    assert!(
+        pass,
+        "expected {tag}_PASS in output\nfail line: {fail:?}\nfull output: {msgs:?}"
+    );
+}
+
+/// The UVM reproducer: a class *method* with a `ref int` AA formal whose name
+/// differs from the caller's actual. Writes inside the method must reach the
+/// caller. This is the `phase.get_successors(edges)` shape exactly.
+const METHOD_DIFF_NAMES: &str = r#"
+class Ph;
+  function void get(ref int outp[int]);
+    outp[1] = 1;
+    outp[2] = 1;
+  endfunction
+endclass
+module top;
+  initial begin
+    Ph h = new;
+    int edges[int];
+    h.get(edges);
+    if (edges.num() == 2)
+      $display("METH_PASS num=%0d", edges.num());
+    else
+      $display("METH_FAIL num=%0d", edges.num());
+  end
+endmodule
+"#;
+
+#[test]
+fn method_ref_aa_different_formal_and_actual_name() {
+    let sim = simulate(METHOD_DIFF_NAMES, 100).expect("simulate failed");
+    assert_pass(&sim, "METH");
+}
+
+/// The `m_successors` shape precisely: an AA keyed by class handle, filled by
+/// a method through a `ref` formal whose name differs from the caller's.
+const HANDLE_KEYED_METHOD: &str = r#"
+class Node;
+  function new(string n); endfunction
+endclass
+class Ph;
+  function void get(ref int outp[Node], input Node a);
+    outp[a] = 1;
+  endfunction
+endclass
+module top;
+  initial begin
+    Ph h = new;
+    Node n = new("A");
+    int edges[Node];
+    h.get(edges, n);
+    if (edges.num() == 1)
+      $display("HNDL_PASS num=%0d", edges.num());
+    else
+      $display("HNDL_FAIL num=%0d", edges.num());
+  end
+endmodule
+"#;
+
+#[test]
+fn method_ref_handle_indexed_aa_different_names() {
+    let sim = simulate(HANDLE_KEYED_METHOD, 100).expect("simulate failed");
+    assert_pass(&sim, "HNDL");
+}
+
+/// The free-function flip side: when the caller's actual has the *same* name
+/// as the `ref` formal, the free-function path lost writeback.
+const FREE_FN_SAME_NAME: &str = r#"
+module top;
+  function automatic void fill(ref int aa[int]);
+    aa[1] = 1;
+    aa[2] = 1;
+  endfunction
+  initial begin
+    int aa[int];
+    fill(aa);
+    if (aa.num() == 2)
+      $display("FREE_PASS num=%0d", aa.num());
+    else
+      $display("FREE_FAIL num=%0d", aa.num());
+  end
+endmodule
+"#;
+
+#[test]
+fn free_function_ref_aa_same_formal_and_actual_name() {
+    let sim = simulate(FREE_FN_SAME_NAME, 100).expect("simulate failed");
+    assert_pass(&sim, "FREE");
+}
+
+/// Regression guard: scalar, dynamic-array, and queue `ref` writeback were
+/// never affected. This ensures a future fix covers the AA path without
+/// regressing the already-working collection kinds.
+const NON_AA_REFS: &str = r#"
+module top;
+  function automatic void f_scalar(ref int s);  s = 99;            endfunction
+  function automatic void f_dyn  (ref int d[]); d = new[2]; d[1]=5; endfunction
+  function automatic void f_queue(ref int q[$]); q.push_back(7);    endfunction
+  initial begin
+    int s = 0; int d[]; int q[$];
+    f_scalar(s);
+    f_dyn(d);
+    f_queue(q);
+    if (s == 99 && d.size()==2 && d[1]==5 && q.size()==1 && q[0]==7)
+      $display("OTHER_PASS s=%0d d.sz=%0d q.sz=%0d", s, d.size(), q.size());
+    else
+      $display("OTHER_FAIL s=%0d d.sz=%0d q.sz=%0d", s, d.size(), q.size());
+  end
+endmodule
+"#;
+
+#[test]
+fn ref_scalar_dynarr_queue_writeback_unaffected() {
+    let sim = simulate(NON_AA_REFS, 100).expect("simulate failed");
+    assert_pass(&sim, "OTHER");
+}

--- a/tests/value_param_specialization.rs
+++ b/tests/value_param_specialization.rs
@@ -1,0 +1,42 @@
+//! Value parameters of a specialized class, referenced bare inside a STATIC
+//! method (no instance constructed). The exact shape of UVM's factory
+//! `uvm_object_registry#(T,"base_class")::get_type_name()` → returns the
+//! string param `Tname`.
+//!
+//! Before the fix, a bare reference to a value parameter inside a static
+//! method fell through to the class's *declared default* (`<unknown>` / 0)
+//! instead of the specialization's actual argument, because no instance is
+//! constructed for a static call and the binding only existed in the
+//! `#(...)` argument list. `resolve_value_param_from_spec` extracts the
+//! argument from the active specialization's signature text and evaluates it
+//! (string literals, numeric literals, and bare name references).
+//!
+//! Verified against reference simulators for the direct-specialization form.
+//! (The typedef'd-specialization instance path — `typedef C#(args) Alias;
+//! Alias::get()` — is a separate, deeper gap: nested parametric typedef
+//! resolution.)
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_contains(sim: &xezim::compiler::Simulator, needle: &str) {
+    let msgs = messages(sim);
+    assert!(
+        msgs.iter().any(|m| m.contains(needle)),
+        "expected {:?} in output\nfull output: {msgs:?}",
+        needle
+    );
+}
+
+const STR_PARAM_SPEC: &str = include_str!("lrm_9_value_param/str_param_spec.sv");
+
+#[test]
+fn value_param_from_specialization_static() {
+    let sim = simulate(STR_PARAM_SPEC, 100).expect("simulate failed");
+    assert_contains(&sim, "STR_PASS 'base_class'");
+    assert_contains(&sim, "INT_PASS 7");
+    assert_contains(&sim, "DEF_PASS '<unknown>'");
+}


### PR DESCRIPTION
 ### Summary

 This branch improves SystemVerilog scheduler and class-model correctness so that genuine UVM library code (factory, phasing, objections,
 register layer) executes rather than stalling. It implements IEEE 1800-2023 §9.7 process control, fixes several generic scheduler bugs, and
 hardens class value-parameter, typedef, and ref-argument handling. All fixes are generic SystemVerilog improvements — the simulator gains no
 UVM-specific dependencies.

 ### Changes

 IEEE 1800-2023 §9.7 — fine-grain process control
 - Implemented the built-in process class: status(), kill(), await(), suspend(), resume(). Process handles modeled as PROCESS_HANDLE_BASE + pid.
 - Verified against reference simulators; 5 self-checking SV tests + golden-text integration test.

 Scheduler & semantic fixes
 - Program-block reactive statements now route through run_process_stmts (was a no-op, breaking reactive testbenches).
 - wait() is level-sensitive: all wait(cond) route to the condition-waiter fixpoint instead of a one-shot delta wakeup.
 - Fork-child write visibility: writes to signal-backed locals captured into child frames now propagate back to the parent.
 - Parenless blocking task/method calls are normalized (Stage 0) before the inlining guards, per LRM §13.5 footnote 42.

 Class & parametric model (need https://github.com/aionhw/xezim-core/pull/6)
 - Chained member access: methods on nested object receivers (obj.q.m()) now walk the heap prefix correctly instead of resolving to the wrong object.
 - ref/output associative-array formals: write back to the caller's array (method path was missing writeback entirely; function path corrupted the caller's array on same-name collisions). New port_is_assoc_array() helper detects AA formals through both direct dims and typedefs.
 - Class-local typedefs are now fully elaborated (process_typedef), so typedef'd types carry correct type/width/dimensions — previously only enum-member names were registered, leaving forward-typedef placeholders in place. This unblocks AA-typed ref formals like ref edges_t.
 - Value parameters in static methods: a bare reference to a value param inside a directly-specialized class (C#(val)::method()) now returns the specialization's argument rather than the declared default.

 ### Test coverage

 - +7 self-checking test files (1,148 lines): §9.7 process control, blocking-task-call, chained member access, fork-var sharing, ref-arg AA writeback, class-local-typedef AA, value-param specialization.
 - 726 self-tests pass, 0 failed, 6 ignored.
 - Every fix verified byte-for-byte against reference simulators before commit.

 ### Known follow-ups
-  Genuine UVM phasing now runs (user callbacks like build_phase fire; the phase DAG expands correctly), exposing the next layer of factory/config_db/objection bugs to address. 
 - Typedef'd specializations (typedef C#(args) Alias; Alias::method()) — the form UVM's factory actually uses — still need nested parametric typedef resolution.