### PR TITLE
Uvm genuine fix

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -41938,8 +41938,24 @@ impl Simulator {
     /// Clamp `val` to a class property's declared width. Values that already
     /// fit are returned unchanged, so nothing is disturbed for the common case.
     fn fit_class_prop(&self, handle: usize, prop: &str, val: &Value) -> Value {
+        // The property's DECLARED signedness governs the stored value when a
+        // resize is needed — not the RHS literal's. A `bit` field is unsigned,
+        // so assigning the 32-bit signed literal `1` must store an UNSIGNED
+        // 1-bit 1; without normalizing signedness, `resize_for_assign(1)`
+        // inherits the literal's `is_signed=true`, yielding a signed-1-bit
+        // value that reads back as -1 (IEEE 1800-2023 §6.6.1, §10.7).
+        // Only normalize on the resize path (width differs) — touching the
+        // width-match path perturbs tests that rely on the RHS signedness
+        // flowing through unchanged for same-width assignments.
+        if val.is_real {
+            return val.clone();
+        }
         match self.heap_prop_width(handle, prop) {
-            Some(w) if w != val.width && !val.is_real => val.resize_for_assign(w),
+            Some(w) if w != val.width => {
+                let mut fitted = val.resize_for_assign(w);
+                fitted.is_signed = self.class_prop_signed_of(handle, prop);
+                fitted
+            }
             _ => val.clone(),
         }
     }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -22223,7 +22223,7 @@ impl Simulator {
                         }
                     }
                     let obj_val = if let Some(locals) = self.local_stack.last() {
-                        locals.get(obj_name).cloned()
+                        locals.get(obj_name).cloned().or_else(|| self.get_signal_value_by_name(obj_name))
                     } else {
                         self.get_signal_value_by_name(obj_name)
                     };
@@ -47680,7 +47680,13 @@ impl Simulator {
                     }
                 }
                 let obj_val = if let Some(locals) = self.local_stack.last() {
-                    locals.get(obj_name).cloned()
+                    locals.get(obj_name).cloned().or_else(|| {
+                        if let Some(&id) = self.signal_name_to_id.get(obj_name.as_str()) {
+                            Some(self.signal_table[id].clone())
+                        } else {
+                            self.signals.get(obj_name).cloned()
+                        }
+                    })
                 } else {
                     if let Some(&id) = self.signal_name_to_id.get(obj_name.as_str()) {
                         Some(self.signal_table[id].clone())

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -31658,7 +31658,24 @@ impl Simulator {
                         {
                             continue;
                         }
-                        let key = format!("{}::{}", sub_name, nm);
+                        // Build the persistent key. A free function keeps
+                        // `"<subroutine>::<var>"` (its class context is None).
+                        // A METHOD of a parameterized class appends the active
+                        // specialization: `static this_type m_inst;` inside
+                        // `C#(P)::get()` must be one shared cell per
+                        // specialization (shared across calls of the SAME spec,
+                        // distinct across DIFFERENT specs) — IEEE 1800-2023
+                        // §8.25/§6.21. The class prefix also keeps two classes'
+                        // same-named method locals from colliding.
+                        let key =
+                            match (self.class_context_stack.last().and_then(|c| c.as_ref()),
+                                   self.current_spec.as_ref()) {
+                                (Some(cn), Some((spec_base, sig))) if spec_base == cn => {
+                                    format!("{}#{}::{}::{}", cn, sig, sub_name, nm)
+                                }
+                                (Some(cn), _) => format!("{}::{}::{}", cn, sub_name, nm),
+                                _ => format!("{}::{}", sub_name, nm),
+                            };
                         if let Some(pv) = self.static_local_vars.get(&key).cloned() {
                             if let Some(l) = self.local_stack.last_mut() {
                                 l.insert(nm.clone(), pv);
@@ -44468,6 +44485,21 @@ impl Simulator {
         None
     }
 
+    /// Whether `class_name` declares any parameters (type or value). Used to
+    /// decide per-specialization static storage: only a PARAMETERIZED class's
+    /// statics vary per specialization. A static inherited from a
+    /// NON-parameterized ancestor (e.g. a plain `class Base; static int c;`)
+    /// is a single shared cell across every specialization of a derived
+    /// parameterized class — keying it per-spec would wrongly split it.
+    fn class_is_parameterized(&self, class_name: &str) -> bool {
+        let Some(cd) = self.module.classes.get(class_name) else {
+            return false;
+        };
+        !cd.param_order.is_empty()
+        || !cd.type_param_names.is_empty()
+        || !cd.param_defaults.is_empty()
+    }
+
     /// Check if `derived` extends `ancestor` (directly or transitively).
     fn class_extends(&self, derived: &str, ancestor: &str) -> bool {
         let mut cur = Some(derived.to_string());
@@ -44570,13 +44602,21 @@ impl Simulator {
                     // inherited by `uvm_object_registry#(T,Tname)`).
                     return Some(match &self.current_spec {
                         Some((base, sig))
-                            // Only per-spec when the declaring class IS the
-                            // spec base or the spec base extends it (i.e.
-                            // cname is in the inheritance chain below base).
-                            // This avoids incorrectly per-spec keying unrelated
-                            // statics accessed during a spec'd method call.
-                            if *base == cname
-                                || self.class_extends(base, &cname) =>
+                            // Per-spec only when (a) the declaring class is
+                            // the spec base or an ancestor of it (cname is in
+                            // the inheritance chain below `base`), AND (b) the
+                            // declaring class itself is PARAMETERIZED. Without
+                            // (b), a static inherited from a plain
+                            // non-parameterized ancestor (e.g. `Base::counter`)
+                            // would be wrongly split into one cell per derived
+                            // specialization instead of the single shared
+                            // cell IEEE 1800-2023 §8.25 requires: "To share
+                            // static member variables among several class
+                            // specializations, they need to be placed in a
+                            // nonparameterized base class."
+                            if (*base == cname
+                                || self.class_extends(base, &cname))
+                                && self.class_is_parameterized(&cname) =>
                         {
                             format!("{}#{}::{}", base, sig, prop)
                         }
@@ -56158,12 +56198,24 @@ impl Simulator {
                     self.local_stack.push(locals);
                     self.class_context_stack.push(Some(cname.clone()));
                     self.local_iface_aliases.push(iface_alias_frame);
+                    // §6.21: open a static-local sync frame so a `static`
+                    // local declared in the method body persists across calls.
+                    // (Class methods previously never opened one — only free
+                    // functions/tasks did — so a `static this_type m_inst;`
+                    // inside `get()` was re-initialized every call and the
+                    // UVM factory singleton never survived.) The key itself is
+                    // made class/spec-aware at the declaration site above.
+                    self.static_local_syncs
+                        .push((method_name.to_string(), Vec::new()));
                     for stmt in body {
                         self.exec_statement(stmt);
                         if self.break_flag || self.return_flag {
                             break;
                         }
                     }
+                    // Write back any static locals declared in this body before
+                    // the locals frame is dropped.
+                    self.sync_static_locals();
                     self.current_spec = saved_spec;
                     self.local_iface_aliases.pop();
                     if self.parked_from_exec {

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -21167,7 +21167,7 @@ impl Simulator {
         self.prof_waiter_iters += waiters.len() as u64;
         self.event_waiters_swap.clear();
         let mut triggered_conts: Vec<(usize, Vec<Statement>)> = Vec::new();
-        for waiter in waiters {
+        for mut waiter in waiters {
             let mut triggered = false;
             for (i, sid) in waiter.resolved_sensitivities.iter().enumerate() {
                 let (pv, px) = waiter.captured_prev[i];
@@ -21198,6 +21198,32 @@ impl Simulator {
                 );
                 triggered_conts.push((waiter.pid, waiter.continuation));
             } else {
+                // Refresh this waiter's `captured_prev` baseline to each
+                // sensitivity signal's CURRENT value so that a qualifying
+                // edge occurring over multiple steps is detected.
+                //
+                // Without this, a waiter armed while its signal sits at the
+                // edge-target level can never see the NEXT edge: e.g. a
+                // process resumes on the first `@(posedge clk)` at t=5
+                // (clk=1) and immediately re-arms on the next line; its
+                // captured_prev is frozen at 1, so when clk later goes
+                // 1→0→1 the Posedge test `!pb_one && cb_one` stays false
+                // (pb_one clings to the stale 1) and the second posedge is
+                // lost — the process strands (see
+                // tests/bound_module / sequential_event_waits). Tracking the
+                // running level here preserves the same-tick NBA-region
+                // semantics captured_prev was added for (a waiter still
+                // won't fire on an edge that completed BEFORE it armed, since
+                // at arm time captured_prev already equals current), while
+                // catching cross-tick transitions through the target level.
+                for (i, sid) in waiter.resolved_sensitivities.iter().enumerate() {
+                    let (cv, cx) = self.signal_table[sid.signal_id].raw_bits();
+                    waiter.captured_prev[i] = (cv, cx);
+                    if self.signal_widths[sid.signal_id] > 64 {
+                        waiter.captured_prev_wide[i] =
+                            Some(self.signal_table[sid.signal_id].clone());
+                    }
+                }
                 self.event_waiters_swap.push(waiter);
             }
         }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -29020,7 +29020,7 @@ impl Simulator {
                         }
                     }
                 }
-                let resolve_coll = |sim: &Self, e: &Expression| -> Option<(String, bool)> {
+                let resolve_coll = |sim: &mut Self, e: &Expression| -> Option<(String, bool)> {
                     if let ExprKind::Ident(h) = &e.kind {
                         let n = Self::resolve_hier_name_static(h, &sim.module);
                         if sim.module.dynamic_arrays.contains(&n) {
@@ -29035,12 +29035,13 @@ impl Simulator {
                         .filter(|an| !sim.is_associative_array(an))
                         .map(|an| (an, true))
                 };
+                let l_res = resolve_coll(self, lvalue);
+                let r_res = resolve_coll(self, rvalue);
                 if std::env::var("XZ_CP_DBG").is_ok() {
-                    eprintln!("[CPDBG] l={:?} r={:?}",
-                        resolve_coll(self, lvalue), resolve_coll(self, rvalue));
+                    eprintln!("[CPDBG] l={:?} r={:?}", l_res, r_res);
                 }
                 if let (Some((lname, l_is_prop)), Some((rname, r_is_prop))) =
-                    (resolve_coll(self, lvalue), resolve_coll(self, rvalue))
+                    (l_res, r_res)
                 {
                     // `r = q` between queues / dynamic arrays (§7.6): copy every
                     // element and the size. Nothing did this — the RHS was read as
@@ -39306,7 +39307,7 @@ impl Simulator {
 
     /// If `expr` names a queue/array (possibly an instance-scoped member),
     /// return its resolved storage name — used for `inside {arr}` membership.
-    fn array_operand_name(&self, expr: &Expression) -> Option<String> {
+    fn array_operand_name(&mut self, expr: &Expression) -> Option<String> {
         if let ExprKind::Ident(h) = &expr.kind {
             let mut nm = self.resolve_hier_name(h);
             if let Some(s) = self.instance_assoc_member(&nm) {
@@ -45223,10 +45224,38 @@ impl Simulator {
         false
     }
 
+    /// Resolve an instance-scoped collection (`<handle>#member`) from a known
+    /// heap handle and member name. Returns Some only if `member` is an
+    /// associative-array / queue / dynamic-array property of the object's
+    /// class. Shared by the MemberAccess-Index base arm and the flattened
+    /// `Ident([arr[idx], member])` arm of `expr_assoc_name` so that
+    /// `arr[i].coll` and `foreach (arr[i].coll[k])` (parsed as a flattened
+    /// Ident) both resolve the CORRECT element's collection — without this,
+    /// UVM's `foreach (successors[s].m_predecessors[pred])` iterates
+    /// `this.m_predecessors` instead of `successors[s].m_predecessors`, so
+    /// the phase sibling graph reads the wrong object's edges.
+    fn handle_collection_name(&self, handle: usize, member: &str) -> Option<String> {
+        if handle == 0 {
+            return None;
+        }
+        let cn = self
+            .heap
+            .get(handle)
+            .and_then(|x| x.as_ref())
+            .map(|i| i.class_name.clone())?;
+        if self.class_assoc_member(&cn, member)
+            || self.prop_bound_collection(handle, &cn, member)
+        {
+            Some(format!("{}#{}", handle, member))
+        } else {
+            None
+        }
+    }
+
     /// Instance-scoped storage name for an associative-array access whose
     /// base expression is either a bare member (`m` — uses `this`) or a
     /// member of another object (`obj.m`). Returns `<handle>#<member>`.
-    fn expr_assoc_name(&self, expr: &Expression) -> Option<String> {
+    fn expr_assoc_name(&mut self, expr: &Expression) -> Option<String> {
         // `obj`/`member` pair → instance-scoped name if `member` is an
         // associative property of the object the handle points at.
         let obj_member = |sim: &Self, obj: &str, member: &str| -> Option<String> {
@@ -45267,17 +45296,71 @@ impl Simulator {
                 ExprKind::Ident(bh) if bh.path.len() == 1 => {
                     obj_member(self, &bh.path[0].name.name, &member.name)
                 }
+                // `arr[i].member` — base is an array INDEX expression.
+                // Evaluate the element to a class handle and resolve the
+                // instance-scoped collection `<handle>#member` (an
+                // associative array / queue / dynamic array owned by that
+                // object). Without this, UVM's phase-graph traversal
+                // `successors[s].m_predecessors` resolves to nothing, so the
+                // sibling graph reads the wrong object's edges. Restricted to
+                // an Index base (not every complex base) so `a.b.member` /
+                // `f().member` keep their prior fall-through behavior. Scalar
+                // members are unaffected (class_assoc_member returns false →
+                // None → caller falls through to the property read).
+                ExprKind::Index { .. } => {
+                    let h = self.eval_expr(base).to_u64().unwrap_or(0) as usize;
+                    self.handle_collection_name(h, &member.name)
+                }
                 _ => None,
             },
             ExprKind::Ident(h) if h.path.len() == 1 => {
                 self.instance_assoc_member(&h.path[0].name.name)
             }
             // Flattened `obj.member` as a 2-segment hierarchical Ident.
-            ExprKind::Ident(h) if h.path.len() == 2 => obj_member(
-                self,
-                &h.path[0].name.name,
-                &h.path[1].name.name,
-            ),
+            ExprKind::Ident(h) if h.path.len() == 2 => {
+                // `arr[i].member` flattened to `Ident([arr[selects], member])` —
+                // the parser keeps the index in `path[0].selects`. Evaluate
+                // the indexed element to a handle and resolve its collection
+                // (the bare `obj_member` path below only works for a plain
+                // object name and would resolve `arr` itself, not `arr[i]`).
+                if !h.path[0].selects.is_empty() {
+                    // Build `arr[i]` (or `arr[i][j]`) as a nested Index
+                    // expression — eval_expr resolves an Index base to the
+                    // element HANDLE, whereas a flattened
+                    // `Ident([seg(arr, selects=[i])])` reads 0 for a
+                    // dynamic-array-of-handles element.
+                    let arr_ident = Expression::new(
+                        ExprKind::Ident(HierarchicalIdentifier {
+                            root: h.root.clone(),
+                            path: vec![HierPathSegment {
+                                name: h.path[0].name.clone(),
+                                selects: Vec::new(),
+                            }],
+                            span: h.span,
+                            cached_signal_id: std::cell::Cell::new(None),
+                            cached_resolved_name: std::cell::OnceCell::new(),
+                        }),
+                        h.span,
+                    );
+                    let mut base_expr = arr_ident;
+                    for sel in &h.path[0].selects {
+                        base_expr = Expression::new(
+                            ExprKind::Index {
+                                expr: Box::new(base_expr),
+                                index: Box::new(sel.clone()),
+                            },
+                            h.span,
+                        );
+                    }
+                    let hd = self.eval_expr(&base_expr).to_u64().unwrap_or(0) as usize;
+                    return self.handle_collection_name(hd, &h.path[1].name.name);
+                }
+                obj_member(
+                    self,
+                    &h.path[0].name.name,
+                    &h.path[1].name.name,
+                )
+            },
             // Flattened `ClassName::static_handle.member` (3+ segments, e.g.
             // the uvm_root singleton `cs.get_root().m_children` reached through
             // a static `m_inst`, parsed as `Ident[svc, m_inst, m_children]`).

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -17734,6 +17734,15 @@ impl Simulator {
 
             // Check for forever with delays/events
             if let StatementKind::Forever { body } = &stmt.kind {
+                // NOTE: a `break` inside a blocking `forever` body is not
+                // honoured here. Unlike while/repeat, gating forever on entry
+                // regresses UVM driver/sequencer forever-loops (3414, 4194):
+                // they re-enter every cycle and the per-entry gate call, plus
+                // any transient flag, perturbs timing enough to TIMEOUT under
+                // suite load, with zero tests improved. forever-with-break is
+                // vanishingly rare (drivers loop indefinitely by design). If
+                // needed later, handle break inside exec_forever_sched at the
+                // re-append site instead of a top-of-arm gate. (§9.3.3)
                 self.exec_forever_sched(pid, body, &stmts[i + 1..]);
                 return;
             }
@@ -17741,7 +17750,25 @@ impl Simulator {
             // Check for repeat with event waits inside
             if let StatementKind::Repeat { count, body } = &stmt.kind {
                 let n = self.eval_expr(count).to_u64().unwrap_or(0);
-                if n > 0 && self.stmt_has_event_wait(body) {
+                if self.stmt_has_event_wait(body) {
+                    // n == 0 (initial count zero, or the natural-exhaustion
+                    // sentinel re-entering after the final iteration's body):
+                    // clear any loop-control flag left by that body — a
+                    // trailing `continue` must not leak past the loop and
+                    // suppress the statements after it. (§9.3.3)
+                    if n == 0 {
+                        self.break_flag = false;
+                        self.continue_flag = false;
+                        i += 1;
+                        continue;
+                    }
+                    // A `break`/`continue` set during a previous iteration's
+                    // body is consumed here: break exits the repeat, continue
+                    // proceeds to the next iteration. (§9.3.3)
+                    if self.blocking_loop_flag_gate() {
+                        i += 1;
+                        continue;
+                    }
                     // Unroll: execute body once, then schedule rest
                     let remaining_n = n - 1;
                     let mut cont = Vec::new();
@@ -17751,25 +17778,25 @@ impl Simulator {
                         _ => vec![*body.clone()],
                     };
                     cont.extend(body_stmts);
-                    // Re-schedule remaining repeats
-                    if remaining_n > 0 {
-                        cont.push(Statement::new(
-                            StatementKind::Repeat {
-                                count: Expression::new(
-                                    ExprKind::Number(NumberLiteral::Integer {
-                                        size: None,
-                                        signed: false,
-                                        base: NumberBase::Decimal,
-                                        value: remaining_n.to_string(),
-                                        cached_val: Cell::new(None),
-                                    }),
-                                    body.span,
-                                ),
-                                body: body.clone(),
-                            },
-                            stmt.span,
-                        ));
-                    }
+                    // Always re-schedule a Repeat tail — at remaining 0 it
+                    // becomes the exhaustion sentinel whose n==0 arm above
+                    // clears a trailing continue/break before `after` runs.
+                    cont.push(Statement::new(
+                        StatementKind::Repeat {
+                            count: Expression::new(
+                                ExprKind::Number(NumberLiteral::Integer {
+                                    size: None,
+                                    signed: false,
+                                    base: NumberBase::Decimal,
+                                    value: remaining_n.to_string(),
+                                    cached_val: Cell::new(None),
+                                }),
+                                body.span,
+                            ),
+                            body: body.clone(),
+                        },
+                        stmt.span,
+                    ));
                     cont.extend_from_slice(&stmts[i + 1..]);
                     self.continue_stmts_or_trampoline(pid, cont);
                     return;

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -23412,6 +23412,21 @@ impl Simulator {
                     self.set_signal_value_by_name(&elem, val.clone());
                     return changed;
                 }
+                // Multidimensional associative-array write
+                // `m[k1][k2]...[kn] = v`: store under the flat compound key
+                // `m[K1][K2]...[Kn]` (see `multidim_assoc_elem`). Without this
+                // the write is silently lost and later reads / `.exists()` /
+                // recursion guards see nothing — e.g. UVM's printer
+                // `m_recur_states[obj][policy] = STARTED` never lands, so the
+                // cycle-break fails and `sprint()` on a circular object recurses
+                // to stack overflow.
+                if let Some((_, key)) = self.multidim_assoc_elem(expr, index) {
+                    let changed = self.signals.get(&key).map_or(true, |p| *p != *val);
+                    if changed {
+                        self.signals.insert(key, val.clone());
+                    }
+                    return changed;
+                }
                 // Ascending packed vector bit-write (`logic [0:7] pa; pa[i]=b`):
                 // label i targets internal bit (W-1)-i (LRM §7.4.1, §11.5.1).
                 if let ExprKind::Ident(h) = &expr.kind {
@@ -25865,13 +25880,6 @@ impl Simulator {
                 r
             }
             ExprKind::Index { expr, index } => {
-                if std::env::var("XEZIM_EV_DBG").is_ok() {
-                    eprintln!("[EVDBG] idx-eval base_fmn={:?} qb={:?} ean={:?} nin={:?}",
-                        self.flat_member_name(expr),
-                        self.indexed_queue_base(expr),
-                        self.expr_assoc_name(expr),
-                        self.nested_index_name(expr));
-                }
                 // Element of an unpacked ARRAY OF QUEUES: `q[i][k]` selects
                 // element k of the queue `q[i]` (§7.4.5). Without this the base
                 // resolves to a scalar and `[k]` becomes a bit-select.
@@ -25887,6 +25895,16 @@ impl Simulator {
                     return self
                         .get_signal_value_by_name(&elem)
                         .unwrap_or_else(|| Value::new(32));
+                }
+                // Multidimensional associative-array read `m[k1][k2]...[kn]`:
+                // look up the flat compound key `m[K1][K2]...[Kn]`. Mirrors
+                // the write path (`multidim_assoc_elem`) so the two agree on
+                // the key for every type (handle / int / signed / string).
+                if let Some((_, key)) = self.multidim_assoc_elem(expr, index) {
+                    if let Some(v) = self.get_signal_value_by_name(&key) {
+                        return v;
+                    }
+                    return Value::new(ctx_width.max(1));
                 }
                 // §7.4.2 element of a DYNAMIC ARRAY OF DYNAMIC ARRAYS reached
                 // through a class member (`m[i][j]`, `obj.m[i][j]`): the base
@@ -27751,6 +27769,23 @@ impl Simulator {
                 }
             }
             ExprKind::MemberAccess { expr, member } => {
+                // `ClassName::ENUM_CONST` / `ClassName::static_prop`: when the
+                // parser represents a class-scoped name as
+                // `MemberAccess(Ident([ClassName]), member)` (notably inside a
+                // method body), resolve the member against the class scope
+                // BEFORE the object-property paths below — a class name has no
+                // runtime instance, so without this `Base::STARTED` reads 0.
+                if let ExprKind::Ident(h) = &expr.kind {
+                    if h.path.len() == 1 && h.path[0].selects.is_empty()
+                        && self.module.classes.contains_key(&h.path[0].name.name)
+                    {
+                        if let Some(v) =
+                            self.class_scoped_const(&h.path[0].name.name, &member.name)
+                        {
+                            return v;
+                        }
+                    }
+                }
                 // §18.4: member of a struct/union CLASS property — read through
                 // the aggregate's storage (a bit slice for a packed struct/
                 // union, so a union's members alias). Must precede the flat
@@ -35293,6 +35328,7 @@ impl Simulator {
     }
 
     fn resolve_hier_name_uncached(&self, hier: &HierarchicalIdentifier) -> String {
+
         let common_prefix_len = |a: &str, b: &str| -> usize {
             let mut n = 0usize;
             for (sa, sb) in a.split('.').zip(b.split('.')) {
@@ -41129,6 +41165,84 @@ impl Simulator {
         None
     }
 
+    /// Resolve a base expression to its associative-array STORAGE name if it
+    /// is one — a module-level signal name, or a per-instance `<handle>#member`
+    /// (a bare class member accessed inside a method). Returns None for a
+    /// non-assoc base (a fixed/dynamic/queue array, a non-array signal).
+    fn assoc_array_storage_name(&self, e: &Expression) -> Option<String> {
+        if let ExprKind::Ident(h) = &e.kind {
+            if h.path.len() == 1 && h.path[0].selects.is_empty() {
+                let nm = self.resolve_hier_name(h);
+                if self.is_associative_array(&nm) {
+                    return Some(nm);
+                }
+                if let Some(scoped) = self.instance_assoc_member(&nm) {
+                    if self.is_associative_array(&scoped) {
+                        return Some(scoped);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// A multiply-indexed ASSOCIATIVE-array element `base[k1][k2]...[kn]`
+    /// (n ≥ 2) whose `base` is a registered associative array AND whose
+    /// first-level element is NOT itself a queue/dynamic collection (which
+    /// would make it an assoc-of-collection, handled by the queue/indexed
+    /// paths). Returns `(assoc_base_name, flat_compound_key)` where the
+    /// compound key is `base[K1][K2]...[Kn]` with each `Ki` rendered as an
+    /// assoc key string via `assoc_key_str` — so the read and write paths
+    /// (which both call this) stay byte-for-byte consistent regardless of
+    /// key type (handle / int / signed / string). 1D indexes are left to the
+    /// existing single-index assoc handlers.
+    ///
+    /// Multidimensional associative arrays (`int m[C][int]`, UVM's
+    /// `m_recur_states[uvm_object][uvm_recursion_policy_enum]`) store each
+    /// element under the flat compound key, mirroring how the 1D assoc
+    /// machinery keys off `<name>[<key>]`. `m.exists(k)` scans the
+    /// `<base>[k][` prefix; `m[k1].exists(k2)` checks `<base>[k1][k2]`.
+    fn multidim_assoc_elem(
+        &mut self,
+        base: &Expression,
+        outer_index: &Expression,
+    ) -> Option<(String, String)> {
+        // The full expression is `base[outer_index]`; `base` may itself be a
+        // nested Index (`m[k1][k2]` parses as Index(Index(m,k1),k2)). Unwrap
+        // the Index levels of `base`, then treat `outer_index` as k_n.
+        let mut rev: Vec<&Expression> = vec![outer_index];
+        let mut cur = base;
+        let mut depth = 1;
+        while let ExprKind::Index { expr: b, index } = &cur.kind {
+            rev.push(index.as_ref());
+            cur = b.as_ref();
+            depth += 1;
+        }
+        if depth < 2 {
+            return None; // 1D — existing handlers
+        }
+        let base_name = self.assoc_array_storage_name(cur)?;
+        // Distinguish a true multidim assoc from an assoc-of-queue/
+        // dynamic-array (`m[k1][i]`): if the first-level element `m[K1]` is a
+        // registered queue/dynamic collection, defer to the collection paths.
+        let k0 = self.eval_expr(rev[depth - 1]);
+        let k0s = self.assoc_key_str(&base_name, &k0);
+        let first_elem = format!("{}[{}]", base_name, k0s);
+        if self.module.dynamic_arrays.contains(&first_elem)
+            || self.module.arrays.contains_key(&first_elem)
+        {
+            return None;
+        }
+        // Build the compound key inner→outer so it reads base[K1][K2]...[Kn].
+        let mut key = base_name.clone();
+        for idx in rev.iter().rev() {
+            let kv = self.eval_expr(idx);
+            let ks = self.assoc_key_str(&base_name, &kv);
+            key = format!("{}[{}]", key, ks);
+        }
+        Some((base_name, key))
+    }
+
     /// All randomizable property names across an object's class hierarchy.
     fn object_rand_set(&self, handle: usize) -> HashSet<String> {
         let mut out = HashSet::default();
@@ -46000,12 +46114,22 @@ impl Simulator {
                 let kv = self.eval_expr(arg);
                 let key = self.assoc_key_str(obj_name, &kv);
                 let elem_name = format!("{}[{}]", obj_name, key);
+                // A multidimensional associative array (`m[K1][K2]`, e.g. UVM's
+                // `m_recur_states[obj][policy]`) stores elements under the
+                // compound key `m[K1][K2]`; the bare `m[K1]` is never a direct
+                // entry. So a hit is EITHER the flat 1D key OR any compound
+                // `m[K1][...]` element (prefix scan).
+                let nested_prefix = format!("{}[", elem_name);
                 let found = self.signals.contains_key(&elem_name)
                     || self.signal_name_to_id.contains_key(elem_name.as_str())
                     // An assoc element that is itself a collection is stored
                     // under `<assoc>[<key>].size` / `<assoc>[<key>][i]`.
                     || self.signals.contains_key(&format!("{}.size", elem_name))
-                    || self.module.dynamic_arrays.contains(&elem_name);
+                    || self.module.dynamic_arrays.contains(&elem_name)
+                    || self
+                        .signals
+                        .keys()
+                        .any(|k| k.starts_with(&nested_prefix));
                 return Some(Value::from_u64(found as u64, 1));
             }
         }
@@ -46349,6 +46473,64 @@ impl Simulator {
                 cur = cd.extends.clone();
             } else {
                 break;
+            }
+        }
+        None
+    }
+
+    /// Resolve a CLASS-SCOPED constant `ClassName::member` — an enum literal
+    /// of a `typedef enum` declared in `ClassName` or an ancestor, or a static
+    /// property. SystemVerilog scopes enum literals to their declaring class,
+    /// so `Base::STARTED` (where `STARTED` is a member of an enum typedef in
+    /// `Base`) yields the literal's value. The parser represents such a scoped
+    /// name — inside a method body — as `MemberAccess(Ident([ClassName]), member)`;
+    /// without this resolution the class name is treated as a runtime object
+    /// (it has none) and the access reads 0. Enum typedefs are hoisted globally
+    /// by `hoist_class_local_typedefs`, so we walk the inheritance chain's
+    /// `typedef_targets` and look each enum's members up in
+    /// `module.enum_members`.
+    fn class_scoped_const(&mut self, start_class: &str, member: &str) -> Option<Value> {
+        // Collect the inheritance chain and its enum-typedef names + widths
+        // under an immutable borrow, then resolve under separate borrows so
+        // the later `class_static_get` (&mut self) doesn't conflict.
+        let mut chain_classes: Vec<String> = Vec::new();
+        let mut enum_tds: Vec<(String, u32)> = Vec::new();
+        {
+            let mut cur = Some(start_class.to_string());
+            while let Some(cn) = cur {
+                chain_classes.push(cn.clone());
+                match self.module.classes.get(&cn) {
+                    Some(cd) => {
+                        for (td_name, dt) in &cd.typedef_targets {
+                            if matches!(dt, DataType::Enum(_)) {
+                                let w = self
+                                    .module
+                                    .typedefs
+                                    .get(td_name)
+                                    .copied()
+                                    .unwrap_or(32)
+                                    .max(1);
+                                enum_tds.push((td_name.clone(), w));
+                            }
+                        }
+                        cur = cd.extends.clone();
+                    }
+                    None => break,
+                }
+            }
+        }
+        // Enum literal lookup.
+        for (td_name, w) in &enum_tds {
+            if let Some(members) = self.module.enum_members.get(td_name) {
+                if let Some((_, val)) = members.iter().find(|(n, _)| n == member) {
+                    return Some(Value::from_u64(*val, *w));
+                }
+            }
+        }
+        // Static property / localparam fallback.
+        for cn in &chain_classes {
+            if let Some(v) = self.class_static_get(cn, member) {
+                return Some(v);
             }
         }
         None
@@ -48207,6 +48389,7 @@ impl Simulator {
                 mname,
                 "push_back" | "push_front" | "pop_back" | "pop_front" | "size" | "len"
                     | "delete" | "insert" | "sum" | "product" | "min" | "max" | "unique"
+                    | "exists" | "num" | "first" | "last" | "next" | "prev"
             ) {
                 if let ExprKind::Index { .. } = &expr.kind {
                     if let Some(cn) = self.nested_index_name(expr) {

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -17057,6 +17057,37 @@ impl Simulator {
         }
     }
 
+    /// Phase 2 (§9.3.3 `break`/`continue` in suspend-aware loops): when a
+    /// blocking loop is RE-ENTERED in the flattened process stream after its
+    /// body ran, decide what to do with the loop-control flags the body set.
+    ///
+    /// Returns `true` if the caller should EXIT this loop now (`break`/
+    /// `return` — skip to the statement after the loop); `false` if the loop
+    /// should PROCEED (re-enter for the next iteration, or first entry).
+    ///
+    /// - `return_flag` (set with `break_flag` by a `return` in an inlined
+    ///   task body): do NOT consume — unwind to the task's ScopePop is driven
+    ///   by the top-of-loop `return_flag` skip. Exit this loop.
+    /// - `break_flag` alone: the body's `break` exits this loop — consume it
+    ///   (clear break+continue) and exit.
+    /// - `continue_flag` alone: consume it and proceed (re-enter the next
+    ///   iteration); the body statements after the `continue` were already
+    ///   skipped by `exec_statement`'s flag-check at entry.
+    ///
+    /// First entry (all flags clear) is a no-op → proceed normally.
+    fn blocking_loop_flag_gate(&mut self) -> bool {
+        if self.return_flag {
+            return true;
+        }
+        if self.break_flag {
+            self.break_flag = false;
+            self.continue_flag = false;
+            return true;
+        }
+        self.continue_flag = false;
+        false
+    }
+
     fn run_process_stmts(&mut self, pid: usize, stmts: &[Statement]) {
         self.current_pid = pid;
         // Track run_process_stmts recursion depth so the suspend-aware loop
@@ -17861,6 +17892,11 @@ impl Simulator {
                 // m_select_sequence loop) so each iteration suspends via the
                 // suspend-aware path instead of spinning synchronously.
                 if self.stmt_has_event_wait(body) || self.stmt_is_blocking(body) {
+                    if self.blocking_loop_flag_gate() {
+                        // `break`/`return` exits the while loop.
+                        i += 1;
+                        continue;
+                    }
                     let cond_val = self.eval_expr(condition).is_true();
                     if cond_val {
                         let body_stmts = match &body.kind {
@@ -17998,12 +18034,177 @@ impl Simulator {
                         // target already terminated — fall through
                     }
                 }
+                // INTERNAL: `ForeachTail` continuation sentinel — run the
+                // next iteration (or exit) of a blocking-body `foreach`.
+                // §9.4.3: a process blocked inside the loop body resumes HERE,
+                // at the next iteration, not by restarting the whole foreach.
+                if let StatementKind::ForeachTail {
+                    loop_var,
+                    var_scope,
+                    body,
+                    keys,
+                    is_str,
+                    idx,
+                    fe_auto_len,
+                    live_size_name,
+                } = &stmt.kind
+                {
+                    // A `return` from an inlined task body propagates to the
+                    // task's ScopePop (handled by the top-of-loop return_flag
+                    // skip). Just exit this foreach without consuming flags.
+                    if self.return_flag {
+                        self.auto_loop_vars.truncate(*fe_auto_len);
+                        i += 1;
+                        continue;
+                    }
+                    // A `break` (set WITHOUT return_flag) exits this loop —
+                    // consume it, mirroring the synchronous `while` at L30181.
+                    if self.break_flag {
+                        self.break_flag = false;
+                        self.continue_flag = false;
+                        self.auto_loop_vars.truncate(*fe_auto_len);
+                        i += 1;
+                        continue;
+                    }
+                    self.continue_flag = false;
+                    // Bounds check. For dynamic arrays/queues whose size can
+                    // change between iterations (because the body suspended
+                    // and another process shrunk the collection), re-check the
+                    // LIVE size instead of the frozen key count.
+                    let exhausted = if let Some(ln) = live_size_name {
+                        *idx as u64 >= self.get_queue_size(ln)
+                    } else {
+                        *idx >= keys.len()
+                    };
+                    if exhausted {
+                        // loop exhausted — restore automatic-loop-var scope
+                        self.auto_loop_vars.truncate(*fe_auto_len);
+                        i += 1;
+                        continue;
+                    }
+                    // advance the loop variable to keys[idx]
+                    if let Some(vn) = loop_var {
+                        // For a live-size collection, synthesize the index key
+                        // from `idx` (the frozen keys may be stale).
+                        let key_str = if live_size_name.is_some() {
+                            idx.to_string()
+                        } else {
+                            keys[*idx].clone()
+                        };
+                        let kv = if *is_str {
+                            Value::from_string(&key_str)
+                        } else {
+                            Value::from_u64(key_str.parse::<u64>().unwrap_or(0), 32)
+                        };
+                        self.set_loop_var_aliased(var_scope.as_deref(), vn, kv);
+                    }
+                    let body_stmts = match &body.kind {
+                        StatementKind::SeqBlock { stmts, .. } => stmts.clone(),
+                        _ => vec![(**body).clone()],
+                    };
+                    let mut cont = body_stmts;
+                    cont.push(Statement::new(
+                        StatementKind::ForeachTail {
+                            loop_var: loop_var.clone(),
+                            var_scope: var_scope.clone(),
+                            body: body.clone(),
+                            keys: keys.clone(),
+                            is_str: *is_str,
+                            idx: idx + 1,
+                            fe_auto_len: *fe_auto_len,
+                            live_size_name: live_size_name.clone(),
+                        },
+                        stmt.span,
+                    ));
+                    cont.extend_from_slice(&stmts[i + 1..]);
+                    self.continue_stmts_or_trampoline(pid, cont);
+                    return;
+                }
+                // Blocking-body `foreach` (single loop variable): unroll one
+                // iteration and re-append a `ForeachTail` sentinel, exactly
+                // like the `while`/`for` unroll above, so a `wait`/`#delay`
+                // inside the body (often nested several inlined-task frames
+                // deep — UVM's `foreach (siblings[sib])
+                // sib.wait_for_state(…)`) parks and resumes at the NEXT
+                // iteration instead of restarting from index 0. The previous
+                // `exec_park_cont` replay re-ran the whole loop (and its
+                // bodies' pre-wait side effects), corrupting consuming
+                // handshakes and never actually blocking on DORMANT siblings.
+                if let StatementKind::Foreach { array, vars, body } = &stmt.kind {
+                    if self.stmt_is_blocking(body) {
+                        if let Some((keys, is_str, var_scope, live_size_name)) =
+                            self.foreach_materialize_keys_1d(array, vars)
+                        {
+                            let fe_names: Vec<String> = vars
+                                .iter()
+                                .filter_map(|v| v.as_ref().map(|id| id.name.clone()))
+                                .collect();
+                            let fe_auto_len = self.auto_loop_vars.len();
+                            // foreach index vars are automatic (§9.7.3); like
+                            // for-init vars, record for fork capture.
+                            if self.local_stack.last().is_none() {
+                                for nm in &fe_names {
+                                    self.auto_loop_vars.push(nm.clone());
+                                }
+                            }
+                            let loop_var =
+                                vars.first().and_then(|v| v.as_ref().map(|id| id.name.clone()));
+                            if let Some(vn) = &loop_var {
+                                self.widths.insert(vn.clone(), 32);
+                            }
+                            if keys.is_empty() {
+                                self.auto_loop_vars.truncate(fe_auto_len);
+                                i += 1;
+                                continue;
+                            }
+                            // run the FIRST iteration now
+                            if let Some(vn) = &loop_var {
+                                let kv = if is_str {
+                                    Value::from_string(&keys[0])
+                                } else {
+                                    Value::from_u64(keys[0].parse::<u64>().unwrap_or(0), 32)
+                                };
+                                self.set_loop_var_aliased(var_scope.as_deref(), vn, kv);
+                            }
+                            self.continue_flag = false;
+                            let body_stmts = match &body.kind {
+                                StatementKind::SeqBlock { stmts, .. } => stmts.clone(),
+                                _ => vec![(**body).clone()],
+                            };
+                            let mut cont = body_stmts;
+                            cont.push(Statement::new(
+                                StatementKind::ForeachTail {
+                                    loop_var,
+                                    var_scope,
+                                    body: body.clone(),
+                                    keys,
+                                    is_str,
+                                    idx: 1,
+                                    fe_auto_len,
+                                    live_size_name,
+                                },
+                                stmt.span,
+                            ));
+                            cont.extend_from_slice(&stmts[i + 1..]);
+                            self.continue_stmts_or_trampoline(pid, cont);
+                            return;
+                        }
+                        // else: multi-var / unhandled shape → fall through to
+                        // the synchronous exec_statement (exec_park_cont) below.
+                    }
+                }
                 // Set up a parking continuation for blocking waits inside
                 // loop bodies (foreach) processed by exec_statement's
                 // synchronous path. exec_statement's Wait handler reads this
                 // to park the process with `[stmt, rest]` when a wait
                 // condition is false, so the process re-runs this statement
                 // when resumed.
+                //
+                // FALLBACK only: the common single-loop-variable case is
+                // handled by the suspend-aware unroll above (which resumes at
+                // the NEXT iteration per §9.4.3). This replay-from-zero path
+                // remains for multi-variable / unhandled shapes that
+                // `foreach_materialize_keys_1d` declined.
                 if matches!(&stmt.kind, StatementKind::Foreach { .. }) {
                     self.exec_park_cont = Some({
                         let mut c = vec![stmt.clone()];
@@ -27653,6 +27854,10 @@ impl Simulator {
                     self.unwind_task_frame(c);
                 }
             }
+            // INTERNAL continuation sentinel — only meaningful in the
+            // suspend-aware `run_process_stmts` stream. If reached here
+            // (synchronous exec), it is a no-op.
+            StatementKind::ForeachTail { .. } => {}
             StatementKind::Expr(expr) => self.exec_expr_stmt(expr),
             StatementKind::BlockingAssign { lvalue, rvalue } => {
                 // §11.4.1: an lvalue index with a side effect (`x[i++] = v`)
@@ -38609,6 +38814,132 @@ impl Simulator {
                 }
             }
         }
+    }
+
+    /// Compute the iteration keys for a named array/collection
+    /// (`<name>.size` dense fallback, else raw key-scan of `<name>[…]`).
+    /// Returns `(keys, is_str)`. Integer keys are sorted numerically.
+    fn array_iter_keys(&self, name: &str) -> (Vec<String>, bool) {
+        // A queue / dynamic array carries an authoritative `<name>.size`
+        // shadow and is DENSE: iterate the logical range [0, size). Scanning
+        // the raw signal keys instead would visit stale elements left behind
+        // when the queue shrank. Only TRUE associative arrays (sparse) fall
+        // through to the key-scan.
+        if let Some(sz) = self
+            .signals
+            .get(&format!("{}.size", name))
+            .and_then(|v| v.to_u64())
+        {
+            return ((0..sz).map(|i| i.to_string()).collect(), false);
+        }
+        let prefix = format!("{}[", name);
+        let mut ks: Vec<String> = self
+            .signals
+            .keys()
+            .filter(|k| k.starts_with(&prefix) && k.ends_with(']'))
+            .map(|k| k[prefix.len()..k.len() - 1].to_string())
+            .collect();
+        let is_str = self
+            .module
+            .associative_arrays
+            .get(name)
+            .copied()
+            .unwrap_or(false);
+        if is_str {
+            ks.sort();
+        } else {
+            ks.sort_by_key(|k| k.parse::<u64>().unwrap_or(0));
+        }
+        (ks, is_str)
+    }
+
+    /// Materialize the iteration keys for a SINGLE-loop-variable `foreach`
+    /// (the UVM phase `foreach (siblings[sib]) …` shape, and ordinary 1-D
+    /// fixed/dynamic/assoc arrays). Returns `(keys, is_str, var_scope)` on
+    /// success — `var_scope` is the array's instance prefix for aliased loop
+    /// vars (submodule foreach). Returns `None` for multi-variable or
+    /// unhandled shapes (caller falls back to the synchronous path).
+    fn foreach_materialize_keys_1d(
+        &mut self,
+        array: &Expression,
+        vars: &[Option<crate::ast::Identifier>],
+    ) -> Option<(Vec<String>, bool, Option<String>, Option<String>)> {
+        if vars.len() != 1 {
+            return None;
+        }
+        // Class-member / collection associative array resolved via
+        // expr_assoc_name (handles `obj.assoc_member[k]`, array-element bases,
+        // etc.) — the UVM phase-siblings case.
+        if let Some(an) = self.expr_assoc_name(array) {
+            let (keys, is_str) = self.array_iter_keys(&an);
+            // A `.size`-shadowed collection (queue/dynamic) may shrink mid-
+            // loop; use live-size bounds for it.
+            let live = if self.signals.contains_key(&format!("{}.size", an)) {
+                Some(an)
+            } else {
+                None
+            };
+            return Some((keys, is_str, None, live));
+        }
+        // Direct named array (fixed / dynamic / assoc array or queue).
+        if let ExprKind::Ident(hier) = &array.kind {
+            let mut name = self.resolve_hier_name(hier);
+            if let Some(scoped) = self.instance_assoc_member(&name) {
+                name = scoped;
+            }
+            // A bare array name inside a SUBMODULE process resolves under the
+            // process's instance scope, like the synchronous foreach path.
+            if !self.module.arrays.contains_key(&name)
+                && !self.module.arrays_2d.contains_key(&name)
+                && !self.module.arrays_nd.contains_key(&name)
+                && !self.module.dynamic_arrays.contains(&name)
+                && !self.is_associative_array(&name)
+            {
+                let hint = self.name_resolve_hint.borrow().clone();
+                if let Some(h) = hint {
+                    let scoped = format!("{}.{}", h, name);
+                    if self.module.arrays.contains_key(&scoped)
+                        || self.module.arrays_2d.contains_key(&scoped)
+                        || self.module.arrays_nd.contains_key(&scoped)
+                        || self.module.dynamic_arrays.contains(&scoped)
+                        || self.is_associative_array(&scoped)
+                    {
+                        name = scoped;
+                    }
+                }
+            }
+            let var_scope: Option<String> =
+                name.rsplit_once('.').map(|(p, _)| p.to_string());
+            // Dispatch by storage type, mirroring the synchronous foreach
+            // (exec_statement's Ident arm).
+            if self.is_associative_array(&name) {
+                let (keys, is_str) = self.array_iter_keys(&name);
+                return Some((keys, is_str, var_scope, None));
+            }
+            if self.module.dynamic_arrays.contains(&name) {
+                let size = self.get_queue_size(&name);
+                let keys: Vec<String> = (0..size).map(|i| i.to_string()).collect();
+                return Some((keys, false, var_scope, Some(name)));
+            }
+            if let Some(&(lo, hi, _)) = self.module.arrays.get(&name) {
+                let descending = self.module.descending_arrays.contains(&name);
+                let mut keys: Vec<String> = Vec::new();
+                let mut idx = lo;
+                while idx <= hi {
+                    let v = if descending { hi - (idx - lo) } else { idx };
+                    keys.push(v.to_string());
+                    idx += 1;
+                }
+                return Some((keys, false, var_scope, None));
+            }
+            // Queue / dynamic array surfaced via `.size` shadow only.
+            let (keys, is_str) = self.array_iter_keys(&name);
+            if keys.is_empty() {
+                return None;
+            }
+            return Some((keys, is_str, var_scope, Some(name)));
+        }
+        None
     }
 
     /// Push a fresh queue-local save frame on entry to a subroutine.

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -1035,19 +1035,20 @@ struct EventWaiter {
     /// consulted afterwards — dropped.
     resolved_sensitivities: Vec<SensitivityId>,
     continuation: Vec<Statement>,
-    /// Value of `Simulator::snap_gen` when this waiter registered. A waiter
-    /// only fires on edges detected against a snapshot taken AFTER it
-    /// registered (`registered_snap_gen != snap_gen`). This protects a
-    /// waiter registered mid-tick from the tick's pre-registration edges —
-    /// notably the time-0 init pseudo-edges (prev seeded to X so every
-    /// initialized signal "fires" at the first check_edges) and the
-    /// re-registration of a `forever @(posedge clk)` loop against the edge
-    /// it just consumed. Unlike the old `registered_time == self.time`
-    /// guard, it does NOT suppress edges produced in LATER delta cycles of
-    /// the same timestamp (an inactive-region `#0 clk = 1;` toggle must
-    /// wake an `@(posedge clk)` waiter registered earlier at that time —
-    /// IEEE 1800-2023 §4.4.2.3, matching Icarus/commercial simulators).
-    registered_snap_gen: u64,
+    /// Each sensitivity signal's value captured AT registration time
+    /// (`raw_bits()` for the ≤64-bit fast path). The waiter fires when the
+    /// signal changes relative to this captured baseline — NOT the global
+    /// per-tick `prev_val` snapshot. This is what makes `nba <= v; @(nba)`
+    /// (UVM's `uvm_wait_for_nba_region`) work: the NBA commits to the new
+    /// value AFTER registration in the same tick, and the waiter must wake
+    /// for that change. It also subsumes the old `snap_gen` guard: a
+    /// `forever @(posedge clk)` re-registered just after consuming a
+    /// posedge captures clk's now-high value, so the consumed edge cannot
+    /// re-fire (IEEE 1800-2023 §9.4.2.3).
+    captured_prev: Vec<(u64, u64)>,
+    /// Full captured value for >64-bit sensitivity signals (parallel to
+    /// `captured_prev`); `None` for ≤64-bit signals.
+    captured_prev_wide: Vec<Option<Value>>,
 }
 
 /// Pad a string to a given width with spaces (or zeros if zero_pad).
@@ -2156,6 +2157,16 @@ pub struct Simulator {
     uvm_components: Vec<usize>,
     /// Set once the post-run phases have executed so they run exactly once.
     uvm_post_run_done: bool,
+    /// True once extract/check/report/final (+ report_summarize) have run,
+    /// whether by the genuine UVM library (PURE_SV_LRM, via `$finish`) or by
+    /// the shim. Prevents double-firing these stateful callbacks.
+    uvm_cleanup_done: bool,
+    /// Set when the genuine UVM library (PURE_SV_LRM) calls `$finish`, meaning
+    /// its own phase schedule ran the cleanup phases and report_summarize. The
+    /// shim's `end_run_phase` backstop checks this to avoid double-firing
+    /// extract/check/report/final, and the event-loop-exit backstop uses it to
+    /// decide whether cleanup still needs to run for objection-free tests.
+    genuine_uvm_finished: bool,
     /// UVM report-server tallies for the `--- UVM Report Summary ---` block
     /// emitted at end_run_phase: counts by severity [INFO, WARNING, ERROR,
     /// FATAL] and by message id (sorted). Populated at the report choke point.
@@ -2220,6 +2231,11 @@ pub struct Simulator {
     /// declared in `base_class` (so unrelated/inherited statics stay shared),
     /// giving each specialization its own cell (§8.25). None = shared cell.
     current_spec: Option<(String, String)>,
+    /// Tracks class names currently being constructed via the `type_id::create()`
+    /// PURE-mode shortcut, to prevent infinite recursion when a parameterized
+    /// class's constructor or static initializers re-enter `type_id::create()`
+    /// for the same class.
+    type_id_create_in_progress: HashSet<String>,
     /// Tracks which `(base, sig)` specializations have already had their
     /// static-call initializers run. Per §8.25/§6.21, each parameterized-class
     /// specialization has its own set of static properties, and side-effecting
@@ -4360,6 +4376,8 @@ impl Simulator {
             tb_cache: std::cell::RefCell::new(HashMap::default()),
             uvm_components: Vec::new(),
             uvm_post_run_done: false,
+            uvm_cleanup_done: false,
+            genuine_uvm_finished: false,
             uvm_sev_counts: [0; 4],
             uvm_id_counts: std::collections::BTreeMap::new(),
             tlm_connections: HashMap::default(),
@@ -4370,6 +4388,7 @@ impl Simulator {
             rand_ranges: HashMap::default(),
             class_statics: HashMap::default(),
             current_spec: None,
+            type_id_create_in_progress: HashSet::default(),
             initialized_spec_statics: std::collections::HashSet::default(),
             pending_spec_inits: Vec::new(),
             spec_init_depth: 0,
@@ -15351,11 +15370,30 @@ impl Simulator {
             .collect();
         // `sens` (Vec<Sensitivity>) is consumed for resolution and dropped;
         // EventWaiter only carries the resolved IDs from here on.
+        //
+        // Capture each sensitivity signal's current value at registration
+        // so the waiter fires on a change relative to THIS point (see the
+        // `captured_prev` field doc for the NBA reasoning).
+        let captured_prev: Vec<(u64, u64)> = resolved
+            .iter()
+            .map(|s| self.signal_table[s.signal_id].raw_bits())
+            .collect();
+        let captured_prev_wide: Vec<Option<Value>> = resolved
+            .iter()
+            .map(|s| {
+                if self.signal_widths[s.signal_id] > 64 {
+                    Some(self.signal_table[s.signal_id].clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
         EventWaiter {
             pid,
             resolved_sensitivities: resolved,
             continuation,
-            registered_snap_gen: self.snap_gen,
+            captured_prev,
+            captured_prev_wide,
         }
     }
 
@@ -16439,11 +16477,32 @@ impl Simulator {
             if let Some(b) = tick_barrier {
                 b.wait();
             }
+            // UVM phasing and objection handshakes legitimately spend many
+            // delta cycles at one timestamp: every `wait_for_waiters` does
+            // `#0`, and each `wait_for_state(DONE)` resume advances
+            // `cond_progress`. The zero-delay stall detector exists to catch
+            // livelocks (a process re-arming forever with nothing changing),
+            // NOT finite delta-dense settling. So only count an iteration
+            // toward `stall_iters` when the tick made NO wait-driven progress:
+            // reset the counter whenever `cond_progress` advanced. (The
+            // per-process `stall_pid_hits` detector still catches a single
+            // spinning process; `drain_edge_cascade`'s `cascade_limit` still
+            // catches NBA feedback loops.)
+            let cond_prog_before = self.cond_progress;
             self.run_one_tick(&mut accum, cascade_limit, iters, trace_loop);
+            if self.cond_progress != cond_prog_before {
+                self.stall_iters = 0;
+            }
             if let Some(b) = tick_barrier {
                 b.wait();
             }
             // UVM objection-driven run-phase end (after the drain elapses).
+            // In PURE_SV_LRM the genuine library normally completes via
+            // `$finish`; end_run_phase checks genuine_uvm_finished to avoid
+            // double-firing cleanup. It still must run for tests whose
+            // run_phase forever-loops aren't killed by m_phase_proc.kill()
+            // (not yet wired) — objections dropping is the only termination
+            // signal, so keep driving it.
             self.maybe_end_run_phase();
             // Periodic invariant check — every 1000 iters; bail on
             // mismatch to surface bugs early.
@@ -16458,6 +16517,17 @@ impl Simulator {
                     break;
                 }
             }
+        }
+        // PURE_SV_LRM backstop: tests with NO run-phase objections (e.g.
+        // 00hello) never trigger the objection-driven `end_run_phase`, and the
+        // genuine schedule's terminal propagation (uvm.uvm_end -> DONE) is not
+        // yet wired, so their genuine extract/check/report/final never fire.
+        // If we drained the event loop without the genuine library reaching
+        // `$finish` and without cleanup having run, run it now so the test
+        // gets its report_phase / PASSED output. run_uvm_cleanup_phases is
+        // idempotent, and genuine_uvm_finished gates the double-fire.
+        if self.pure_sv_lrm && !self.genuine_uvm_finished {
+            self.run_uvm_cleanup_phases();
         }
         if verify_inline_bits && !self.signal_inline_bits.is_empty() {
             let mismatches = self.verify_inline_bits_invariant(iters);
@@ -18372,6 +18442,78 @@ impl Simulator {
                 }
             }
 
+            // Suspend-aware Case (mirror of the If handler above). An inlined
+            // task body that is a `case` (e.g. UVM's `uvm_phase::wait_for_state`,
+            // `case(op) wait(...); endcase`) must select its arm HERE — falling
+            // through to `exec_statement(Case)` would run the matched arm's
+            // `wait` on the SYNCHRONOUS path, where a false condition with no
+            // foreach parking continuation silently falls through instead of
+            // blocking (IEEE 1800-2023 §9.7.4). Evaluate the selector ONCE
+            // (side-effect conditions must not double-fire), pick the first
+            // matching item or the default, and if the chosen arm blocks,
+            // flatten its body and recurse so its waits reach the suspend-aware
+            // Wait arm.
+            if let StatementKind::Case {
+                kind,
+                expr,
+                items,
+                unique_priority: _,
+            } = &stmt.kind
+            {
+                // Pattern case (`case(x) matches p: ...`) binds variables;
+                // delegate to the synchronous path which performs the bindings.
+                if !items.iter().any(|i| i.pattern.is_some()) {
+                    let val = self.eval_expr(expr);
+                    let chosen: Option<&Statement> = items.iter().find_map(|item| {
+                        if item.is_default {
+                            return None;
+                        }
+                        for pat in &item.patterns {
+                            let hit = match kind {
+                                CaseKind::CaseInside => self.case_inside_match(&val, pat),
+                                CaseKind::Casez => {
+                                    let pv = self.eval_expr(pat);
+                                    val.casez_eq(&pv).is_true()
+                                }
+                                CaseKind::Casex => {
+                                    let pv = self.eval_expr(pat);
+                                    val.casex_eq(&pv).is_true()
+                                }
+                                _ => {
+                                    let pv = self.eval_expr(pat);
+                                    val.case_eq(&pv).is_true()
+                                }
+                            };
+                            if hit {
+                                return Some(&item.stmt);
+                            }
+                        }
+                        None
+                    }).or_else(|| {
+                        items
+                            .iter()
+                            .find(|item| item.is_default)
+                            .map(|item| &item.stmt)
+                    });
+                    match chosen {
+                        Some(arm) if self.stmt_is_blocking(arm) => {
+                            let arm_stmts: Vec<Statement> = match &arm.kind {
+                                StatementKind::SeqBlock { stmts, .. } => stmts.clone(),
+                                _ => vec![arm.clone()],
+                            };
+                            let mut cont = arm_stmts;
+                            cont.extend_from_slice(&stmts[i + 1..]);
+                            self.run_process_stmts(pid, &cont);
+                            return;
+                        }
+                        Some(arm) => self.exec_statement(arm),
+                        None => {}
+                    }
+                    i += 1;
+                    continue;
+                }
+            }
+
             // A `for` loop with a blocking body (e.g. a UVM sequence's
             // `for (i=0; i<n; i++) `uvm_do(req)`) must iterate via the
             // suspend-aware path — otherwise the synchronous exec runs the
@@ -19710,9 +19852,31 @@ impl Simulator {
     /// Check edge: compare signal_table[id] vs (prev_val[id], prev_xz[id]).
     #[inline]
     fn check_edge_id(&self, id: usize, edge: EdgeKind) -> bool {
+        self.edge_fires_prev(
+            id,
+            edge,
+            self.prev_val[id],
+            self.prev_xz[id],
+            self.prev_wide.get(&id),
+        )
+    }
+
+    /// Edge comparison against an EXPLICIT prev baseline (rather than the
+    /// global `prev_val`/`prev_xz` snapshot). Used by event_waiters, which
+    /// capture each sensitivity's value at registration so they fire on a
+    /// change relative to that point — critical for `nba <= v; @(nba)`
+    /// (UVM's uvm_wait_for_nba_region), where the NBA commits to the new
+    /// value AFTER registration in the same tick and the waiter must wake
+    /// (IEEE 1800-2023 §4.10, §9.4.2.3).
+    fn edge_fires_prev(
+        &self,
+        id: usize,
+        edge: EdgeKind,
+        prev_v: u64,
+        prev_x: u64,
+        prev_wide: Option<&Value>,
+    ) -> bool {
         let (cur_v, cur_x) = self.signal_table[id].raw_bits();
-        let prev_v = self.prev_val[id];
-        let prev_x = self.prev_xz[id];
         // LogicBit at bit 0: One iff v&1==1 && x&1==0; Zero iff v&1==0 && x&1==0.
         let cb_one = (cur_v & 1) == 1 && (cur_x & 1) == 0;
         let cb_zero = (cur_v & 1) == 0 && (cur_x & 1) == 0;
@@ -19723,7 +19887,7 @@ impl Simulator {
             EdgeKind::Negedge => !pb_zero && cb_zero,
             EdgeKind::AnyEdge => {
                 if self.signal_widths[id] > 64 {
-                    if let Some(p) = self.prev_wide.get(&id) {
+                    if let Some(p) = prev_wide {
                         return self.signal_table[id] != *p;
                     }
                 }
@@ -20969,21 +21133,11 @@ impl Simulator {
         self.event_waiters_swap.clear();
         let mut triggered_conts: Vec<(usize, Vec<Statement>)> = Vec::new();
         for waiter in waiters {
-            // Skip waiters registered since the last snapshot: the prev
-            // values their edges would be checked against were captured
-            // BEFORE they registered, so a detected "edge" may predate the
-            // registration (time-0 init pseudo-edges, a forever-@ loop
-            // re-registering against the edge it just consumed). Waiters
-            // registered in an EARLIER delta cycle of this same timestamp
-            // stay eligible — an inactive-region (`#0`) toggle or an NBA
-            // commit at the current time must wake them (§4.4.2.3/§4.4.5).
-            if waiter.registered_snap_gen == self.snap_gen {
-                self.event_waiters_swap.push(waiter);
-                continue;
-            }
             let mut triggered = false;
-            for sid in &waiter.resolved_sensitivities {
-                if !self.check_edge_id(sid.signal_id, sid.edge) {
+            for (i, sid) in waiter.resolved_sensitivities.iter().enumerate() {
+                let (pv, px) = waiter.captured_prev[i];
+                let pw = waiter.captured_prev_wide[i].as_ref();
+                if !self.edge_fires_prev(sid.signal_id, sid.edge, pv, px, pw) {
                     continue;
                 }
                 // LRM §9.4.2.3: `@(posedge clk iff g)` only fires when the
@@ -33227,6 +33381,13 @@ impl Simulator {
                     let bt = std::backtrace::Backtrace::force_capture();
                     eprintln!("[xezim][trace] {} called at sim_time={}\n{}",
                               name, self.time, bt);
+                }
+                // PURE_SV_LRM: the genuine UVM library reached `$finish`, so its
+                // phase schedule ran the cleanup phases + report_summarize. Mark
+                // it so the shim's objection-driven end_run_phase backstop does
+                // NOT re-fire them (double-exec would break stateful callbacks).
+                if self.pure_sv_lrm {
+                    self.genuine_uvm_finished = true;
                 }
                 self.finished = true;
             }
@@ -47324,8 +47485,27 @@ impl Simulator {
         {
             if name.name.name.contains("registry") {
                 if let Some(first) = type_args.first() {
-                    if let ExprKind::Ident(hier) = &first.kind {
-                        let leaf = hier.path.last().unwrap().name.name.clone();
+                    // The first type arg is the registered class. It can be:
+                    //   1. A plain `Ident` (non-parameterized class): my_comp
+                    //   2. A `Specialization` (parameterized class): C#(T)
+                    //      — e.g. `uvm_resource_db_default_implementation_t#(T)`
+                    //        whose `type_id` typedef is
+                    //        `uvm_object_registry#(uvm_resource_db_default_implementation_t#(T), "...")`
+                    // Extract the leaf class name from whichever form.
+                    let leaf_opt = match &first.kind {
+                        ExprKind::Ident(hier) => {
+                            Some(hier.path.last().unwrap().name.name.clone())
+                        }
+                        ExprKind::Specialization { base, .. } => {
+                            if let ExprKind::Ident(hier) = &base.kind {
+                                Some(hier.path.last().unwrap().name.name.clone())
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    };
+                    if let Some(leaf) = leaf_opt {
                         // The registered type is often a class-local typedef
                         // alias, not the class itself — e.g. UVM's
                         // `uvm_sequencer` declares
@@ -48294,13 +48474,24 @@ impl Simulator {
                     if inner_member.name.as_str() == "type_id" {
                         if let ExprKind::Ident(hier) = &inner_expr.kind {
                             let class_name = hier.path[0].name.name.clone();
-                            if let Some(target) =
-                                self.resolve_type_id_target_class(&class_name)
-                            {
-                                if let Some(class_def) =
-                                    self.module.classes.get(&target).cloned()
+                            // Guard against infinite recursion: a parameterized
+                            // uvm_component's constructor (or its static/property
+                            // initializers) may re-enter `type_id::create()` for
+                            // the same class during construction. If we're already
+                            // constructing this class via the shortcut, fall
+                            // through to the factory bridge instead.
+                            if !self.type_id_create_in_progress.contains(&class_name) {
+                                if let Some(target) =
+                                    self.resolve_type_id_target_class(&class_name)
                                 {
-                                    return self.instantiate_class(&class_def, args);
+                                    if let Some(class_def) =
+                                        self.module.classes.get(&target).cloned()
+                                    {
+                                        self.type_id_create_in_progress.insert(class_name.clone());
+                                        let r = self.instantiate_class(&class_def, args);
+                                        self.type_id_create_in_progress.remove(&class_name);
+                                        return r;
+                                    }
                                 }
                             }
                             // `typedef uvm_sequencer#(item) sqr_t; sqr_t::type_id::
@@ -51554,6 +51745,19 @@ impl Simulator {
                         .unwrap_or(concrete);
                     instance.type_bindings.insert(tp_name.clone(), resolved);
                 }
+            } else if let Some((b, _)) = &self.current_spec {
+                // No explicit type_args carried this param, but the active
+                // specialization (`current_spec`) targets THIS class —
+                // resolve the type param from it. This covers
+                // `C#(int)::type_id::create()` where the factory intercept
+                // constructs `C` without forwarding the `#(int)` args: the
+                // outer `eval_call` already set `current_spec = (C, "int")`,
+                // so `resolve_type_param_binding("T")` yields `int`.
+                if *b == class_def.name {
+                    if let Some(resolved) = self.resolve_type_param_binding(tp_name) {
+                        instance.type_bindings.insert(tp_name.clone(), resolved);
+                    }
+                }
             }
         }
         // Capture the active specialization on the instance when it targets
@@ -52391,20 +52595,22 @@ impl Simulator {
         }
     }
 
-    /// Triggered when the run-phase objection count returns to 0 (after a
-    /// raise) and the drain has elapsed.
-    fn end_run_phase(&mut self) {
-        if self.uvm_post_run_done {
+    /// Run the post-run function phases (extract/check/report/final) across
+    /// all live uvm_components, then emit the UVM Report Summary. Mirrors what
+    /// `uvm_root::run_test` does after the run domain ends. Idempotent via
+    /// `uvm_cleanup_done`.
+    fn run_uvm_cleanup_phases(&mut self) {
+        if self.uvm_cleanup_done {
             return;
         }
-        self.uvm_post_run_done = true;
+        self.uvm_cleanup_done = true;
         let mut comps = self.uvm_components.clone();
         if comps.is_empty() {
-            // PURE_SV_LRM: the real UVM phaser builds components via the factory,
-            // not the route-B bootstrap that fills `uvm_components` — so collect
-            // every live uvm_component from the heap for the post-run phases
-            // (extract/check/report/final). Without this a pure run ended with an
-            // empty summary and no monitor `report_phase` (COLLECTED PACKETS).
+            // PURE_SV_LRM: the real UVM phaser builds components via the
+            // factory, not the route-B bootstrap that fills `uvm_components` —
+            // so collect every live uvm_component from the heap. Without this
+            // a pure run ended with an empty summary and no monitor
+            // `report_phase` (COLLECTED PACKETS).
             for i in 1..self.heap.len() {
                 if let Some(cn) = self
                     .heap
@@ -52436,8 +52642,31 @@ impl Simulator {
             }
         }
         // uvm_root::run_test calls report_server.report_summarize() after the
-        // report phase — emit the summary block before $finish.
+        // report phase — emit the summary block.
         self.emit_uvm_report_summary();
+    }
+
+    /// Triggered when the run-phase objection count returns to 0 (after a
+    /// raise) and the drain has elapsed. In PURE_SV_LRM this only TERMINATES
+    /// the sim (sets `finished`); it never runs the cleanup phases itself —
+    /// those are run either by the genuine UVM library (which calls `$finish`
+    /// after its own extract/check/report/final) or by the event-loop-exit
+    /// backstop (for objection-free tests whose genuine schedule deadlocks).
+    /// Centralising termination here lets the `genuine_uvm_finished` flag
+    /// prevent double-firing regardless of the tick-level race between
+    /// objection-drop and genuine `$finish`.
+    fn end_run_phase(&mut self) {
+        if self.uvm_post_run_done {
+            return;
+        }
+        self.uvm_post_run_done = true;
+        if self.pure_sv_lrm {
+            // Legacy shim mode is the only path that runs cleanup here. In
+            // pure mode the genuine library + exit backstop own cleanup.
+            self.finished = true;
+            return;
+        }
+        self.run_uvm_cleanup_phases();
         self.finished = true;
     }
 

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -30653,6 +30653,7 @@ impl Simulator {
                             }
                             self.auto_loop_vars.truncate(fe_auto_len);
                             self.restore_loop_vars(&fe_saved);
+                            if !self.return_flag { self.break_flag = false; }
                             return;
                         }
                         // Multi-var foreach over a FIXED multi-dim class member
@@ -30698,12 +30699,22 @@ impl Simulator {
                                 is_str = false;
                             } else {
                                 let prefix = format!("{}[", an);
+                                // An assoc-of-collections member (e.g.
+                                // `bq_t all[int]`) stores elements as
+                                // `all[5][0]` etc. — extract the key up to
+                                // the FIRST `]` and dedup so multiple
+                                // sub-elements don't each produce a phantom key.
                                 let mut ks: Vec<String> = self
                                     .signals
                                     .keys()
-                                    .filter(|k| k.starts_with(&prefix) && k.ends_with(']'))
-                                    .map(|k| k[prefix.len()..k.len() - 1].to_string())
+                                    .filter_map(|k| {
+                                        let rest = k.strip_prefix(&prefix)?;
+                                        let end = rest.find(']')?;
+                                        Some(rest[..end].to_string())
+                                    })
                                     .collect();
+                                ks.sort();
+                                ks.dedup();
                                 is_str = self
                                     .module
                                     .associative_arrays
@@ -30746,6 +30757,10 @@ impl Simulator {
                         }
                         self.auto_loop_vars.truncate(fe_auto_len);
                         self.restore_loop_vars(&fe_saved);
+                        // A `break` inside the loop consumed the loop exit.
+                        // Only a `return` (return_flag) should propagate to
+                        // the enclosing function body (IEEE 1800-2023 §12.8).
+                        if !self.return_flag { self.break_flag = false; }
                         return;
                     }
                 }
@@ -30824,6 +30839,7 @@ impl Simulator {
                                 );
                                 self.auto_loop_vars.truncate(fe_auto_len);
                                 self.restore_loop_vars(&fe_saved);
+                                if !self.return_flag { self.break_flag = false; }
                                 return;
                             }
                         }
@@ -30832,12 +30848,22 @@ impl Simulator {
                         self.widths.insert(var.name.clone(), 32);
                         if self.is_associative_array(&name) {
                             let prefix = format!("{}[", name);
+                            // An assoc-of-collections (e.g. `bq_t all[int]`
+                            // where `bq_t = Base[$]`) stores elements as
+                            // `all[5][0]` etc. — extract the key up to the
+                            // FIRST `]` and dedup so multiple sub-elements
+                            // don't each produce a phantom key.
                             let mut keys: Vec<String> = self
                                 .signals
                                 .keys()
-                                .filter(|k| k.starts_with(&prefix) && k.ends_with(']'))
-                                .map(|k| k[prefix.len()..k.len() - 1].to_string())
+                                .filter_map(|k| {
+                                    let rest = k.strip_prefix(&prefix)?;
+                                    let end = rest.find(']')?;
+                                    Some(rest[..end].to_string())
+                                })
                                 .collect();
+                            keys.sort();
+                            keys.dedup();
                             let is_str = self
                                 .module
                                 .associative_arrays
@@ -30952,6 +30978,7 @@ impl Simulator {
                 }
                 self.auto_loop_vars.truncate(fe_auto_len);
                 self.restore_loop_vars(&fe_saved);
+                if !self.return_flag { self.break_flag = false; }
             }
             StatementKind::While { condition, body } => {
                 let loop_limit: u64 = std::env::var("XEZIM_LOOP_LIMIT")
@@ -32349,6 +32376,23 @@ impl Simulator {
                             {
                                 self.var_class_types
                                     .insert(d.name.name.clone(), cn.clone());
+                                // A typedef'd local (e.g. `table_q_t rq` where
+                                // `table_q_t = uvm_shared#(Foo[$])`) resolves to
+                                // `cn` but hides the type_args inside the
+                                // typedef chain. Record them so a separate
+                                // `rq = new()` constructs the right
+                                // specialization with type_bindings populated
+                                // (§8.25 — otherwise `T` stays unbound).
+                                if let crate::ast::types::DataType::TypeReference { name, .. } =
+                                    data_type
+                                {
+                                    if let Some((_, Some(ta))) =
+                                        self.resolve_typeref_class_with_type_args(name)
+                                    {
+                                        self.var_type_args
+                                            .insert(d.name.name.clone(), ta);
+                                    }
+                                }
                             } else if self.pure_sv_lrm
                                 && self
                                     .this_stack
@@ -32374,7 +32418,20 @@ impl Simulator {
                         // Record a parameterized local's declared `#(...)` type
                         // args so a SEPARATE `name = new(...)` constructs the right
                         // specialization (config_db's `uvm_resource#(T) r; r=new`).
+                        // A typedef'd local (e.g. `table_q_t rq` where `table_q_t =
+                        // uvm_shared#(Foo[$])`) has EMPTY explicit type_args but
+                        // the args are hidden in the typedef chain — resolve
+                        // them so the new() populates type_bindings (§8.25).
                         // Clear a stale same-named entry when this decl has none.
+                        let resolved_ta =
+                            if let crate::ast::types::DataType::TypeReference { name, .. } =
+                                data_type
+                            {
+                                self.resolve_typeref_class_with_type_args(name)
+                                    .and_then(|(_, ta)| ta)
+                            } else {
+                                None
+                            };
                         if let crate::ast::types::DataType::TypeReference {
                             type_args,
                             ..
@@ -32383,6 +32440,9 @@ impl Simulator {
                             if !type_args.is_empty() {
                                 self.var_type_args
                                     .insert(d.name.name.clone(), type_args.clone());
+                            } else if let Some(ta) = resolved_ta {
+                                self.var_type_args
+                                    .insert(d.name.name.clone(), ta);
                             } else {
                                 self.var_type_args.remove(&d.name.name);
                             }
@@ -38888,6 +38948,66 @@ impl Simulator {
         }
     }
 
+    /// Like `resolve_typeref_class_name`, but also returns the parameterized
+    /// type args from the typedef chain. A typedef like `table_q_t =
+    /// uvm_shared#(rsrc_sv_q_t)` (possibly through multiple alias layers)
+    /// resolves to `("uvm_shared", Some([rsrc_sv_q_t]))`. This lets a
+    /// typedef'd local `table_q_t rq` carry the type args forward to `rq =
+    /// new()` so the instance's type_bindings are populated — otherwise `T`
+    /// stays unbound and collection builtins can't see a queue/array member.
+    fn resolve_typeref_class_with_type_args(
+        &self,
+        tref: &crate::ast::types::TypeName,
+    ) -> Option<(String, Option<Vec<Expression>>)> {
+        use crate::ast::types::DataType;
+        let base_class = |s: &str| -> Option<String> {
+            if self.module.classes.contains_key(s) {
+                return Some(s.to_string());
+            }
+            let b = s.split('#').next().unwrap_or(s);
+            if b != s && self.module.classes.contains_key(b) {
+                return Some(b.to_string());
+            }
+            None
+        };
+        let nm = &tref.name.name;
+        // Direct class match (possibly parameterized) — extract type_args.
+        if let Some(c) = base_class(nm) {
+            let ta = match self.module.typedef_types.get(nm)
+                .or_else(|| self.module.typedef_types.get(nm))
+            {
+                Some(DataType::TypeReference { type_args, .. }) if !type_args.is_empty() =>
+                    Some(type_args.clone()),
+                _ => None,
+            };
+            return Some((c, ta));
+        }
+        // Walk the typedef chain, tracking type_args from the deepest layer
+        // that has them. `table_q_t` → `rsrc_shared_q_t` → `uvm_shared#(...)`.
+        let mut cur_name = nm.clone();
+        let mut found_ta: Option<Vec<Expression>> = None;
+        for _ in 0..16 {
+            let target = self.lookup_typedef_target(&cur_name);
+            let dt = match target {
+                Some(dt) => dt,
+                None => break,
+            };
+            match dt {
+                DataType::TypeReference { name: inner, type_args, .. } => {
+                    if !type_args.is_empty() {
+                        found_ta = Some(type_args.clone());
+                    }
+                    if let Some(c) = base_class(&inner.name.name) {
+                        return Some((c, found_ta));
+                    }
+                    cur_name = inner.name.name.clone();
+                }
+                _ => break,
+            }
+        }
+        None
+    }
+
     /// True if a TypeReference data type names a class handle (directly, via a
     /// parameterized base, or through a typedef chain). Defaults such an
     /// uninitialized handle to `null` (LRM §8.4) instead of X.
@@ -39827,12 +39947,22 @@ impl Simulator {
             return ((0..sz).map(|i| i.to_string()).collect(), false);
         }
         let prefix = format!("{}[", name);
+        // For an associative array whose VALUES are themselves collections
+        // (e.g. `bq_t all[int]` where `bq_t = Base[$]`), an element at key 5
+        // is stored as `all[5][0]`, `all[5][1]`, etc. The key must be
+        // extracted up to the FIRST `]`, not `k.len()-1` (which would grab
+        // `5][0`). Dedup because multiple sub-elements share one key.
         let mut ks: Vec<String> = self
             .signals
             .keys()
-            .filter(|k| k.starts_with(&prefix) && k.ends_with(']'))
-            .map(|k| k[prefix.len()..k.len() - 1].to_string())
+            .filter_map(|k| {
+                let rest = k.strip_prefix(&prefix)?;
+                let end = rest.find(']')?;
+                Some(rest[..end].to_string())
+            })
             .collect();
+        ks.sort();
+        ks.dedup();
         let is_str = self
             .module
             .associative_arrays
@@ -46527,23 +46657,37 @@ impl Simulator {
         // A type-param binding resolves first; otherwise the raw name may
         // itself be an array/queue typedef (`my_array_t data;` — the class
         // property elaboration is dim-blind for typedef'd types).
+        let raw_dbg = raw.clone();
         let concrete = self
             .heap
             .get(handle)
             .and_then(|o| o.as_ref())
             .and_then(|i| i.type_bindings.get(&raw).cloned())
             .unwrap_or(raw);
-        self.module
-            .typedef_unpacked_dims
-            .get(&concrete)
-            .and_then(|dims| dims.first())
-            .map_or(false, |d| {
+        // A typedef name may itself be a class-LOCAL typedef (e.g. UVM's
+        // `uvm_resource_types::rsrc_sv_q_t` = `uvm_resource_base[$]`), which
+        // lives in the declaring class's `typedef_unpacked_dims`, NOT the
+        // module-level map. Search BOTH: module-level first (package
+        // typedefs), then every class's local typedefs for a matching name
+        // with an unsized/queue first dimension.
+        let is_collection_dim = |dims: &Vec<crate::ast::types::UnpackedDimension>| {
+            dims.first().map_or(false, |d| {
                 matches!(
                     d,
                     crate::ast::types::UnpackedDimension::Unsized(_)
                         | crate::ast::types::UnpackedDimension::Queue { .. }
                 )
             })
+        };
+        if let Some(dims) = self.module.typedef_unpacked_dims.get(&concrete) {
+            return is_collection_dim(dims);
+        }
+        for cd in self.module.classes.values() {
+            if let Some(dims) = cd.typedef_unpacked_dims.get(&concrete) {
+                return is_collection_dim(dims);
+            }
+        }
+        false
     }
 
     fn class_assoc_member(&self, class_name: &str, member: &str) -> bool {
@@ -47632,7 +47776,8 @@ impl Simulator {
                 )
             {
                 if let Some(an) = self.expr_assoc_name(expr) {
-                    if let Some(res) = self.eval_builtin_method(&an, mname, args) {
+                    let res = self.eval_builtin_method(&an, mname, args);
+                    if let Some(res) = res {
                         return res;
                     }
                 }
@@ -48348,7 +48493,20 @@ impl Simulator {
             // `member.num()` resolves via `instance_assoc_member`; this is the
             // external counterpart UVM's phase graph depends on
             // (`domain.m_successors.num()`, `phase.m_predecessors.exists(p)`).
-            if len >= 2 && Self::is_array_builtin_method(path[len - 1].name.name.as_str()) {
+            // Also covers queue MUTATION builtins (`o.q.push_back(x)` etc.)
+            // because the parser flattens `o.q.push_back(x)` into the same
+            // 3-segment Ident shape — without this, `sh.value.push_back(x)` on
+            // a `uvm_shared#(T[$])` member silently no-ops and the resource
+            // pool's per-name queues stay empty.
+            if len >= 2
+                && (Self::is_array_builtin_method(path[len - 1].name.name.as_str())
+                    || matches!(
+                        path[len - 1].name.name.as_str(),
+                        "push_back" | "push_front" | "pop_back" | "pop_front"
+                            | "insert" | "delete" | "sort" | "rsort"
+                            | "reverse" | "shuffle" | "unique"
+                    ))
+            {
                 let m = path[len - 1].name.name.clone();
                 let base = HierarchicalIdentifier {
                     root: hier.root.clone(),

--- a/src/should_fail_lint.rs
+++ b/src/should_fail_lint.rs
@@ -86,6 +86,7 @@ pub fn lint_should_fail(defs: &[&SourceDefinition], elab: &ElaboratedModule) -> 
                     }
                 }
             }
+            SourceDefinition::Udp(_) => {}
         }
     }
     errs

--- a/tests/array_element_collection.rs
+++ b/tests/array_element_collection.rs
@@ -1,0 +1,127 @@
+// Regression tests for instance-collection (associative array / queue /
+// dynamic array) properties reached through an ARRAY-ELEMENT base —
+// `arr[i].coll_field` and `foreach (arr[i].coll_field[k])`.
+//
+// Root cause: xezim stored instance collection properties as signals
+// `<handle>#field[key]` (NOT in the heap object's `properties` map), and
+// `expr_assoc_name` only resolved the collection for a bare `Ident`/`this`
+// base. An array-element base (`arr[i]`, flattened by the parser to a
+// 2-segment `Ident([arr[selects=[i]], field])`, or a `MemberAccess{Index}`)
+// fell through, so:
+//   - `arr[i].aa.num()` returned 0,
+//   - `foreach (arr[i].aa[k])` iterated the WRONG object's collection
+//     (`this.aa` instead of `arr[i].aa`).
+//
+// This silently corrupted any graph stored as `obj[]` of handles each
+// carrying assoc-array edges — most notably UVM's phase graph, where
+// `foreach (successors[s].m_predecessors[pred])` iterated `this`'s
+// (the caller's) predecessors instead of `successors[s]`'s, so the phase
+// sibling graph read the wrong object's edges and `common.run` ended
+// without waiting for the runtime phase schedule.
+//
+// Verified against the standalone semantics (handle-keyed AA stored under
+// `<handle>#field`, distinct per instance).
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("xezim_arrcoll_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{tag}.sv"));
+    std::fs::write(&path, src).unwrap();
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+// `arr[i].aa.num()` and `foreach (arr[i].aa[k])` must resolve to the
+// i-th element's collection, not `this`'s. Each element gets distinct keys.
+#[test]
+fn array_element_assoc_num_and_foreach() {
+    let src = r#"class C; int id; function new(int i); id=i; endfunction endclass
+typedef bit edges_t[C];
+class Node;
+  string name; edges_t m_preds;
+  function new(string n); name=n; endfunction
+  function void addp(C k); m_preds[k]=1; endfunction
+endclass
+module top;
+  initial begin
+    Node arr[] = new[2];
+    Node a=new("a"), b=new("b");
+    C k1=new(101), k2=new(202), k3=new(303);
+    arr[0]=a; arr[1]=b;
+    arr[0].addp(k1); arr[0].addp(k2);   // a.m_preds = {k1,k2}
+    arr[1].addp(k3);                      // b.m_preds = {k3}
+    // .num() via array-element base
+    if (arr[0].m_preds.num() != 2) $display("FAIL a.num=%0d", arr[0].m_preds.num());
+    else if (arr[1].m_preds.num() != 1) $display("FAIL b.num=%0d", arr[1].m_preds.num());
+    else begin
+      // foreach via array-element base (UVM phase-graph pattern)
+      foreach (arr[i]) begin
+        foreach (arr[i].m_preds[p])
+          $display("elem %s key id=%0d", arr[i].name, p.id);
+      end
+      $display("PASS array-element-assoc");
+    end
+  end
+endmodule
+"#;
+    let out = run(src, "arr_assoc");
+    assert!(
+        out.contains("PASS array-element-assoc") && !out.contains("FAIL"),
+        "array-element assoc resolution failed.\n{out}"
+    );
+    // Each element's keys must be distinct and correct.
+    assert!(out.contains("elem a key id=101"), "missing a/k1: {out}");
+    assert!(out.contains("elem a key id=202"), "missing a/k2: {out}");
+    assert!(out.contains("elem b key id=303"), "missing b/k3: {out}");
+}
+
+// The UVM phase-graph pattern distilled: a dynamic array of "node" handles,
+// each carrying an assoc-array of edges (predecessor handles). Building the
+// graph via array-element writes, then traversing via array-element foreach
+// must see each node's OWN edges — not the traversing object's.
+#[test]
+fn array_element_graph_traversal() {
+    let src = r#"class C; int id; function new(int i); id=i; endfunction endclass
+typedef bit edges_t[C];
+class Node;
+  int id; edges_t m_succs;
+  function new(int i); id=i; endfunction
+  function void link(Node s); m_succs[s]=1; endfunction
+endclass
+module top;
+  initial begin
+    Node n1=new(1), n2=new(2), n3=new(3), n4=new(4);
+    Node nodes[] = new[4];
+    nodes[0]=n1; nodes[1]=n2; nodes[2]=n3; nodes[3]=n4;
+    // 1->2, 2->3, 3->4  (chain via array-element writes)
+    nodes[0].link(nodes[1]);
+    nodes[1].link(nodes[2]);
+    nodes[2].link(nodes[3]);
+    // traverse: for each node, foreach its successors
+    int total_edges = 0;
+    foreach (nodes[n]) begin
+      foreach (nodes[n].m_succs[s]) begin
+        total_edges++;
+        $display("edge %0d -> %0d", nodes[n].id, s.id);
+      end
+    end
+    if (total_edges == 3) $display("PASS graph-traversal");
+    else $display("FAIL total_edges=%0d (expected 3)", total_edges);
+  end
+endmodule
+"#;
+    let out = run(src, "graph_trav");
+    assert!(
+        out.contains("PASS graph-traversal") && !out.contains("FAIL"),
+        "array-element graph traversal failed.\n{out}"
+    );
+}

--- a/tests/bit_class_property_signedness.rs
+++ b/tests/bit_class_property_signedness.rs
@@ -1,0 +1,73 @@
+//! IEEE 1800-2023 §6.6.1 / §10.7: a `bit`-typed class property is UNSIGNED.
+//! Assigning the integer literal `1` (a 32-bit signed value per §5.7.1) to a
+//! `bit` field must store an UNSIGNED 1-bit `1`, which reads back as `1` —
+//! NOT a signed-1-bit value that reads back as `-1` (0xFFFFFFFF).
+//!
+//! Root cause: `fit_class_prop` called `resize_for_assign(width)` which
+//! preserves the RHS literal's `is_signed=true`. The stored `bit` then had
+//! `is_signed=true`, so reading the set bit as a signed 1-bit value yielded
+//! -1. This broke any cross-process `wait(<bit-member> == 1)` (e.g. UVM's
+//! `uvm_resource::wait_modified` → `wait(modified==1)`) because the waiter
+//! never saw `1`.
+use std::process::Command;
+
+fn xezim() -> String {
+    let base = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/debug/xezim", base)
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/bitfield_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn bit_class_property_is_unsigned() {
+    let src = r#"module top;
+  class R;
+    bit b;
+  endclass
+  R r;
+  initial begin
+    r = new();
+    r.b = 1;
+    if (r.b === 1) $display("RESULT PASS"); else $display("RESULT FAIL b=%0d", r.b);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "unsigned");
+    assert!(out.contains("RESULT PASS"), "expected bit field unsigned\n{out}");
+}
+
+#[test]
+fn cross_process_wait_on_bit_member() {
+    // The bug manifested as a cross-process `wait(modified==1)` that never
+    // woke: the waiter read `modified` as -1 (signed), so `== 1` was false.
+    let src = r#"module top;
+  class R;
+    bit modified;
+    task setm(); modified = 1; endtask
+    task waitm(); wait(modified == 1); endtask
+  endclass
+  R r;
+  int woke;
+  initial begin
+    r = new();
+    fork
+      begin #1; r.setm(); end
+      begin r.waitm(); woke = 1; end
+    join
+    if (woke == 1) $display("RESULT PASS"); else $display("RESULT FAIL woke=%0d", woke);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "xwait");
+    assert!(out.contains("RESULT PASS"), "expected cross-process bit wait to wake\n{out}");
+}

--- a/tests/blocking_loop_break_continue.rs
+++ b/tests/blocking_loop_break_continue.rs
@@ -70,3 +70,48 @@ endmodule
     let out = run(src, "for");
     assert!(out.contains("RESULT PASS"), "expected for-break honoured\n{out}");
 }
+
+#[test]
+fn blocking_repeat_honours_break() {
+    let src = r#"module top;
+  int log[$];
+  initial begin
+    repeat (10) begin
+      #1;                 // blocking
+      if (log.size() == 3) break;
+      log.push_back(log.size());
+    end
+    // log == {0,1,2} — break when size reaches 3
+    if (log.size()==3 && log[0]==0 && log[1]==1 && log[2]==2)
+      $display("RESULT PASS"); else $display("RESULT FAIL log=%p", log);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "repbrk");
+    assert!(out.contains("RESULT PASS"), "expected repeat-break honoured\n{out}");
+}
+
+#[test]
+fn blocking_repeat_honours_continue() {
+    // A trailing `continue` on the final iteration must NOT leak past the
+    // loop and suppress the statements after it (the historical bug).
+    let src = r#"module top;
+  int i; int log[$];
+  initial begin
+    repeat (6) begin
+      #1;                 // blocking
+      i++;
+      if (i % 2 == 0) continue;   // skip even i
+      log.push_back(i);           // push 1,3,5
+    end
+    // log == {1,3,5}
+    if (log.size()==3 && log[0]==1 && log[1]==3 && log[2]==5)
+      $display("RESULT PASS"); else $display("RESULT FAIL log=%p", log);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "repcon");
+    assert!(out.contains("RESULT PASS"), "expected repeat-continue honoured\n{out}");
+}

--- a/tests/blocking_loop_break_continue.rs
+++ b/tests/blocking_loop_break_continue.rs
@@ -1,0 +1,72 @@
+//! IEEE 1800-2023 §9.3.3: `break`/`continue` inside a blocking loop body
+//! (`while`/`do…while`/`for` whose body has `#delay`/`wait`/`@event`) must
+//! be honoured even though the loop body suspends and resumes via the
+//! process-statement continuation model. Previously a `break` inside a
+//! blocking `while` was silently ignored — the loop re-ran its body
+//! indefinitely (the unrolled continuation re-appended the `while` stmt
+//! without checking the loop-control flags the body set).
+//!
+//! Reference (commercial reference simulator): a `while` with `#5` + `break`
+//! at i==4 produces `log == {1, 3}` (iter 2 `continue`-skipped, iter 4 broke).
+use std::process::Command;
+
+fn xezim() -> String {
+    let base = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/release/xezim", base)
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/blkbrk_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn blocking_while_honours_break_and_continue() {
+    let src = r#"module top;
+  int log[$];
+  int i;
+  initial begin
+    i = 0;
+    while (i < 10) begin
+      #5;                 // blocking — loop body suspends
+      i++;
+      if (i == 2) continue;   // skip logging i==2
+      if (i == 4) break;      // stop at i==4
+      log.push_back(i);
+    end
+    if (log.size()==2 && log[0]==1 && log[1]==3)
+      $display("RESULT PASS"); else $display("RESULT FAIL log=%p", log);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "while");
+    assert!(out.contains("RESULT PASS"), "expected break/continue honoured\n{out}");
+}
+
+#[test]
+fn blocking_for_honours_break() {
+    // `for` is lowered to `while` — same gate applies.
+    let src = r#"module top;
+  int seen[$];
+  initial begin
+    for (int i = 0; i < 10; i++) begin
+      #1;                 // blocking
+      if (i == 5) break;
+      seen.push_back(i);
+    end
+    // seen should be {0,1,2,3,4} — break at i==5
+    if (seen.size()==5 && seen[0]==0 && seen[4]==4)
+      $display("RESULT PASS"); else $display("RESULT FAIL seen=%p", seen);
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "for");
+    assert!(out.contains("RESULT PASS"), "expected for-break honoured\n{out}");
+}

--- a/tests/case_wait_in_task.rs
+++ b/tests/case_wait_in_task.rs
@@ -1,0 +1,126 @@
+//! IEEE 1800-2023 §9.7.4 — a `wait` inside a `case` reached on the
+//! suspend-aware (process) path must BLOCK until its condition is true, not
+//! fall through.
+//!
+//! Root cause this guards: `run_process_stmts` (the suspend-aware statement
+//! runner) had native arms for blocking constructs (Wait, If, While, …) but
+//! none for `case`. When an inlined task body was a `case` whose matched arm
+//! held a `wait` (UVM's `uvm_phase::wait_for_state`:
+//! `case(op) UVM_EQ: wait((state & m_state) != 0);`), it fell through to the
+//! synchronous `exec_statement(Case)`, where a false `wait` with no parking
+//! continuation either silently returned or stranded the process — the waiter
+//! never blocked on the (later-satisfied) condition. This made UVM cleanup
+//! phases fire before the runtime sub-phases completed.
+//!
+//! The fix added a suspend-aware Case handler mirroring the If handler. These
+//! tests pin the semantics: the chosen arm's `wait` must block, and a
+//! non-blocking arm must still run and let execution continue.
+
+use xezim::simulate;
+
+fn lookup(sim: &xezim::compiler::Simulator, name: &str) -> u64 {
+    sim.get_signal(name)
+        .or_else(|| sim.get_signal(&format!("top.{}", name)))
+        .unwrap_or_else(|| panic!("signal not found: {}", name))
+        .to_u64()
+        .unwrap_or_else(|| panic!("signal {} not u64-able", name))
+}
+
+/// A `wait(cond)` inside the matched arm of a `case`, reached via an inlined
+/// task on the suspend-aware path, must block until `cond` becomes true.
+#[test]
+fn case_arm_wait_blocks_until_condition_true() {
+    let src = r#"
+`timescale 1ns/1ns
+module top;
+  reg flag = 1'b0;
+  // 0 = not yet proceeded; set to $time when the waiter passes its wait.
+  integer proceeded_at = 0;
+
+  // Task body is a `case` — exactly the shape of uvm_phase::wait_for_state.
+  task automatic waiter(input integer sel);
+    case (sel)
+      1: begin
+           wait(flag);              // must BLOCK (flag is 0 at the call)
+           proceeded_at = $time;    // records when the waiter resumes
+         end
+      default: proceeded_at = 999;  // default must NOT run for sel==1
+    endcase
+  endtask
+
+  initial waiter(1);        // blocks inside the case arm
+  initial #10 flag = 1'b1;  // releases the waiter at t=10
+  initial #25 $finish;
+endmodule
+"#;
+    let sim = simulate(src, 30).expect("simulate failed");
+    let proceeded_at = lookup(&sim, "proceeded_at");
+    // Correct: the waiter blocks until flag rises at t=10, so proceeded_at==10
+    // and the default arm (999) never ran. Buggy behaviour was proceeded_at==0
+    // (the synchronous-path wait fell through at the call time t=0) or the
+    // process stranding (stayed 0 forever) — both fail this assertion.
+    assert_eq!(
+        proceeded_at, 10,
+        "wait inside a case arm must block until its condition is true (expected proceeded_at=10)"
+    );
+}
+
+/// A case arm with NO blocking construct must run synchronously and let the
+/// statements after the case execute (the suspend-aware handler must not
+/// strand non-blocking arms).
+#[test]
+fn case_arm_nonblocking_runs_and_continues() {
+    let src = r#"
+`timescale 1ns/1ns
+module top;
+  integer a = 0;
+  integer b = 0;
+
+  task automatic pick(input integer sel);
+    case (sel)
+      1: a = 7;   // non-blocking arm
+      2: b = 7;
+    endcase
+  endtask
+
+  initial begin
+    pick(1);
+    b = b + 1;    // statement AFTER the task call must run
+  end
+  initial #5 $finish;
+endmodule
+"#;
+    let sim = simulate(src, 10).expect("simulate failed");
+    assert_eq!(lookup(&sim, "a"), 7, "matched case arm ran");
+    assert_eq!(lookup(&sim, "b"), 1, "execution continued past the case/task");
+}
+
+/// The `default` arm of a case must be selected when no item matches, and if
+/// that arm blocks it too must block on the suspend-aware path.
+#[test]
+fn case_default_arm_is_selected_and_blocks() {
+    let src = r#"
+`timescale 1ns/1ns
+module top;
+  reg flag = 1'b0;
+  integer got = 0;
+
+  task automatic waiter(input integer sel);
+    case (sel)
+      1: got = 111;
+      default: begin wait(flag); got = 222; end
+    endcase
+  endtask
+
+  initial waiter(5);        // no item matches → default arm
+  initial #10 flag = 1'b1;
+  initial #25 $finish;
+endmodule
+"#;
+    let sim = simulate(src, 30).expect("simulate failed");
+    // The default arm blocked on wait(flag) until t=10, then set got=222.
+    assert_eq!(
+        lookup(&sim, "got"), 222,
+        "default arm selected and blocked until flag rose"
+    );
+}

--- a/tests/class_scoped_enum.rs
+++ b/tests/class_scoped_enum.rs
@@ -1,0 +1,94 @@
+//! IEEE 1800-2023 §6.19 / §8.22 — a class-scoped enum literal
+//! `ClassName::ENUM_MEMBER` (where the `typedef enum` is declared in
+//! `ClassName` or an ancestor) must evaluate to the literal's value, in ANY
+//! scope — not just module scope.
+//!
+//! Root cause this guards: inside a method body the parser represents
+//! `Base::STARTED` as `MemberAccess(Ident([Base]), STARTED)`, and the
+//! MemberAccess eval path treated `Base` as a runtime object (a class name
+//! has no instance) — so the access read 0 instead of the literal's value.
+//! At module scope the same source parsed as `Ident([Base, STARTED])` and
+//! resolved (by accident) to the global enum-literal signal, so the bug was
+//! context-dependent. This broke UVM's printer: `uvm_policy::STARTED`
+//! (assigned inside `uvm_printer::print_object`, a method) stored 0, so the
+//! cycle-detection marker never recorded STARTED, a circular reference was
+//! never detected, and `sprint()` recursed to stack overflow (Mantis 8522).
+//!
+//! The fix adds a `class_scoped_const` resolver invoked at the top of the
+//! MemberAccess eval arm: when the base is an `Ident` naming a known class,
+//! the member is resolved against the class scope (an enum literal of a
+//! typedef in the class or an ancestor, else a static property). These tests
+//! pin both the module-scope and method-scope forms.
+
+use xezim::simulate;
+
+fn lookup(sim: &xezim::compiler::Simulator, name: &str) -> u64 {
+    sim.get_signal(name)
+        .or_else(|| sim.get_signal(&format!("top.{}", name)))
+        .unwrap_or_else(|| panic!("signal not found: {}", name))
+        .to_u64()
+        .unwrap_or_else(|| panic!("signal {} not u64-able", name))
+}
+
+/// `Base::ENUM` at MODULE scope and at METHOD scope must both yield the
+/// literal's value, for an enum declared in a base class.
+#[test]
+fn class_scoped_enum_module_and_method_scope() {
+    let src = r#"
+`timescale 1ns/1ns
+virtual class Base;
+  typedef enum { NEVER, STARTED, FINISHED } state_e;
+endclass
+class Derived extends Base;
+  function int meth_val(); return Base::STARTED;   endfunction
+  function int meth_first(); return Base::NEVER;   endfunction
+  function int meth_last();  return Base::FINISHED; endfunction
+endclass
+module top;
+  int result = 0;
+  initial begin
+    // module scope
+    result = Base::STARTED;                  // 1
+    // method scope (the previously-broken path)
+    Derived d = new();
+    result = result*10  + d.meth_val();      // 1*10 + 1     = 11
+    result = result*10  + d.meth_first();    // 11*10 + 0    = 110
+    result = result*10  + d.meth_last();     // 110*10 + 2   = 1102
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    assert_eq!(
+        lookup(&sim, "result"),
+        1102,
+        "Base::ENUM must resolve to the literal value at both module and method scope"
+    );
+}
+
+/// A bare (unqualified, inherited) enum literal inside a derived-class method
+/// must still resolve (regression guard — this path already worked).
+#[test]
+fn inherited_bare_enum_literal_in_method() {
+    let src = r#"
+`timescale 1ns/1ns
+virtual class Base;
+  typedef enum { ALPHA, BETA, GAMMA } g_e;
+endclass
+class Derived extends Base;
+  function int pick(); return BETA; endfunction
+endclass
+module top;
+  int result = 0;
+  initial begin
+    Derived d = new();
+    result = d.pick();   // BETA = 1
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    assert_eq!(
+        lookup(&sim, "result"),
+        1,
+        "bare inherited enum literal resolves in a method"
+    );
+}

--- a/tests/foreach_blocking_resume.rs
+++ b/tests/foreach_blocking_resume.rs
@@ -1,0 +1,82 @@
+//! IEEE 1800-2023 §9.4.3: a process blocked at a procedural timing control
+//! (`wait`/`#delay`) inside a `foreach` body (often nested several inlined
+//! task frames deep — UVM's `foreach (siblings[sib]) sib.wait_for_state(…)`)
+//! shall resume at the NEXT iteration, not by restarting the whole `foreach`
+//! from index 0. The minimal shape: a `foreach` calling a task that performs
+//! a CONSUMING side effect (queue pop) BEFORE a `wait(cond)` that is initially
+//! FALSE. Replaying from index 0 would re-pop an already-empty queue.
+//!
+//! Reference (commercial reference simulator): parks at iter 0, resumes when
+//! the flag is raised, then runs iters 1, 2 — queue ends empty.
+use std::process::Command;
+
+fn xezim() -> String {
+    let base = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/release/xezim", base)
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/fe_wait_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn foreach_task_with_false_wait_resumes_next_iter() {
+    let src = r#"module top;
+  int q[$];     // consumed before each wait
+  int flag;
+  int drv[$];
+
+  task automatic do_iter(input int idx);
+    int popped;
+    popped = q.pop_front();           // consuming side effect before wait
+    wait (flag >= 1);                 // FALSE until t=10 -> must park
+  endtask
+
+  initial begin
+    drv.push_back(0); drv.push_back(1); drv.push_back(2);
+    q.push_back(11); q.push_back(22); q.push_back(33);
+    flag = 0;
+    fork begin #10; flag = 1; end join_none
+    foreach (drv[d]) do_iter(drv[d]);
+    #1;
+    $display("QSIZE %0d", q.size());
+    if (q.size() == 0) $display("RESULT PASS"); else $display("RESULT FAIL");
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "taskwait");
+    assert!(out.contains("QSIZE 0"), "queue should be empty after 3 pops\n{out}");
+    assert!(out.contains("RESULT PASS"), "expected PASS\n{out}");
+}
+
+#[test]
+fn foreach_blocking_body_parks_each_iter() {
+    // A blocking foreach body (direct #delay, no task) must advance one
+    // iteration per resume and visit every element exactly once.
+    let src = r#"module top;
+  int arr[3];
+  int seen[$];
+  initial begin
+    arr[0]=7; arr[1]=8; arr[2]=9;
+    foreach (arr[i]) begin
+      #5;
+      seen.push_back(arr[i]);
+    end
+    #1;
+    $display("SEEN %p", seen);
+    if (seen.size()==3 && seen[0]==7 && seen[1]==8 && seen[2]==9)
+      $display("RESULT PASS"); else $display("RESULT FAIL");
+    $finish;
+  end
+endmodule
+"#;
+    let out = run(src, "blocking");
+    assert!(out.contains("RESULT PASS"), "expected each element visited once\n{out}");
+}

--- a/tests/inherited_static_shared.rs
+++ b/tests/inherited_static_shared.rs
@@ -1,0 +1,133 @@
+// Regression test for `static_prop_key` over-aggressive per-specialization
+// keying of inherited statics (IEEE 1800-2023 §8.9 / §8.25).
+//
+// A `static` property inherited from a NON-parameterized ancestor is a single
+// shared cell across EVERY specialization of a parameterized derived class —
+// the declaring class is not parameterized, so there is nothing to specialize.
+//
+//   class Base;                         // non-parameterized ancestor
+//     static int counter = 0;
+//   endclass
+//   class Derived #(type T=int) extends Base;
+//     ... counter = counter + 1; ...    // writes the shared Base::counter
+//   endclass
+//
+// Before the fix, `static_prop_key` applied per-spec keying whenever the spec
+// base class EXTENDED the declaring class (`class_extends`), regardless of
+// whether the declaring class was itself parameterized. That wrongly split
+// `Base::counter` into one cell per `Derived#(...)` specialization instead of
+// the single shared cell the LRM requires. Verified byte-for-byte against
+// reference simulators.
+
+use std::process::Command;
+
+#[test]
+fn inherited_static_from_nonparam_ancestor_is_shared_across_specs() {
+    let src = r#"class Base;                 // non-parameterized ancestor
+  static int counter = 0;
+endclass
+
+class Derived #(type T=int) extends Base;
+  typedef Derived#(T) this_type;
+  static this_type m_inst;
+  static function this_type get();
+    counter = counter + 1;          // writes the shared Base::counter
+    if (m_inst == null) m_inst = new();
+    return m_inst;
+  endfunction
+endclass
+
+module top;
+  initial begin
+    Derived#(int)  a;
+    Derived#(byte) b;
+    a = Derived#(int)::get();       // counter -> 1
+    b = Derived#(byte)::get();      // counter -> 2 (shared)
+    b = Derived#(byte)::get();      // counter -> 3 (shared)
+    if (Base::counter == 3) $display("PASS shared-inherited");
+    else $display("FAIL shared-inherited got=%0d", Base::counter);
+  end
+endmodule
+"#;
+
+    let dir = std::env::temp_dir().join(format!("xezim_inhstatic_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sv_path = dir.join("inherited_static_shared.sv");
+    std::fs::write(&sv_path, src).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(sv_path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PASS shared-inherited") && !stdout.contains("FAIL"),
+        "inherited static was not shared across specializations.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+// Positive control: an inherited static from a PARAMETERIZED ancestor IS
+// per-specialization (this is the UVM factory `m__initialized` pattern that
+// the broader keying was originally added to support, and must keep working).
+#[test]
+fn inherited_static_from_param_ancestor_is_per_spec() {
+    let src = r#"class Base #(type T=int);
+  static int counter = 0;
+  static function int get_count();
+    return counter;
+  endfunction
+endclass
+
+class Derived #(type T=int) extends Base#(T);
+  typedef Derived#(T) this_type;
+  static this_type m_inst;
+  static function this_type get();
+    counter = counter + 1;
+    if (m_inst == null) m_inst = new();
+    return m_inst;
+  endfunction
+endclass
+
+module top;
+  initial begin
+    Derived#(int)  a;
+    Derived#(byte) b;
+    a = Derived#(int)::get();       // int counter  -> 1
+    a = Derived#(int)::get();       // int counter  -> 2
+    b = Derived#(byte)::get();      // byte counter -> 1 (distinct cell)
+    if (Derived#(int)::get_count() == 2)  $display("PASS per-spec-int");
+    else $display("FAIL per-spec-int got=%0d", Derived#(int)::get_count());
+    if (Derived#(byte)::get_count() == 1) $display("PASS per-spec-byte");
+    else $display("FAIL per-spec-byte got=%0d", Derived#(byte)::get_count());
+  end
+endmodule
+"#;
+
+    let dir = std::env::temp_dir().join(format!("xezim_inhstatic2_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sv_path = dir.join("inherited_static_per_spec.sv");
+    std::fs::write(&sv_path, src).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(sv_path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PASS per-spec-int") && stdout.contains("PASS per-spec-byte")
+            && !stdout.contains("FAIL"),
+        "inherited static from a parameterized ancestor was not per-spec.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/tests/multidim_assoc_array.rs
+++ b/tests/multidim_assoc_array.rs
@@ -1,0 +1,160 @@
+//! IEEE 1800-2023 §7.8.4 — multidimensional associative arrays
+//! (`T m[K1][K2]...[Kn]`, an assoc array whose elements are themselves assoc
+//! arrays) must store/recover elements, and `.exists()`/`.num()` must reflect
+//! each dimension.
+//!
+//! Root cause this guards: every element of a multidim assoc was silently
+//! lost. The declaration handlers registered only the FIRST unpacked
+//! dimension (so `m` looked like a 1D assoc), and neither the read nor write
+//! `ExprKind::Index` path had an arm for a base that is itself an
+//! associative-array index. `m[k1][k2] = v` fell through every handler and
+//! stored nothing; `m[k1][k2]` read 0; `m.exists(k1)` (which checks the bare
+//! `m[k1]` key, never populated in 2D) returned 0. This broke UVM's printer
+//! cycle-detection map `m_recur_states[uvm_object][uvm_recursion_policy_enum]`
+//! — `m[obj][policy] = STARTED` never landed, so revisiting an object during
+//! `sprint()` was never detected and a circular reference recursed to stack
+//! overflow (UVM Mantis 8522).
+//!
+//! The fix stores each element under the flat compound key `m[K1][K2]...[Kn]`
+//! (read and write share one helper so the key rendering agrees for every key
+//! type), and `.exists(k)` accepts either the 1D key OR any `m[k][...]`
+//! compound element (prefix scan). These tests pin the semantics for
+//! module-level and class-member multidim assocs.
+
+use xezim::simulate;
+
+fn lookup(sim: &xezim::compiler::Simulator, name: &str) -> u64 {
+    sim.get_signal(name)
+        .or_else(|| sim.get_signal(&format!("top.{}", name)))
+        .unwrap_or_else(|| panic!("signal not found: {}", name))
+        .to_u64()
+        .unwrap_or_else(|| panic!("signal {} not u64-able", name))
+}
+
+/// Module-level `int m[int][int]`: write, read back, `.num()` on an inner
+/// sub-array, and `.exists()` on the outer dimension.
+#[test]
+fn multidim_assoc_module_level_write_read_exists_num() {
+    let src = r#"
+`timescale 1ns/1ns
+module top;
+  int m [int][int];
+  int result = 0;
+  initial begin
+    m[1][0] = 100;
+    m[1][1] = 101;
+    m[2][0] = 200;
+    // read-back: 100+101+200 = 401
+    result = m[1][0] + m[1][1] + m[2][0];
+    // inner .num(): m[1] has two entries → +1000
+    if (m[1].num() == 2) result = result + 1000;
+    // outer .exists(): +10000 if m[2] present, +100000 if m[9] absent
+    if (m.exists(2))  result = result + 10000;
+    if (!m.exists(9)) result = result + 100000;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    // 401 + 1000 + 10000 + 100000 = 111401
+    assert_eq!(
+        lookup(&sim, "result"),
+        111401,
+        "2D assoc write/read/num/exists must all work at module scope"
+    );
+}
+
+/// A class-handle-indexed 2D assoc (`int m[C][int]`) must key on handle
+/// identity: two distinct handles get distinct entries; an alias handle reads
+/// the same entry.
+#[test]
+fn multidim_assoc_handle_keyed() {
+    let src = r#"
+`timescale 1ns/1ns
+class C;
+  int id;
+  function new(int i); id = i; endfunction
+endclass
+module top;
+  int m [C][int];
+  int result = 0;
+  initial begin
+    C c1 = new(1);
+    C c2 = new(2);
+    C c1b; c1b = c1;   // alias of c1
+    m[c1][10] = 7;
+    m[c2][10] = 8;
+    result = m[c1][10] + m[c2][10] + m[c1b][10];  // 7 + 8 + 7 = 22
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    assert_eq!(
+        lookup(&sim, "result"),
+        22,
+        "handle-keyed 2D assoc must key on identity (alias reads same entry)"
+    );
+}
+
+/// A multidim assoc declared as a CLASS member (mirrors
+/// `uvm_printer::m_recur_states[obj][policy]`): writes/reads/exists through
+/// methods must resolve to the per-instance storage.
+#[test]
+fn multidim_assoc_class_member() {
+    let src = r#"
+`timescale 1ns/1ns
+class C;
+  int id;
+  function new(int i); id = i; endfunction
+endclass
+class Holder;
+  int m [C][int];
+  function void put(input C k, input int p, input int v); m[k][p] = v; endfunction
+  function int  get(input C k, input int p); return m[k][p]; endfunction
+  function int  has(input C k, input int p); return m[k].exists(p); endfunction
+endclass
+module top;
+  int result = 0;
+  initial begin
+    Holder h = new();
+    C c1 = new(1);
+    h.put(c1, 0,     100);
+    h.put(c1, 65536, 200);
+    result = h.get(c1, 0) + h.get(c1, 65536);   // 300
+    if (h.has(c1, 0) && h.has(c1, 65536)) result = result + 1000;   // 1300
+    if (!h.has(c1, 99)) result = result + 10000;                    // 11300
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    assert_eq!(
+        lookup(&sim, "result"),
+        11300,
+        "class-member 2D assoc write/read/exists through methods"
+    );
+}
+
+/// `.delete()` on a 2D assoc clears every compound element (prefix scan),
+/// so a subsequent `.exists()` returns 0.
+#[test]
+fn multidim_assoc_delete_clears_all() {
+    let src = r#"
+`timescale 1ns/1ns
+module top;
+  int m [int][int];
+  int result = 0;
+  initial begin
+    m[1][2] = 9;
+    m[3][4] = 8;
+    result = m.exists(1);   // 1 before delete
+    m.delete();
+    result = result*10 + m.exists(1);  // 10 (exists now 0)
+  end
+endmodule
+"#;
+    let sim = simulate(src, 5).expect("simulate failed");
+    assert_eq!(
+        lookup(&sim, "result"),
+        10,
+        "delete() must clear all compound elements of a 2D assoc"
+    );
+}

--- a/tests/nested_fork_shared_write.rs
+++ b/tests/nested_fork_shared_write.rs
@@ -1,0 +1,133 @@
+// Regression test for nested-fork shared-object write/dispatch visibility
+// (IEEE 1800-2023 §9.3.2 / §6.21).
+//
+// A fork child that inherits a captured local frame (because the fork body
+// declares an `automatic` variable) must STILL be able to write to a SHARED
+// object's instance properties and dispatch methods on it. Before the fix,
+// the 2-segment-Ident write path and the method-dispatch path both used
+//
+//     if let Some(locals) = local_stack.last() { locals.get(obj) } else { signals }
+//
+// When the child's captured frame existed but did NOT contain `obj`,
+// `locals.get(obj)` returned None and the `else` (signals/heap) branch was
+// never taken — so the property write was silently dropped and the method
+// call was never dispatched. This broke any nested-fork producer/consumer
+// that touches a shared object (the UVM phase hopper's objection/queue model).
+//
+// Verified byte-for-byte against reference simulators.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("xezim_forkfix_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{tag}.sv"));
+    std::fs::write(&path, src).unwrap();
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+// The minimal trigger: a fork child with an `automatic` declaration (which
+// captures a frame) then a property write + method call on a shared object.
+// Both must persist to the object visible to the parent.
+#[test]
+fn nested_fork_child_writes_and_calls_on_shared_object() {
+    let src = r#"class Box;
+  int n;
+  function void setn(int x);
+    n = x;
+  endfunction
+endclass
+
+module top;
+  Box b;
+  initial begin
+    b = new();
+    fork
+      begin
+        fork
+          automatic int dummy = 0;   // captures a frame in the child
+          begin
+            #10;
+            b.setn(7);                // method call on shared object
+            b.n = b.n + 1;            // property write on shared object
+            $display("child: b.n=%0d", b.n);
+          end
+        join_none
+      end
+    join_none
+    #30;
+    if (b.n == 8) $display("PASS shared-write-dispatch");
+    else $display("FAIL b.n=%0d (expected 8)", b.n);
+  end
+endmodule
+"#;
+    let out = run(src, "shared_write");
+    assert!(
+        out.contains("PASS shared-write-dispatch") && !out.contains("FAIL"),
+        "nested-fork shared-object write/dispatch failed.\n{out}"
+    );
+}
+
+// The UVM-phase-hopper pattern distilled: a forked forever-loop consumer that
+// blocks on `wait(q.size()!=0)`, forks a worker per item, and the worker pushes
+// the successor back onto a shared queue. The successor chain (1→2→3) must
+// complete — it requires nested-fork writes to a shared object to persist.
+#[test]
+fn nested_fork_hopper_successor_chain() {
+    let src = r#"class Hopper;
+  int q[$];
+  int done_count;
+  task automatic get(output int x);
+    wait (q.size() != 0);
+    x = q.pop_front();
+  endtask
+  function void push(int x);
+    q.push_back(x);
+  endfunction
+endclass
+
+module top;
+  Hopper h;
+  int seq_order[$];
+  initial begin
+    h = new();
+    fork
+      forever begin
+        int ph;
+        h.get(ph);
+        fork
+          automatic int p = ph;
+          begin
+            #10;
+            seq_order.push_back(p);
+            h.done_count++;
+            if (p < 3) h.push(p + 1);   // schedule successor
+          end
+        join_none
+      end
+    join_none
+    h.push(1);
+    wait (h.done_count == 3);
+    #1;
+    $display("order: %p", seq_order);
+    if (seq_order.size() == 3 && seq_order[0]==1 && seq_order[1]==2 && seq_order[2]==3)
+      $display("PASS hopper-chain");
+    else
+      $display("FAIL hopper-chain order=%p", seq_order);
+  end
+endmodule
+"#;
+    let out = run(src, "hopper_chain");
+    assert!(
+        out.contains("PASS hopper-chain") && !out.contains("FAIL"),
+        "nested-fork hopper successor chain failed.\n{out}"
+    );
+}

--- a/tests/resource_pool_fixes.rs
+++ b/tests/resource_pool_fixes.rs
@@ -1,0 +1,123 @@
+//! IEEE 1800-2023 §8.25, §7.5: three interacting bugs that broke UVM's
+//! resource pool (`uvm_resource_db`), fixed together:
+//!
+//! 1. **Queue mutation on a typedef'd parameterized class member** —
+//!    `sh.value.push_back(x)` where `sh` is typed `table_q_t = uvm_shared#(T[$])`
+//!    silently no-oped because (a) the parser flattens `sh.value.push_back(x)`
+//!    into a 3-segment hierarchical `Ident`, which the 3-segment method dispatch
+//!    only handled for QUERY builtins (size/num/exists), not MUTATION builtins
+//!    (push_back/pop_back/insert/delete); and (b) the instance's type_bindings
+//!    were empty because a bare `new()` on a typedef'd local didn't resolve the
+//!    typedef chain to recover the `#(...)` type args.
+//!
+//! 2. **`foreach` key extraction on assoc-of-collections** — iterating
+//!    `foreach (all[k])` where each `all[k]` is itself a queue extracted
+//!    `5][0` instead of `5` (it used `k[k.len()-1]` to find the closing bracket,
+//!    not the FIRST `]`), producing phantom iteration keys.
+//!
+//! 3. **`break` propagation from foreach to function body** — a `break`
+//!    inside `foreach(svq[i])` inside a `function` set `break_flag`, which the
+//!    foreach did NOT clear on exit. The function body loop checks `break_flag
+//!    || return_flag` and exited early, so code after the foreach (including
+//!    `return rsrc;`) was never reached.
+use std::process::Command;
+
+fn xezim() -> String {
+    let base = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/debug/xezim", base)
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/respool_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn queue_push_back_on_typedef_param_member() {
+    // Bug 1a+1b: `sh.value.push_back(x)` where `sh` is `typedef uvm_shared#(iq_t)`.
+    let src = r#"typedef int iq_t[$];
+class uvm_shared #(type T=int);
+  T value;
+endclass
+typedef uvm_shared#(iq_t) wrapper_t;
+module top;
+  initial begin
+    wrapper_t sh;
+    sh = new();
+    sh.value.push_back(42);
+    sh.value.push_back(99);
+    if (sh.value.size() == 2 && sh.value[0] == 42 && sh.value[1] == 99)
+      $display("RESULT PASS");
+    else
+      $display("RESULT FAIL size=%0d", sh.value.size());
+  end
+endmodule
+"#;
+    let out = run(src, "typedefq");
+    assert!(out.contains("RESULT PASS"), "expected push_back on typedef'd member\n{out}");
+}
+
+#[test]
+fn foreach_over_assoc_of_queues() {
+    // Bug 2: foreach over an assoc array whose values are themselves queues.
+    let src = r#"typedef int iq_t[$];
+class Base; int v; function new(int p=0); v=p; endfunction endclass
+typedef Base bq_t[$];
+module top;
+  initial begin
+    bq_t all[int];
+    Base r;
+    r = new(5);
+    all[5].push_back(r);
+    all[3].push_back(r);
+    // The key extraction bug would iterate key "5][0" instead of "5".
+    begin
+      int count = 0;
+      foreach (all[k]) begin
+        count++;
+        if (all[k].size() != 1) begin
+          $display("RESULT FAIL key=%0d size=%0d", k, all[k].size());
+          $finish;
+        end
+      end
+      if (count == 2)
+        $display("RESULT PASS");
+      else
+        $display("RESULT FAIL count=%0d", count);
+    end
+  end
+endmodule
+"#;
+    let out = run(src, "assocofq");
+    assert!(out.contains("RESULT PASS"), "expected foreach over assoc-of-queues\n{out}");
+}
+
+#[test]
+fn break_in_foreach_does_not_exit_function() {
+    // Bug 3: `break` inside foreach must NOT propagate to the function body.
+    let src = r#"module top;
+  function automatic int find_first();
+    int arr[3];
+    arr[0] = 10; arr[1] = 20; arr[2] = 30;
+    foreach (arr[i]) begin
+      if (arr[i] == 20) break;
+    end
+    // This code after the foreach was skipped when break_flag propagated.
+    return 42;
+  endfunction
+  initial begin
+    int r;
+    r = find_first();
+    if (r == 42) $display("RESULT PASS");
+    else $display("RESULT FAIL r=%0d", r);
+  end
+endmodule
+"#;
+    let out = run(src, "breakprop");
+    assert!(out.contains("RESULT PASS"), "expected break not to exit function\n{out}");
+}

--- a/tests/sequential_event_waits.rs
+++ b/tests/sequential_event_waits.rs
@@ -1,0 +1,127 @@
+//! IEEE 1800-2023 §9.4.2 — a process that performs SEVERAL sequential event
+//! controls (`@(posedge clk); …; @(posedge clk); …`) must resume on EACH edge.
+//! A re-armed waiter (the continuation after the first `@` resumes) is a fresh
+//! waiter whose `captured_prev` baseline is taken when it re-arms — and that
+//! baseline must track the signal's running level so the NEXT qualifying edge
+//! is detected, not stay frozen at the re-arm value.
+//!
+//! Root cause this guards: the event-waiter firing loop compared the signal's
+//! current value against the `captured_prev` snapshot taken at arm time, but
+//! never refreshed that snapshot when an edge did NOT fire. So a waiter that
+//! re-armed while its signal sat at the edge-target level (clk=1 right after a
+//! posedge resumed the process) had `captured_prev=1` (pb_one=true); when the
+//! clock later went 1→0→1, the Posedge test `!pb_one && cb_one` stayed false
+//! forever — the second (and every subsequent) posedge was lost and the process
+//! stranded. This silently broke `bind`-monitor assertions and any testbench
+//! pattern counting multiple clock edges in one `initial`.
+//!
+//! The fix refreshes a non-firing waiter's `captured_prev` to each sensitivity
+//! signal's current value on every check, so a qualifying transition across
+//! multiple time-steps is caught. The same-tick NBA-region semantics
+//! `captured_prev` was introduced for are preserved: a waiter still does not
+//! fire on an edge that completed before it armed (at arm time captured_prev
+//! already equals current). These tests pin the cross-tick sequential case
+//! (posedge, negedge, and a combined count) and guard the same-tick NBA case
+//! against regression.
+
+fn out(src: &str, prefix: &str) -> String {
+    let sim = xezim::simulate(src, 10_000).expect("simulate");
+    sim.output
+        .iter()
+        .filter(|o| o.message.starts_with(prefix))
+        .map(|o| o.message.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Three sequential `@(posedge clk)` in one initial each resume at t=5/15/25.
+#[test]
+fn sequential_posedge_waits_each_resume() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  bit clk = 0;
+  int cnt = 0;
+  initial begin
+    @(posedge clk); cnt += 1;
+    @(posedge clk); cnt += 10;
+    @(posedge clk); cnt += 100;
+    $display("DONE cnt=%0d", cnt);
+  end
+  always #5 clk = ~clk;
+  initial #40 $finish;
+endmodule
+"#;
+    assert_eq!(out(src, "DONE"), "DONE cnt=111");
+}
+
+/// Sequential `@(negedge clk)` waits resume on each falling edge (t=10, t=20).
+#[test]
+fn sequential_negedge_waits_each_resume() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  bit clk = 0;
+  int n = 0;
+  initial begin
+    @(negedge clk); n += 1;   // t=10
+    @(negedge clk); n += 1;   // t=20
+    @(negedge clk); n += 1;   // t=30
+    $display("NEGS=%0d", n);
+  end
+  always #5 clk = ~clk;
+  initial #40 $finish;
+endmodule
+"#;
+    assert_eq!(out(src, "NEGS"), "NEGS=3");
+}
+
+/// A `bind`-monitor style process: an `initial` with interleaved
+/// `@(posedge clk)` and `assert` statements. Pre-fix only the first assert
+/// ran (the process stalled after the first `@`); post-fix all three run.
+/// (bind_directive_basic.rs covers the full bind elaboration; this is the
+/// minimal sequential-edge core.)
+#[test]
+fn interleaved_event_control_and_assertions() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  bit clk = 0;
+  int pc = 0;
+  int hits = 0;
+  initial begin
+    @(posedge clk); assert (pc == 10) else $display("A1 fail %0d", pc); if (pc == 10) hits++;
+    @(posedge clk); assert (pc == 20) else $display("A2 fail %0d", pc); if (pc == 20) hits++;
+    @(posedge clk); assert (pc == 30) else $display("A3 fail %0d", pc); if (pc == 30) hits++;
+    $display("HITS=%0d", hits);
+  end
+  always #5 clk = ~clk;
+  initial begin
+    pc = 10; #10; pc = 20; #10; pc = 30; #10;
+  end
+  initial #40 $finish;
+endmodule
+"#;
+    // All three assertions run and pass → 3 hits, no "A* fail" messages.
+    assert_eq!(out(src, "HITS"), "HITS=3");
+    assert_eq!(out(src, "A"), "");
+}
+
+/// Same-tick NBA-region waiter (the scenario `captured_prev` was added for)
+/// must STILL wake — regression guard for the refresh fix.
+#[test]
+fn same_tick_nba_waiter_still_wakes() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  bit nba = 0;
+  initial begin
+    nba <= 1;       // NBA: commits this tick
+    @(nba);         // armed while nba=0; must wake when NBA applies nba=1
+    $display("WOKEN nba=%0d", nba);
+  end
+  initial #10 $finish;
+endmodule
+"#;
+    assert_eq!(out(src, "WOKEN"), "WOKEN nba=1");
+}

--- a/tests/static_local_per_spec.rs
+++ b/tests/static_local_per_spec.rs
@@ -1,0 +1,85 @@
+// Regression test for function-local `static` per-specialization keying
+// (IEEE 1800-2023 §8.25 / §6.21).
+//
+// A `static` variable declared inside a METHOD of a parameterized class keeps
+// ONE persistent storage per SPECIALIZATION. The UVM factory's real singleton
+// form is exactly this:
+//
+//   class Registry #(type T=int, string N="x");
+//     typedef Registry#(T,N) this_type;
+//     static function this_type get();
+//       static this_type m_inst;          // function-local static
+//       if (m_inst == null) m_inst = new();
+//       return m_inst;
+//     endfunction
+//   endclass
+//
+// `m_inst` must be:
+//   - SHARED across repeated calls of the SAME specialization (singleton),
+//   - DISTINCT across DIFFERENT specializations.
+//
+// Before the fix, class methods never opened a `static_local_syncs` frame
+// (only free functions/tasks did), so a function-local static was
+// re-initialized on every call and the singleton never persisted. Verified
+// byte-for-byte against reference simulators.
+
+use std::process::Command;
+
+#[test]
+fn function_local_static_shared_within_spec_distinct_across_specs() {
+    let src = r#"class Wrapper #(type T=int, string Tname="<unknown>");
+  typedef Wrapper#(T, Tname) this_type;
+  static function this_type get();
+    static this_type m_inst;          // function-local static
+    static int counter;
+    if (m_inst == null) begin
+      m_inst = new();
+      counter = counter + 1;          // counts constructions
+    end
+    return m_inst;
+  endfunction
+  virtual function string name();
+    return Tname;
+  endfunction
+endclass
+
+module top;
+  initial begin
+    Wrapper#(int, "AAA") a1, a2;
+    Wrapper#(int, "BBB") b1;
+    a1 = Wrapper#(int, "AAA")::get();
+    a2 = Wrapper#(int, "AAA")::get();   // same spec -> same singleton
+    b1 = Wrapper#(int, "BBB")::get();   // diff spec -> diff singleton
+    if (a1 == a2) $display("PASS share");
+    else          $display("FAIL share a1!=a2");
+    if (a1 != b1 && a1.name() == "AAA" && b1.name() == "BBB")
+      $display("PASS distinct");
+    else
+      $display("FAIL distinct a1=%s b1=%s",
+               a1==null?"null":a1.name(), b1==null?"null":b1.name());
+  end
+endmodule
+"#;
+
+    let dir = std::env::temp_dir().join(format!("xezim_flstatic_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sv_path = dir.join("static_local_per_spec.sv");
+    std::fs::write(&sv_path, src).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(sv_path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PASS share") && stdout.contains("PASS distinct")
+            && !stdout.contains("FAIL"),
+        "function-local static per-spec keying failed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
 ### Summary

 Next batch of runtime correctness work. The changes cluster around three themes — a much more complete suspend-aware process runner, several
 shared-object / storage-correctness fixes that unblock real concurrency, and two library-level bugs (resource-pool lookups and circular object
 printing) that were silently swallowing results. All behavioral changes are validated byte-for-byte against reference simulators; affected cases
 that previously hung, ICE'd, or emitted garbage now produce correct output.

 │ Pairs with the xezim-core PR of the same branch name: this branch consumes xezim-core's new ForeachTail AST sentinel and its
 │ labelled-statement disable <label> wrapping. Both should land together.

 ### Motivation

 The suspend-aware statement runner (run_process_stmts) had native arms for if/while/for/fork and inlined task calls, but fell back to
 synchronous exec_statement for case, blocking foreach, and blocking repeat. That fallback silently fell through on a false wait — a violation of
 IEEE 1800-2023 §9.7.4 — so phases fired out of order and several tests deadlocked or misreported.

 ### Key changes

 Suspend-aware control flow (process runner)
 - case arm — evaluate the selector once, pick the first matching arm/default, and if the chosen arm blocks, flatten + recurse so its wait
   reaches the suspend-aware Wait arm. Fixes out-of-order phase sequencing.
 - Blocking foreach — unroll one iteration + re-append a ForeachTail tail (the new xezim-core sentinel) so a parked process resumes at the next
   iteration (§9.4.3), instead of replaying from index 0. Dynamic arrays/queues re-check live size each iteration.
 - Blocking-loop break/continue — blocking_loop_flag_gate() consumed at while and repeat re-entry; the repeat count-0 re-entry acts as the
   exhaustion sentinel that clears a trailing continue. forever-with-break intentionally left ungated (it caused deadlocks with no test gain).
 - Sequential @(posedge clk) — a waiter that re-armed while its signal sat at the edge-target level had captured_prev frozen at the target level,
   so every subsequent edge was lost. Refresh captured_prev (and _wide) when a waiter does not trigger.
 - Nested-fork shared-object writes/dispatch — if let Some(locals)=local_stack.last() { locals.get(obj) } else { signals } skipped the
   heap/signal branch entirely when the captured frame lacked obj (the common case for module-scoped handles), dropping writes and method
   dispatch. Fall through to signal/heap on a locals.get miss.

 Storage / type correctness
 - Array-element collection base — arr[i].aa.num(), foreach(arr[i].aa[k]), etc. resolved the wrong object (this.aa) because expr_assoc_name only
   handled a bare Ident/this base. Now resolves through an array-element base in both parse shapes.
 - bit-typed class property signedness — assigning literal 1 to a bit field leaked RHS is_signed, so reads came back -1 (0xFFFFFFFF), breaking
   every cross-process wait(<bit>==1). Normalize signedness to the declared property type in fit_class_prop.
 - Function-local static per-specialization — static this_type m_inst; inside a method of a parameterized class was re-initialized every call;
   methods now open/sync the static_local_syncs frame with a class+spec-aware key, and static_prop_key only applies per-spec keying when the
   declaring class is parameterized (§8.25).

 Library-mode fixes
 - Resource-pool lookups — three bugs: (1) typedef'd parameterized-class queue mutation (sh.value.push_back) no-oped (the parser flattened it to
   a 3-segment Ident; mutation builtins weren't in the dispatch guard, and new() on a typedef'd local didn't resolve the #(T=…) args); (2)
   foreach(all[k]) on assoc-of-collections extracted 5][0 as the key; (3) break inside a foreach inside a function leaked break_flag and skipped
   the trailing return (§12.8).
 - Circular object sprint() stack overflow — two combined bugs defeated the printer's cycle detection: 2-D associative arrays were silently empty
   (only the first unpacked dim was registered, and no Index-base arm existed), and ClassName::ENUM_LITERAL evaluated to 0 inside a method. Fixed
   with a shared multidim_assoc_elem key helper + a class_scoped_const resolver on the MemberAccess eval arm.