### PR TITLE
tests: genfor localparam substitution and type-param default resolution

### DIFF
--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -39,3 +39,5 @@ file,topic,description
 38_resolver_dispatch.sv,resolution tier 2,user-defined nettype resolver function dispatch
 39_builtin_nettype_resolution.sv,resolution tier 1,per-NetType fold for wand wor triand trior supply
 40_struct_nettype_resolution.sv,resolution tier 2,struct-typed nettype with real field and field-by-field resolver
+41_genfor_localparam_idx.sv,generate-for elaboration,genvar-dependent localparam init substituted per iteration
+42_typeparam_default_resolution.sv,type parameter defaults,non-overridden parameter type default resolved against overridden numeric params

--- a/tests/sv_compliance/tests_advanced/41_genfor_localparam_idx.sv
+++ b/tests/sv_compliance/tests_advanced/41_genfor_localparam_idx.sv
@@ -1,0 +1,34 @@
+// §27.4: localparam declared inside a generate-for body can reference the
+// genvar. The elaborate phase must substitute the genvar into the initializer
+// so each iteration gets its per-iteration constant.
+//
+// Mirrors rr_arb_tree: nested generate-for loops create a binary-tree of
+// localparams `Idx0 = 2**level-1+l` that index a continuous-assign LHS.
+// If genvar substitution is missing, every Idx0 resolves to 0 and vec[0] is
+// driven multiple times while higher bits stay X.
+// Expected output: TEST_PASS
+module inner #(parameter int unsigned NumIn = 5) ();
+  if (NumIn == unsigned'(1)) begin : gen_pass
+    logic dummy;
+  end else begin : gen_arbiter
+    localparam int unsigned NumLevels = unsigned'($clog2(NumIn));
+    logic [2**NumLevels-2:0] vec;
+
+    for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : gen_levels
+      for (genvar l = 0; l < 2**level; l++) begin : gen_level
+        localparam int unsigned Idx0 = 2**level-1+l;
+        assign vec[Idx0] = 1'b1;
+      end
+    end
+
+    initial begin
+      #1;
+      if (vec === 7'b1111111) $display("TEST_PASS genfor localparam idx vec=%b", vec);
+      else                    $display("TEST_FAIL genfor localparam idx vec=%b (expected 1111111)", vec);
+    end
+  end
+endmodule
+
+module top;
+  inner #(.NumIn(5)) u_inner ();
+endmodule

--- a/tests/sv_compliance/tests_advanced/42_typeparam_default_resolution.sv
+++ b/tests/sv_compliance/tests_advanced/42_typeparam_default_resolution.sv
@@ -1,0 +1,21 @@
+// §6.20.3: `parameter type T = expr` — a type-parameter default that
+// references a numeric parameter of the same module must resolve against the
+// overridden value of that parameter when a sub-instance is inlined.
+//
+// Without the fix, $bits(val) stays 4 (the module's own default W=4) instead
+// of 8 (the caller's override), because the non-overridden T default is never
+// re-evaluated against the sub-instance's merged param map.
+// Expected output: TEST_PASS
+module sub #(parameter int unsigned W = 4, parameter type T = logic[W-1:0]) ();
+  T val;
+  initial begin
+    val = '1;
+    #1;
+    if ($bits(val) == 8) $display("TEST_PASS typeparam default W=%0d bits=%0d", W, $bits(val));
+    else                 $display("TEST_FAIL typeparam default W=%0d bits=%0d (expected 8)", W, $bits(val));
+  end
+endmodule
+
+module top;
+  sub #(.W(8)) u_sub ();
+endmodule

--- a/tests/sv_compliance_runner.rs
+++ b/tests/sv_compliance_runner.rs
@@ -215,6 +215,50 @@ fn test_sv_30_let_construct() {
 fn test_sv_31_user_defined_nettypes() {
     run_positive_compliance_test("tests_advanced", "31_user_defined_nettypes.sv");
 }
+#[test]
+fn test_sv_32_streaming_operators() {
+    run_positive_compliance_test("tests_advanced", "32_streaming_operators.sv");
+}
+#[test]
+fn test_sv_33_assignment_patterns() {
+    run_positive_compliance_test("tests_advanced", "33_assignment_patterns.sv");
+}
+#[test]
+fn test_sv_34_case_inside_ranges() {
+    run_positive_compliance_test("tests_advanced", "34_case_inside_ranges.sv");
+}
+#[test]
+fn test_sv_35_disable_fork() {
+    run_positive_compliance_test("tests_advanced", "35_disable_fork.sv");
+}
+#[test]
+fn test_sv_36_tagged_union_patterns() {
+    run_positive_compliance_test("tests_advanced", "36_tagged_union_patterns.sv");
+}
+#[test]
+fn test_sv_37_z_skip_resolution() {
+    run_positive_compliance_test("tests_advanced", "37_z_skip_resolution.sv");
+}
+#[test]
+fn test_sv_38_resolver_dispatch() {
+    run_positive_compliance_test("tests_advanced", "38_resolver_dispatch.sv");
+}
+#[test]
+fn test_sv_39_builtin_nettype_resolution() {
+    run_positive_compliance_test("tests_advanced", "39_builtin_nettype_resolution.sv");
+}
+#[test]
+fn test_sv_40_struct_nettype_resolution() {
+    run_positive_compliance_test("tests_advanced", "40_struct_nettype_resolution.sv");
+}
+#[test]
+fn test_sv_41_genfor_localparam_idx() {
+    run_positive_compliance_test("tests_advanced", "41_genfor_localparam_idx.sv");
+}
+#[test]
+fn test_sv_42_typeparam_default_resolution() {
+    run_positive_compliance_test("tests_advanced", "42_typeparam_default_resolution.sv");
+}
 
 #[test]
 fn test_sv_neg01_duplicate_declaration() {


### PR DESCRIPTION
## Summary

Regression tests for [aionhw/xezim-core#10](https://github.com/aionhw/xezim-core/pull/10). CI will be red until that PR merges — the two are intended to be reviewed together and merged in order (core first, then this).

- **`41_genfor_localparam_idx.sv`** — mirrors `rr_arb_tree` from common_cells. Nested generate-for loops create body localparams `Idx0 = 2**level-1+l` that index a continuous-assign LHS. Tests that genvar substitution reaches localparam inits inside generate-for and that the param map expands to a fixpoint. Expected: `TEST_PASS`.

- **`42_typeparam_default_resolution.sv`** — sub-module with `parameter type T = logic[W-1:0]`; caller overrides `W=8` but leaves `T` at default. Tests that the non-overridden type-param default is re-evaluated against the sub-instance param map (`$bits(T)` must be 8, not the module-default 4). Expected: `TEST_PASS`.

Also wires up the previously-added tests 32–40 in `sv_compliance_runner.rs` (files existed in `tests_advanced/` and the manifest but had no Rust test functions).

## Test plan

- [ ] Merge aionhw/xezim-core#10 first (CI depends on it)
- [ ] `cargo test test_sv_41` → `TEST_PASS genfor localparam idx vec=1111111`
- [ ] `cargo test test_sv_42` → `TEST_PASS typeparam default W=8 bits=8`
- [ ] `cargo test --test sv_compliance_runner` — all 40 existing tests still pass