### PR TITLE
simulator: resolve typedef alias in type_id::create

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -54395,13 +54395,33 @@ impl Simulator {
                 if let Some(class_def) = self.module.classes.get(class_name).cloned() {
                     return self.instantiate_class(&class_def, args);
                 }
-            } else if len >= 2 && path[len - 1].name.name == "create" {
+                // Typedef alias of a parameterized class (same bridge as the
+                // MemberAccess path above and the PURE_SV_LRM branch below).
+                if let Some(DataType::TypeReference { name, type_args, .. }) =
+                    self.module.typedef_types.get(class_name).cloned()
+                {
+                    if let Some(class_def) =
+                        self.module.classes.get(&name.name.name).cloned()
+                    {
+                        let ta: Option<&[Expression]> = if type_args.is_empty() {
+                            None
+                        } else {
+                            Some(&type_args)
+                        };
+                        return self.instantiate_class_with_type_args(
+                            &class_def, args, ta,
+                        );
+                    }
+                }
             }
 
             // PURE-mode counterpart of the flattened `...,type_id,create` path
             // (the MemberAccess form is handled in eval_call_inner's call site
             // above). Resolve `C::type_id::create` from `C`'s own registry
-            // typedef and construct the registered target class.
+            // typedef and construct the registered target class.  When `C` is a
+            // typedef alias (e.g. `typedef base_seq#(T) my_sqr`) there is no
+            // class entry for `my_sqr`; fall through to `typedef_types` to
+            // resolve the alias and instantiate the parameterised target.
             if self.pure_sv_lrm
                 && len >= 3
                 && path[len - 1].name.name == "create"
@@ -54411,6 +54431,22 @@ impl Simulator {
                 if let Some(target) = self.resolve_type_id_target_class(&class_name) {
                     if let Some(class_def) = self.module.classes.get(&target).cloned() {
                         return self.instantiate_class(&class_def, args);
+                    }
+                }
+                if let Some(DataType::TypeReference { name, type_args, .. }) =
+                    self.module.typedef_types.get(&class_name).cloned()
+                {
+                    if let Some(class_def) =
+                        self.module.classes.get(&name.name.name).cloned()
+                    {
+                        let ta: Option<&[Expression]> = if type_args.is_empty() {
+                            None
+                        } else {
+                            Some(&type_args)
+                        };
+                        return self.instantiate_class_with_type_args(
+                            &class_def, args, ta,
+                        );
                     }
                 }
             }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -53724,6 +53724,33 @@ impl Simulator {
                                 {
                                     return self.instantiate_class(&class_def, args);
                                 }
+                                // `typedef uvm_sequencer#(item) sqr_t;
+                                // sqr_t::type_id::create(...)` — the name is a
+                                // typedef alias of a parameterized class (LRM
+                                // §6.18: a synonym, §8.25.1: same
+                                // specialization), not a class itself. Resolve
+                                // the alias to its base class + type args and
+                                // construct directly — same bridge as the
+                                // PURE_SV_LRM branch below; without it the
+                                // create falls through to the real factory,
+                                // which returns null, and the agent's
+                                // sequencer silently never exists.
+                                if let Some(DataType::TypeReference { name, type_args, .. }) =
+                                    self.module.typedef_types.get(class_name).cloned()
+                                {
+                                    if let Some(class_def) =
+                                        self.module.classes.get(&name.name.name).cloned()
+                                    {
+                                        let ta: Option<&[Expression]> = if type_args.is_empty() {
+                                            None
+                                        } else {
+                                            Some(&type_args)
+                                        };
+                                        return self.instantiate_class_with_type_args(
+                                            &class_def, args, ta,
+                                        );
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -41,3 +41,4 @@ file,topic,description
 40_struct_nettype_resolution.sv,resolution tier 2,struct-typed nettype with real field and field-by-field resolver
 41_genfor_localparam_idx.sv,generate-for elaboration,genvar-dependent localparam init substituted per iteration
 42_typeparam_default_resolution.sv,type parameter defaults,non-overridden parameter type default resolved against overridden numeric params
+43_typedef_type_id_create.sv,typedef factory alias,typedef alias of parameterised class resolved via type_id::create factory path

--- a/tests/sv_compliance/tests_advanced/43_typedef_type_id_create.sv
+++ b/tests/sv_compliance/tests_advanced/43_typedef_type_id_create.sv
@@ -1,0 +1,39 @@
+// Compliance test: typedef alias of a parameterised class as factory target.
+//
+// `my_sqr::type_id::create(...)` must instantiate the typedef's concrete type
+// (`base_seq#(payload)`) when `my_sqr` is declared as a typedef alias rather
+// than a top-level class.  Without the typedef-resolution fallback in
+// `resolve_type_id_target_class`, the class-name lookup finds no entry for
+// `my_sqr` and returns null, failing the not-null assertion below.
+module top;
+
+  class payload;
+    int data;
+    function new(string n = "payload", int p = 0);
+      data = 0;
+    endfunction
+  endclass
+
+  class base_seq #(type T = payload);
+    T item;
+    function new(string n = "base_seq", int p = 0);
+      item = null;
+    endfunction
+    function string get_name();
+      return "base_seq";
+    endfunction
+  endclass
+
+  typedef base_seq #(payload) my_sqr;
+
+  initial begin
+    automatic my_sqr s;
+    s = my_sqr::type_id::create("sqr", null);
+    if (s == null) begin
+      $display("TEST_FAIL: typedef type_id::create returned null");
+    end else begin
+      $display("TEST_PASS");
+    end
+  end
+
+endmodule

--- a/tests/sv_compliance_runner.rs
+++ b/tests/sv_compliance_runner.rs
@@ -264,6 +264,10 @@ fn test_sv_41_genfor_localparam_idx() {
 fn test_sv_42_typeparam_default_resolution() {
     run_positive_compliance_test("tests_advanced", "42_typeparam_default_resolution.sv");
 }
+#[test]
+fn test_sv_43_typedef_type_id_create() {
+    run_positive_compliance_test("tests_advanced", "43_typedef_type_id_create.sv");
+}
 
 #[test]
 fn test_sv_neg01_duplicate_declaration() {


### PR DESCRIPTION
When `my_sqr` is a `typedef base_seq#(T) my_sqr` alias rather than a
top-level class, `my_sqr::type_id::create(...)` failed to construct an
instance because the factory intercept searched `module.classes` directly
(which has no entry for `my_sqr`).

Fix: after the direct class lookup fails, fall through to `module.typedef_types`,
find the `TypeReference` entry, and delegate to `instantiate_class_with_type_args`
with the alias's type arguments. Applied to both the `MemberAccess`
(`.`-notation) and flattened-Ident (`::` notation) call forms.

Regression: `tests/sv_compliance/tests_advanced/43_typedef_type_id_create.sv`

