### PR TITLE
fix: TLM connect/write intercept for statement-position method calls

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -58320,12 +58320,22 @@ impl Simulator {
             _ => return false,
         };
         for tgt in targets {
-            // A connected target is typically a uvm_*_imp/export that forwards
-            // the call to the actual implementer it wraps (its `m_imp`: the
-            // subscriber, the fifo, ...). Deliver straight to that implementer —
-            // the imp's own forwarding `task put`/`function write` carries a
-            // "port not bound" guard keyed on m_imp_list (which the route-B
-            // phaser doesn't populate), so calling the imp directly would stall.
+            // An analysis `write` must run the connected imp's OWN write method,
+            // because `uvm_analysis_imp_decl(SFX)` generates an imp whose write
+            // forwards to `m_imp.write``SFX` (e.g. `write_in`) — NOT the plain
+            // `write`. Shortcutting to the implementer and calling `write`
+            // directly (as the pull path does) silently no-ops for those
+            // suffixed subscribers. The generated analysis-imp write carries no
+            // "port not bound" guard, so invoking it directly is safe; its body
+            // dispatches to the correct suffixed method on the implementer.
+            if mname == "write" {
+                self.exec_method_call(tgt, mname, args);
+                continue;
+            }
+            // Pull/blocking traffic (`put`/`get`): the imp's own forwarding
+            // carries a "port not bound" guard keyed on m_imp_list (which the
+            // route-B phaser doesn't populate), so calling the imp directly
+            // would stall — deliver straight to the implementer it wraps.
             let implementer = self
                 .heap
                 .get(tgt)

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -54870,6 +54870,28 @@ impl Simulator {
                             return self.exec_cg_method_call(handle, method_name, args);
                         }
                         if handle < self.heap.len() && self.heap[handle].is_some() {
+                            // TLM intercept: statement-level obj.connect()/write()
+                            // flattens to Ident([obj, method]) and never reaches the
+                            // MemberAccess intercept above — mirror it here.
+                            if real_uvm {
+                                if method_name == "connect" {
+                                    let tgt = args
+                                        .first()
+                                        .map(|a| self.eval_expr(a).to_u64().unwrap_or(0) as usize)
+                                        .unwrap_or(0);
+                                    if tgt != 0 {
+                                        self.tlm_connections
+                                            .entry(handle)
+                                            .or_default()
+                                            .push(tgt);
+                                    }
+                                    // fall through to execute the real connect() body
+                                } else if matches!(method_name.as_str(), "write" | "put") {
+                                    if self.tlm_deliver(handle, method_name, args) {
+                                        return Value::zero(32);
+                                    }
+                                }
+                            }
                             return self.exec_method_call(handle, method_name, args);
                         }
                     }

--- a/tests/uvm/analysis_imp_decl_test.sv
+++ b/tests/uvm/analysis_imp_decl_test.sv
@@ -1,0 +1,40 @@
+// Regression for uvm_analysis_imp_decl write routing.
+//
+// tlm_deliver previously shortcut directly to implementer.write(), which is a
+// no-op for imp_decl subscribers (their write() forwards to write_in/write_out).
+// Fix: tlm_deliver calls imp.write() so the imp's own SV method dispatches to
+// the correct suffixed method on the implementer.
+//
+// Run with PURE_SV_LRM=0 so uses_real_uvm() is true and TLM interception
+// is active.
+`include "uvm_mock.svh"
+
+module top;
+  import uvm_pkg::*;
+
+  class scoreboard;
+    int n_in, n_out;
+    function void write_in(int t);  n_in++;  endfunction
+    function void write_out(int t); n_out++; endfunction
+  endclass
+
+  initial begin
+    automatic scoreboard scb = new;
+    automatic uvm_analysis_imp_in  #(int, scoreboard) imp_in  = new("imp_in",  scb);
+    automatic uvm_analysis_imp_out #(int, scoreboard) imp_out = new("imp_out", scb);
+    automatic uvm_analysis_port #(int) in_ap  = new("in_ap");
+    automatic uvm_analysis_port #(int) out_ap = new("out_ap");
+
+    in_ap.connect(imp_in);
+    out_ap.connect(imp_out);
+
+    in_ap.write(7);
+    in_ap.write(8);
+    out_ap.write(9);
+
+    if (scb.n_in !== 2 || scb.n_out !== 1)
+      $display("TEST_FAIL: n_in=%0d (exp 2) n_out=%0d (exp 1)", scb.n_in, scb.n_out);
+    else
+      $display("TEST_PASS");
+  end
+endmodule

--- a/tests/uvm/uvm_mock.svh
+++ b/tests/uvm/uvm_mock.svh
@@ -47,6 +47,44 @@ package uvm_pkg;
     endfunction
   endclass
 
+  // Needed so uses_real_uvm() returns true when PURE_SV_LRM=0.
+  class uvm_objection;
+  endclass
+
+  // TLM analysis port: connect() and write() are intercepted by xezim's
+  // tlm_deliver shim when uses_real_uvm() is true (PURE_SV_LRM=0).
+  class uvm_analysis_port #(type T = int);
+    string name;
+    function new(string n, uvm_component parent = null); name = n; endfunction
+    function void connect(/* imp */ imp); endfunction
+    function void write(T t); endfunction
+  endclass
+
+  // Plain analysis imp (no suffix): write() forwards to m_imp.write().
+  class uvm_analysis_imp #(type T = int, type IMP = int);
+    string name;
+    IMP m_imp;
+    function new(string n, IMP imp); name = n; m_imp = imp; endfunction
+    function void write(T t); m_imp.write(t); endfunction
+  endclass
+
+  // uvm_analysis_imp_decl(_in) / (_out): write() dispatches to the suffixed
+  // method on the subscriber so xezim's tlm_deliver can call imp.write()
+  // and still reach write_in() / write_out() on the implementer.
+  class uvm_analysis_imp_in #(type T = int, type IMP = int);
+    string name;
+    IMP m_imp;
+    function new(string n, IMP imp); name = n; m_imp = imp; endfunction
+    function void write(T t); m_imp.write_in(t); endfunction
+  endclass
+
+  class uvm_analysis_imp_out #(type T = int, type IMP = int);
+    string name;
+    IMP m_imp;
+    function new(string n, IMP imp); name = n; m_imp = imp; endfunction
+    function void write(T t); m_imp.write_out(t); endfunction
+  endclass
+
   class uvm_root extends uvm_component;
     uvm_component test_inst;
 

--- a/tests/uvm_integration_tests.rs
+++ b/tests/uvm_integration_tests.rs
@@ -1,4 +1,6 @@
 use std::fs;
+use std::path::Path;
+use std::process::Command;
 use xezim::*;
 
 #[test]
@@ -37,6 +39,32 @@ fn test_uvm_mock() {
     );
 
     assert!(res.is_ok(), "UVM Mock test failed: {:?}", res.err());
+}
+
+/// `uvm_analysis_imp_decl`-style routing: `in_ap.write(7)` must reach
+/// `scb.write_in()`, not `scb.write()`. Requires `PURE_SV_LRM=0` so TLM
+/// interception is active. Regression for the flat-ident dispatch bug where
+/// statement-position `obj.connect(p)` never reached the TLM intercept.
+#[test]
+fn test_uvm_analysis_imp_decl() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let sv_file = Path::new(manifest_dir).join("tests/uvm/analysis_imp_decl_test.sv");
+    let inc_dir = Path::new(manifest_dir).join("tests/uvm");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xezim"))
+        .env("PURE_SV_LRM", "0")
+        .arg("-I")
+        .arg(inc_dir.to_str().unwrap())
+        .arg(sv_file.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("TEST_PASS") && !stdout.contains("TEST_FAIL"),
+        "analysis_imp_decl routing test failed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
 }
 
 // Real uvm-1.2 package: elaborates cleanly and the run_test/coreservice/


### PR DESCRIPTION
Statement-position method calls like `ap.connect(imp)` and `ap.write(x)` flatten to a 2-segment hierarchical `Ident([ap, method])` in the AST. The TLM intercept block — which records `connect` connections and routes `write`/`put` via `tlm_deliver` — is guarded on `ExprKind::MemberAccess`, so the flat-ident parse shape silently bypassed it: `tlm_connections` was never populated and analysis traffic was never routed to subscribers.

Fix: mirror the `connect`/`write`/`put` interception in the 2-segment-ident dispatch path, just before the `exec_method_call` fallthrough.

**Reproducer:** `tests/uvm/analysis_imp_decl_test.sv` — a scoreboard with `write_in`/`write_out` methods connected via two `uvm_analysis_imp_decl`-style imps. Before fix: `n_in=0, n_out=0`. After: `n_in=2, n_out=1`.

Run with `PURE_SV_LRM=0` (enables TLM interception). Regression test in `test_uvm_analysis_imp_decl` (`tests/uvm_integration_tests.rs`).