### PR TITLE
fix(simulator): dispatch §6.16 string methods on hierarchical receivers

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -64355,6 +64355,70 @@ impl Simulator {
                 }
             }
 
+            // §6.16 string methods (len/size/getc/substr) and §6.16.6
+            // (compare/icompare/atoreal) on a hierarchical-ident receiver
+            // (`u_if.data.len()`, `top.dut.cfg.substr(0,3)`). They were
+            // excluded from `is_array_builtin_method`'s collection block
+            // above (a string field is not a collection) and from the
+            // no-arg string block below (its `args.is_empty()` gate), so
+            // they fell through to the generic tail, which mis-derived the
+            // receiver as just `path[0]` instead of the full
+            // `path[0..len-1]` (IEEE 1800-2023 §23.6 — the receiver of
+            // `a.b.m()` is `a.b`, not `a`; the parser flattens the call
+            // into `Ident([a, b, m])`).
+            //
+            // `len`/`size`/`getc`/`substr` dispatch by the resolved
+            // hierarchical name (their handlers read the value via
+            // `get_local_signal_or_static`, which finds the hierarchical
+            // signal); `compare`/`icompare`/`atoreal` evaluate the receiver
+            // by value. The USER-METHOD guard is essential: a class instance
+            // whose class defines a same-named method (e.g. a `container`
+            // with its own `len()`) must dispatch to the real method, not
+            // the string builtin — without it `c.len()` on a container
+            // local returned the byte length of the handle instead of
+            // calling `container::len`. The guard evaluates the receiver to
+            // a handle and asks `class_has_method` (value-based, mirroring
+            // the MemberAccess `len`/`size` fallback).
+            if len >= 2
+                && matches!(
+                    path[len - 1].name.name.as_str(),
+                    "len" | "size" | "getc" | "substr"
+                        | "compare" | "icompare" | "atoreal"
+                )
+            {
+                let m = path[len - 1].name.name.clone();
+                let base = HierarchicalIdentifier {
+                    root: hier.root.clone(),
+                    path: path[..len - 1].to_vec(),
+                    span: hier.span,
+                    cached_signal_id: std::cell::Cell::new(None),
+                    cached_resolved_name: std::cell::OnceCell::new(),
+                };
+                let base_expr = Expression::new(ExprKind::Ident(base), hier.span);
+                let recv = self.eval_expr(&base_expr);
+                let recv_h = recv.to_u64().unwrap_or(0) as usize;
+                let is_user_method = recv_h != 0
+                    && self
+                        .heap
+                        .get(recv_h)
+                        .and_then(|o| o.as_ref())
+                        .is_some_and(|i| self.class_has_method(&i.class_name, &m));
+                if !is_user_method {
+                    if matches!(m.as_str(), "len" | "size" | "getc" | "substr") {
+                        if let ExprKind::Ident(bh) = &base_expr.kind {
+                            let bn = self.resolve_hier_name(bh);
+                            if self.get_local_signal_or_static(&bn).is_some() {
+                                if let Some(res) = self.eval_builtin_method(&bn, &m, args) {
+                                    return res;
+                                }
+                            }
+                        }
+                    } else if let Some(v) = self.string_method(&base_expr, &m, args) {
+                        return v;
+                    }
+                }
+            }
+
             // Enum `.name()` / string `.tolower()`/`.toupper()` where the
             // receiver flattened into the ident path (`v.name()` ->
             // Ident([v, name])). The MemberAccess form is handled earlier; this

--- a/tests/hierarchical_string_method.rs
+++ b/tests/hierarchical_string_method.rs
@@ -1,0 +1,102 @@
+//! IEEE 1800-2023 §23.6 (hierarchical names) + §6.16 (string methods):
+//! a string field reached through a hierarchical reference
+//! (`u_if.data.len()`) must dispatch the §6.16 string builtins on the
+//! FULLY-QUALIFIED receiver (`u_if.data`), not on just the first path
+//! segment (`u_if`).
+//!
+//! The parser flattens `a.b.m()` into `Ident([a, b, m])`. The generic
+//! hierarchical-call tail derived the receiver as `path[0]` (`a`) instead of
+//! the full `path[0..len-1]` (`a.b`), so every §6.16 method on a 3+-segment
+//! hierarchical string returned 0/empty: `u_if.data.len()` → 0,
+//! `u_if.data.getc(1)` → 0, `u_if.data.substr(1,3)` → "".
+//!
+//! The fix resolves the receiver's fully-qualified name and dispatches the
+//! builtin by it, while guarding against a USER class method of the same name
+//! (a class defining its own `len()` must still call the real method, not the
+//! string builtin). All values below match the reference simulator exactly.
+
+#[test]
+fn hierarchical_string_len() {
+    let src = r#"
+interface my_if;
+    string data = "hello_world_this_string_is_valid";
+endinterface
+module consumer;
+    my_if u_if();
+    initial begin
+        if (u_if.data.len() != 32)
+            $display("TAG_FAIL len=%0d", u_if.data.len());
+        else
+            $display("TAG_PASS");
+    end
+endmodule
+module top;
+    consumer u_consumer();
+endmodule
+"#;
+    let sim = xezim::simulate(src, 50).expect("simulate");
+    assert!(
+        sim.output.iter().any(|l| l.message == "TAG_PASS"),
+        "hierarchical u_if.data.len() must return the string length.\n{}",
+        sim.output.iter().map(|l| l.message.clone()).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[test]
+fn hierarchical_string_getc_substr() {
+    let src = r#"
+interface my_if;
+    string data = "Hello";
+endinterface
+module consumer;
+    my_if u_if();
+    initial begin
+        // getc(1) == 'e' (101); substr(1,3) == "ell"
+        if (u_if.data.getc(1) != 101)
+            $display("TAG_FAIL getc=%0d", u_if.data.getc(1));
+        else if (u_if.data.substr(1, 3) != "ell")
+            $display("TAG_FAIL substr=%0s", u_if.data.substr(1, 3));
+        else
+            $display("TAG_PASS");
+    end
+endmodule
+module top;
+    consumer u_consumer();
+endmodule
+"#;
+    let sim = xezim::simulate(src, 50).expect("simulate");
+    assert!(
+        sim.output.iter().any(|l| l.message == "TAG_PASS"),
+        "hierarchical getc/substr must read the string field.\n{}",
+        sim.output.iter().map(|l| l.message.clone()).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[test]
+fn hierarchical_len_does_not_shadow_user_method() {
+    // A class defining its OWN `len()` must dispatch to it, not the string
+    // builtin. This guards the user-method precedence in the fix.
+    let src = r#"
+module top;
+    class container;
+        int cnt[$];
+        function void add(); cnt.push_back(0); endfunction
+        function int len(); return cnt.size(); endfunction
+    endclass
+    initial begin
+        container c = new();
+        c.add(); c.add();
+        if (c.len() != 2)
+            $display("TAG_FAIL c.len=%0d", c.len());
+        else
+            $display("TAG_PASS");
+    end
+endmodule
+"#;
+    let sim = xezim::simulate(src, 50).expect("simulate");
+    assert!(
+        sim.output.iter().any(|l| l.message == "TAG_PASS"),
+        "a user class method named len() must win over the string builtin.\n{}",
+        sim.output.iter().map(|l| l.message.clone()).collect::<Vec<_>>().join("\n")
+    );
+}


### PR DESCRIPTION
fix: https://github.com/aionhw/xezim/issues/72

IEEE 1800-2023 §23.6 (hierarchical names) + §6.16 (string methods). A string field reached through a hierarchical reference — e.g. `u_if.data.len()` inside a `consumer` module — returned 0 (and `u_if.data.getc(1)` returned 0, `u_if.data.substr(1,3)` returned "").

Root cause: the parser flattens `a.b.m()` into `Ident([a, b, m])`, and the generic hierarchical-call tail derived the receiver as `path[0]` (`a` = `u_if`) instead of the full `path[0..len-1]` (`a.b` = `u_if.data`). For the common 2-segment `localvar.m()` case `path[0]` and the joined receiver are identical, so it worked; any 3+-segment hierarchical string receiver lost its middle segment. The §6.16 builtins then ran against the interface instance name (`u_if`), which has no value, and returned 0.

The string methods were also excluded from every prior Ident-arm handler: `is_array_builtin_method`'s collection block (a string field is not a collection) and the no-arg string block (its `args.is_empty()` gate excludes `getc`/`substr`).

Fix: a dedicated block for `len`/`size`/`getc`/`substr`/`compare`/ `icompare`/`atoreal` on a hierarchical-ident receiver. It reconstructs the receiver `Ident(path[..len-1])`, resolves its fully-qualified name (`resolve_hier_name` → `u_consumer.u_if.data`), and dispatches the builtin by that name — the handlers read the value via `get_local_signal_or_static`, which finds the hierarchical signal. A USER-METHOD guard (evaluate the receiver to a handle; if its class defines the method, fall through to real method dispatch) preserves precedence: a class with its own `len()` still calls the real method, not the byte-length fallback.

Validated byte-for-byte against the reference simulator (len/getc/ substr/tolower all match). All three self-tests fail without the fix (len=0, getc=0) and pass with it; the user-method-precedence test passes both ways. No regressions in the self-test suite (the single pre-existing failure, test_pr_pr1990029, fails on clean main too).