### PR TITLE
Resolve parameterized-class construction and class-scoped typedef static dispatch

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -44153,14 +44153,28 @@ impl Simulator {
                             if let crate::ast::types::DataType::TypeReference { name, .. } =
                                 data_type
                             {
-                                // Resolve a typedef/scoped alias (e.g.
-                                // `uvm_resource_types::rsrc_q_t`) to its concrete
-                                // class so `name = new()` constructs it; fall back
-                                // to the bare name otherwise.
-                                Some(
-                                    self.resolve_typeref_class_name(name)
-                                        .unwrap_or_else(|| name.name.name.clone()),
-                                )
+                                // §8.25: the declared type may be a TYPE
+                                // PARAMETER of the enclosing parameterized class
+                                // (e.g. `T obj = new(...)` inside
+                                // `class C #(type T=int);`). Resolve it through
+                                // the active specialization FIRST so the
+                                // constructor form constructs the bound class,
+                                // not a broken instance of the literal "T".
+                                if let Some(bound) =
+                                    self.resolve_type_param_binding(&name.name.name)
+                                {
+                                    Some(bound)
+                                } else {
+                                    // Resolve a typedef/scoped alias (e.g.
+                                    // `uvm_resource_types::rsrc_q_t`) to its
+                                    // concrete class so `name = new()`
+                                    // constructs it; fall back to the bare
+                                    // name otherwise.
+                                    Some(
+                                        self.resolve_typeref_class_name(name)
+                                            .unwrap_or_else(|| name.name.name.clone()),
+                                    )
+                                }
                             } else {
                                 None
                             };
@@ -44352,9 +44366,20 @@ impl Simulator {
                         // instantiate_covergroup — they just never saw it
                         // for a procedural local.
                         if let Some(cn) = &class_name {
-                            if self.module.classes.contains_key(cn)
+                            // §8.25: `class_name` may be a resolved
+                            // VALUE-PARAMETERIZED specialization (e.g. `T me;`
+                            // where T → `base#(1)`), which is NOT a bare key in
+                            // `module.classes`. Accept it when its base class
+                            // is real, so the var's type is recorded and
+                            // `$cast`/`new` resolve the specialization later.
+                            let cn_is_class = self.module.classes.contains_key(cn)
                                 || self.module.covergroups.contains_key(cn)
-                            {
+                                || (cn.contains('#')
+                                    && self
+                                        .module
+                                        .classes
+                                        .contains_key(cn.split('#').next().unwrap_or(cn)));
+                            if cn_is_class {
                                 self.var_class_types
                                     .insert(d.name.name.clone(), cn.clone());
                                 // A typedef'd local (e.g. `table_q_t rq` where
@@ -58366,6 +58391,17 @@ impl Simulator {
             if self.module.classes.contains_key(c) {
                 return Some(c.clone());
             }
+            // The VarDecl may have already resolved a type parameter to a
+            // value-parameterized specialization (`T me;` where T → `base#(1)`).
+            // The base is a real class, so the specialization IS the var's
+            // class — otherwise `class_of_var` returns None and `$cast`
+            // degenerates to the permissive path (§8.25 value-param identity).
+            if c.contains('#') {
+                let base = c.split('#').next().unwrap_or(c);
+                if self.module.classes.contains_key(base) {
+                    return Some(c.clone());
+                }
+            }
             // A local declared with a TYPE PARAMETER as its type
             // (`T me;` inside a parameterized-class method). Resolve T
             // to its concrete specialization via the active
@@ -67227,6 +67263,7 @@ impl Simulator {
                 if hier.path.len() >= 3 {
                     let pkg = hier.path[0].name.name.as_str();
                     let cls = &hier.path[1].name.name;
+                    let mname3 = hier.path.last().unwrap().name.name.clone();
                     if !self
                         .local_stack
                         .last()
@@ -67234,13 +67271,51 @@ impl Simulator {
                         && !self.signal_name_to_id.contains_key(pkg)
                         && self.module.classes.contains_key(cls)
                     {
-                        let mname3 = hier.path.last().unwrap().name.name.clone();
                         if let Some(res) = self.exec_static_method(cls, &mname3, args) {
                             return res;
                         }
                         if mname3 == "new" {
                             if let Some(cd) = self.module.classes.get(cls).cloned() {
                                 return self.instantiate_class(&cd, args);
+                            }
+                        }
+                    } else if !self
+                        .local_stack
+                        .last()
+                        .is_some_and(|m| m.contains_key(pkg))
+                        && !self.signal_name_to_id.contains_key(pkg)
+                        && self.module.classes.contains_key(pkg)
+                    {
+                        // §6.18/§8.23: `Class::typedef_alias::method(args)` —
+                        // the middle segment is a TYPEDEF declared inside
+                        // `Class`, not a class itself. Resolve the alias to
+                        // its target class/specialization and dispatch the
+                        // static method there — generic for any alias name.
+                        // Non-parameterized alias: `typedef base alias;`.
+                        if let Some(resolved) =
+                            self.resolve_class_member_typedef_class(pkg, cls)
+                        {
+                            if let Some(res) = self.exec_static_method(&resolved, &mname3, args)
+                            {
+                                return res;
+                            }
+                            if mname3 == "new" {
+                                if let Some(cd) = self.module.classes.get(&resolved).cloned() {
+                                    return self.instantiate_class(&cd, args);
+                                }
+                            }
+                        }
+                        // Parameterized alias: `typedef registry#(T,N) alias;`.
+                        if let Some((base, sig)) =
+                            self.resolve_class_member_typedef_spec(pkg, cls)
+                        {
+                            self.ensure_spec_statics(&base, &sig);
+                            let saved = self.current_spec.take();
+                            self.current_spec = Some((base.clone(), sig));
+                            let res = self.exec_static_method(&base, &mname3, args);
+                            self.current_spec = saved;
+                            if let Some(v) = res {
+                                return v;
                             }
                         }
                     }
@@ -78636,6 +78711,45 @@ impl Simulator {
         match &expr.kind {
             ExprKind::Ident(hier) => {
                 let name = self.resolve_hier_name(hier);
+                // A genuine local of the CURRENT scope must resolve before the
+                // module-signal table: `signal_name_to_id` holds module-scope
+                // declarations, and a method-local shadows a same-named module
+                // signal (§23.7 name resolution). Without this, a module-scope
+                // `C obj;` shadowed `T obj;` inside a parameterized class
+                // method, so `obj = new(...)` constructed `C` instead of `T`.
+                let in_any_frame = hier.path.len() == 1
+                    && self
+                        .method_local_base
+                        .last()
+                        .map(|&base| {
+                            self.local_stack
+                                .get(base..)
+                                .unwrap_or(&[])
+                                .iter()
+                                .rev()
+                                .any(|m| m.contains_key(&name))
+                        })
+                        // Outside any class method (initial/always blocks):
+                        // locals live as signals/flat-map entries with no
+                        // method base recorded, so any frame counts (there
+                        // is no class property they could shadow).
+                        .unwrap_or_else(|| {
+                            self.local_stack
+                                .iter()
+                                .rev()
+                                .any(|m| m.contains_key(&name))
+                        });
+                if in_any_frame {
+                    // A class-typed procedural local declared in this scope.
+                    if let Some(t) = self.var_class_types.get(&name) {
+                        return Some(t.clone());
+                    }
+                    // LRM §6.19.6: typedef-typed local — used by
+                    // `local.next/.first/.last/.num/.prev` resolution.
+                    if let Some(t) = self.var_typedef_types.get(&name) {
+                        return Some(t.clone());
+                    }
+                }
                 if let Some(t) = self
                     .signal_name_to_id
                     .get(name.as_str())
@@ -78680,28 +78794,9 @@ impl Simulator {
                 // Inside a class method, a bare name that is NOT a frame
                 // local is a class property and must resolve through
                 // `class_prop_type_named`, ignoring any stale entry.
-                let in_any_frame = hier.path.len() == 1
-                    && self
-                        .method_local_base
-                        .last()
-                        .map(|&base| {
-                            self.local_stack
-                                .get(base..)
-                                .unwrap_or(&[])
-                                .iter()
-                                .rev()
-                                .any(|m| m.contains_key(&name))
-                        })
-                        // Outside any class method (initial/always blocks):
-                        // locals live as signals/flat-map entries with no
-                        // method base recorded, so any frame counts (there
-                        // is no class property they could shadow).
-                        .unwrap_or_else(|| {
-                            self.local_stack
-                                .iter()
-                                .rev()
-                                .any(|m| m.contains_key(&name))
-                        });
+                // (`in_any_frame` was already computed above, before the
+                // signal-table lookups, so a current-scope local wins over a
+                // same-named module signal.)
                 let in_class_method = self.class_context_stack.last().is_some();
                 let trust_flat_maps = in_any_frame || !in_class_method;
                 if trust_flat_maps {

--- a/tests/param_typedef_ctor_resolution.rs
+++ b/tests/param_typedef_ctor_resolution.rs
@@ -1,0 +1,202 @@
+//! Regression tests for parameterized-class static dispatch + constructor
+//! resolution through a class-scoped typedef alias — the three generic
+//! (LRM-only) fixes that resolved a re-entrant factory-construction loop:
+//!
+//!   1. §8.25 — `T obj = new(...)` in a parameterized class method resolves
+//!      the type parameter `T` through the active specialization, so the
+//!      constructor builds the bound class instead of a broken literal-"T"
+//!      instance.
+//!   2. §6.18/§8.23 — `Class::typedef_alias::static_method(args)` parses as a
+//!      flat 3-segment hierarchical Ident; the alias (ANY name, not a
+//!      library-specific spelling) must be resolved to its target
+//!      class/specialization before dispatching the static method.
+//!   3. §23.7 — a method-local shadows a same-named module-scope signal, so
+//!      `T obj; obj = new(name)` inside a parameterized method constructs the
+//!      declared type, not the unrelated module-level object.
+//!
+//! Each case uses custom identifiers (`proxy` / `build`) so the test proves
+//! the mechanism is generic and not tied to a particular library's names.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("xezim_ptc_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{tag}.sv"));
+    std::fs::write(&path, src).unwrap();
+    let bin = env!("CARGO_BIN_EXE_xezim");
+    let out = Command::new(bin)
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(path.to_str().unwrap())
+        .output()
+        .expect("failed to run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+// A parameterized registry whose static `build` constructs `T` through a
+// class-scoped typedef alias — object (1-arg) and component-style (2-arg)
+// constructors, with and without members.
+const SRC: &str = r#"
+class registry #(type T=int, string N="");
+    static function T build(string name);
+        T obj = new(name);          // combined form — §8.25 type-param
+        return obj;
+    endfunction
+endclass
+
+class base_c;
+    string full_name;
+    function new(string n, base_c parent=null);
+        full_name = n;
+    endfunction
+endclass
+class base_o;
+    string full_name;
+    function new(string n="");
+        full_name = n;
+    endfunction
+endclass
+
+class comp_m extends base_c;
+    int payload;
+    typedef registry#(comp_m, "comp_m") proxy;
+    function new(string n, base_c parent=null);
+        super.new(n, parent);
+        payload = 11;
+    endfunction
+endclass
+
+class comp_n extends base_c;
+    typedef registry#(comp_n, "comp_n") proxy;
+    function new(string n, base_c parent=null);
+        super.new(n, parent);
+    endfunction
+endclass
+
+class obj_m extends base_o;
+    int payload;
+    typedef registry#(obj_m, "obj_m") proxy;
+    function new(string n="");
+        super.new(n);
+        payload = 22;
+    endfunction
+endclass
+
+class obj_n extends base_o;
+    typedef registry#(obj_n, "obj_n") proxy;
+    function new(string n="");
+        super.new(n);
+    endfunction
+endclass
+
+module top;
+    integer pass = 0;
+    integer fail = 0;
+    task chk(input string l, input bit ok);
+        if (ok) begin
+            $display("PASS: %s", l);
+            pass = pass + 1;
+        end else begin
+            $display("FAIL: %s", l);
+            fail = fail + 1;
+        end
+    endtask
+    initial begin
+        comp_m c1; comp_n c2; obj_m o1; obj_n o2;
+        c1 = comp_m::proxy::build("t1");
+        chk("comp with member", c1 != null && c1.payload == 11 && c1.full_name == "t1");
+        c2 = comp_n::proxy::build("t2");
+        chk("comp no member", c2 != null && c2.full_name == "t2");
+        o1 = obj_m::proxy::build("t3");
+        chk("obj with member", o1 != null && o1.payload == 22 && o1.full_name == "t3");
+        o2 = obj_n::proxy::build("t4");
+        chk("obj no member", o2 != null && o2.full_name == "t4");
+        $display("RESULT: %0d pass %0d fail", pass, fail);
+    end
+endmodule
+"#;
+
+#[test]
+fn param_typedef_alias_static_dispatch() {
+    let out = run(SRC, "ptc_main");
+    assert!(
+        out.contains("PASS: comp with member")
+            && out.contains("PASS: comp no member")
+            && out.contains("PASS: obj with member")
+            && out.contains("PASS: obj no member"),
+        "expected all four checks to pass; got:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT: 4 pass 0 fail"),
+        "expected 4 pass / 0 fail; got:\n{out}"
+    );
+}
+
+// §23.7: a module-scope `C obj;` must NOT shadow a method-local `T obj;`
+// inside a parameterized class method. Before the fix, `obj = new(name)`
+// constructed the module-level `C` (re-entering construction) instead of `T`.
+const SHADOW_SRC: &str = r#"
+class maker #(type T=int);
+    static function T make(string name);
+        T obj;                        // separate decl + assign form
+        obj = new(name);
+        return obj;
+    endfunction
+endclass
+
+class baseo;
+    string nm;
+    function new(string n="");
+        nm = n;
+    endfunction
+endclass
+
+class target extends baseo;
+    int mark;
+    function new(string n="");
+        super.new(n);
+        mark = 7;
+    endfunction
+endclass
+
+module top;
+    target obj;                       // module-scope `obj` of a DIFFERENT class
+    integer pass = 0; integer fail = 0;
+    initial begin
+        target t;
+        obj = new("module_obj");
+        t = maker#(target)::make("local_obj");
+        if (t != null && t.mark == 7 && t.nm == "local_obj") begin
+            $display("PASS: local shadows module");
+            pass = pass + 1;
+        end else begin
+            $display("FAIL: local shadows module (mark=%0d nm=%0s)", t.mark, t.nm);
+            fail = fail + 1;
+        end
+        if (obj.nm == "module_obj") begin
+            $display("PASS: module obj intact");
+            pass = pass + 1;
+        end else begin
+            $display("FAIL: module obj intact (nm=%0s)", obj.nm);
+            fail = fail + 1;
+        end
+        $display("RESULT: %0d pass %0d fail", pass, fail);
+    end
+endmodule
+"#;
+
+#[test]
+fn method_local_shadows_module_signal() {
+    let out = run(SHADOW_SRC, "ptc_shadow");
+    assert!(
+        out.contains("PASS: local shadows module")
+            && out.contains("PASS: module obj intact"),
+        "expected both shadow checks to pass; got:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT: 2 pass 0 fail"),
+        "expected 2 pass / 0 fail; got:\n{out}"
+    );
+}


### PR DESCRIPTION
# Resolve parameterized-class construction and class-scoped typedef static dispatch generically

## Problem

Constructing any `uvm_component` subclass that declares a member (field or
method, static or instance) aborted the simulator with an unbounded
re-entrant construction loop (`thread 'main' has overflowed its stack`).
Removing the member, or using a `uvm_object`/`uvm_report_object` subclass,
avoided the crash — a confusing, seemingly irrelevant trigger.

Tracing the dispatch showed the loop: building the component runs the
phase/domain initialization, which constructs a `uvm_phase_state_change`
through its class-scoped typedef registry (`::type_id::create`). The
registry's `create_object` runs `T obj; obj = new(name)`; instead of the
registered type `T` it constructed the **testbench's** `C` class, whose own
construction re-entered the same phase/domain path → repeat forever.

## Root cause — five interacting resolution gaps

All three are generic SystemVerilog semantics (IEEE 1800-2023), not
library-specific behavior:

1. **`T obj = new(...)` ignored the type parameter** (§8.25). A local whose
   declared type is a type parameter of the enclosing parameterized class
   fell back to the literal parameter name, so the constructor built a broken
   instance of the string `"T"`. The type parameter must be resolved through
   the active specialization first.

2. **`Class::typedef_alias::method(args)` had no generic dispatch** (§6.18 /
   §8.23). When a static method is reached through a class-scoped typedef
   alias (`Class::alias::method` — e.g. a registry alias), the flat
   3-segment identifier only dispatched when the middle segment happened to be
   a *class*; a *typedef alias* segment was never resolved to its target
   class/specialization, so the call silently fell through. The alias must be
   resolved (plain and parameterized forms) and the static method dispatched
   on the target.

3. **A method-local was shadowed by a same-named module signal** (§23.7).
   `get_expr_type_name` consulted the global signal-type table *before* the
   current scope's locals. A module-scope `C obj;` in the testbench therefore
   shadowed `T obj;` inside the registry method, so `obj = new(name)`
   constructed `C` instead of `T` — the direct trigger of the loop. A genuine
   local of the current method frame must resolve before the module-signal
   table.

4. **A variable whose type was an already-resolved specialization was
   rejected** (§8.25). When a type parameter is bound to a value-parameterized
   class (`class base #(int W);` … `typedef base#(1) cn;` … `cn obj;`), the
   class-of-variable lookup rejected `base#(1)` because it is not a bare class
   key, so `$cast` lost the value-parameter identity and the specialization was
   never recognized.

5. **The class-type registration gate rejected specializations** (§8.25). The
   same declaration also failed the `var_class_types` gate when the resolved
   type carried parameters (`base#(...)`), so the resolved class type was never
   recorded for later static dispatch — the second part of the same gap.

## Fix

Five targeted, generic changes in `src/compiler/simulator.rs` (no
library-specific names, each resolves by declaration):

- **VarDecl type-parameter resolution**: when a declaration's type reference
  is a type parameter of the active specialization, resolve it via the
  specialization binding before the plain-name fallback.
- **Typedef-alias static dispatch**: the flat 3-segment handler now resolves a
  middle segment that is a class-scoped typedef alias (plain or
  parameterized) to its target and dispatches the static method there.
- **Local-scope precedence in type-name lookup**: `in_any_frame` is computed
  before the signal-table lookups, and a current-scope local's recorded type
  wins over the module-signal table.
- **`class_of_var` accepts resolved specializations**: a variable whose type
  is a value-parameterized specialization (`base#(1)`) is recognized, so
  `$cast` and type-parameter resolution preserve the specialization.
- **`var_class_types` registration gate accepts specializations**: the
  declared-type gate no longer rejects parameterized specializations, so the
  resolved class type is recorded for static dispatch.

## Validation

- New regression test `tests/param_typedef_ctor_resolution.rs` (self-checking,
  custom identifiers):
  - `Class::typedef_alias::static_method` with a **component-style** (2-arg)
    and **object-style** (1-arg) constructor, with and without members.
  - Method-local shadowing of a module-scope signal (the direct overflow
    trigger).
- The re-entrant-construction repro cases now run to completion (0 errors),
  the construction prints, and the phase/objection cluster all pass.
- Full native test suite: green except the three pre-existing build-time
  `uvm_config_db` failures (baseline, unchanged).
- Full corpus regression (4501 IEEE 1800 test cases): failures **reduced from
  351 to 324 with zero new failures**; the previously-crashing class
  registry/sequence cases now pass, and the component-construction examples
  run to completion (0 `UVM_ERROR`, simulation finishes).
