### PR TITLE
test: make uvm_config_db tests self-contained (fix CI red on main)

### DIFF
--- a/tests/classes/uvm_config_db_tests.rs
+++ b/tests/classes/uvm_config_db_tests.rs
@@ -1,29 +1,46 @@
 //! config_db scope-matching regression tests (pure in-process).
 //!
-//! These exercise xezim's `uvm_config_db#(T)::set/get` interception (scope-aware
-//! instance-name matching, wildcards, and misses) by running the real 1800.2
-//! UVM library *in-process* via `simulate_multi` — no subprocess, no hardcoded
-//! binary path, no reference simulator. Reference comparison belongs in the dev
-//! workflow, not in the committed suite.
+//! These exercise xezim's `uvm_config_db#(T)::set/get` interception
+//! (scope-aware instance-name matching, wildcards, and misses) entirely
+//! in-process via `simulate_multi` — no subprocess, no external UVM library,
+//! no reference simulator.
+//!
+//! The interception fires once the parser resolves `uvm_config_db#(int)` as a
+//! defined parameterized class, so instead of pulling in the full 1800.2
+//! library (which is not shipped in this repo and is absent in CI) we prepend a
+//! minimal stub: a `uvm_component` shell that answers `get_full_name()`, and a
+//! `uvm_config_db` shell whose empty static methods xezim intercepts by name.
 
 use xezim::simulate_multi;
 
-/// Run a UVM-using top module in-process and return the joined `$display`
-/// output. The real UVM library (`uvm_pkg.sv`) is compiled alongside the test
-/// source, with its `src/` on the include path — exactly the command shape the
-/// CLI uses, but without shelling out.
-fn run_in_process(src: &str) -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    let uvm_dir = format!("{}/../1800.2-2020.3.1", manifest);
-    let uvm_pkg = std::fs::read_to_string(format!("{}/src/uvm_pkg.sv", uvm_dir))
-        .expect("could not read 1800.2 uvm_pkg.sv");
-    let inc = format!("{}/src", uvm_dir);
+/// Minimal UVM class shells. `uvm_config_db`'s static `set`/`get`/`exists`
+/// bodies are empty because xezim intercepts them by class name — the real
+/// logic lives in `Simulator::exec_config_db`. `uvm_component` only needs to
+/// satisfy `get_full_name()` for the interception's scope resolution.
+const STUB: &str = r#"
+class uvm_component;
+  string m_name;
+  function new(string name); m_name = name; endfunction
+  function string get_full_name(); return m_name; endfunction
+endclass
 
+class uvm_config_db #(type T = int);
+  static function void set(uvm_component cntxt, string inst, string field, T val); endfunction
+  static function bit get(uvm_component cntxt, string inst, string field, ref T val); endfunction
+  static function bit exists(uvm_component cntxt, string inst, string field); endfunction
+endclass
+"#;
+
+/// Run `src` (a `module top`) in-process and return the joined `$display`
+/// output. The UVM stub is prepended so the interception recognises
+/// `uvm_config_db`; no external files are read.
+fn run_in_process(src: &str) -> String {
+    let full = format!("{}\n{}", STUB, src);
     let sim = simulate_multi(
-        &[uvm_pkg, src.to_string()],
+        &[full],
         50_000,
         Some("top"),
-        &[inc],
+        &[],
         &[],
         None,
         false,
@@ -59,9 +76,7 @@ fn run_in_process(src: &str) -> String {
 #[test]
 fn test_config_db_inst_name() {
     let src = r#"
-`include "uvm_macros.svh"
 module top;
-  import uvm_pkg::*;
   initial begin
     #1;
     uvm_config_db#(int)::set(null, "tc", "my_int", 42);
@@ -98,9 +113,7 @@ endmodule
 #[test]
 fn test_config_db_wildcard() {
     let src = r#"
-`include "uvm_macros.svh"
 module top;
-  import uvm_pkg::*;
   initial begin
     #1;
     uvm_config_db#(int)::set(null, "*", "my_int", 99);
@@ -130,9 +143,7 @@ endmodule
 #[test]
 fn test_config_db_hit_wildcard_and_miss() {
     let src = r#"
-`include "uvm_macros.svh"
 module top;
-  import uvm_pkg::*;
   initial begin
     #1;
     uvm_config_db#(int)::set(null, "tc", "my_int", 42);


### PR DESCRIPTION
The three `uvm_config_db` regression tests read the 1800.2 UVM library from a sibling directory (`../1800.2-2020.3.1/src/uvm_pkg.sv`) at runtime via `CARGO_MANIFEST_DIR`. That directory is **not part of this repo** and is absent in CI, so every CI run panicked with:

```
could not read 1800.2 uvm_pkg.sv: Os { code: 2, kind: NotFound, ... }
```

This makes `main` itself red — confirmed on upstream run [#31040830437](https://github.com/aionhw/xezim/actions/runs/31040830437) (`17f2fc4`), where `test_config_db_inst_name`, `test_config_db_wildcard`, and `test_config_db_hit_wildcard_and_miss` all fail identically.

## Root cause

The interception these tests exercise (`Simulator::exec_config_db` — scope-aware instance-name matching, wildcards, and misses) fires once the parser resolves `uvm_config_db#(int)` as a **defined parameterized class**. It does not need the real library — just the class definition (plus `uvm_component` so `get_full_name()` resolves). The full 1800.2 library was pulled in only to obtain those class shells.

## Fix

Replace the external `read_to_string` with a 12-line inline stub prepended to each test source:

```systemverilog
class uvm_component;
  string m_name;
  function new(string name); m_name = name; endfunction
  function string get_full_name(); return m_name; endfunction
endclass

class uvm_config_db #(type T = int);
  static function void set(uvm_component cntxt, string inst, string field, T val); endfunction
  static function bit get(uvm_component cntxt, string inst, string field, ref T val); endfunction
  static function bit exists(uvm_component cntxt, string inst, string field); endfunction
endclass
```

The `set`/`get`/`exists` bodies are empty because xezim intercepts them by class name — the real logic lives in `exec_config_db`, which is what the tests validate.

## Coverage (unchanged)

All three behaviors still asserted:
- `test_config_db_inst_name` — specific-instance `set`→`get` hit; wildcard `"*"` set → any-getter hit
- `test_config_db_wildcard` — wildcard set→get **value round-trip** (the `ref` arg is written)
- `test_config_db_hit_wildcard_and_miss` — specific hit + wildcard hit + **miss** (unset field returns 0)

## Side benefit

Each test now runs in ~**0.01s** instead of ~**4.8s** — it no longer compiles the 50k-line UVM library. That is 3 × 4.8s = ~14s cut from every CI run.

## Validation

- All 3 tests pass in-process (0 failed).
- No external file references remain (`grep` for `1800.2`, `uvm_pkg`, `read_to_string`, `CARGO_MANIFEST_DIR` returns nothing functional).

Unrelated to the struct-property work in #82; this is a standalone CI fix for `main`.