### PR TITLE
sim: avoid i128 underflow for unsigned rand domains at width 127

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -56068,7 +56068,10 @@ impl Simulator {
                                             (1i128 << ww.saturating_sub(1)) - 1,
                                         )
                                     } else {
-                                        (0, (1i128 << ww) - 1)
+                                        // §18.4: unsigned domain [0, 2^ww - 1];
+                                        // for ww == 127 that bound is i128::MAX,
+                                        // and the shift form underflows in debug.
+                                        (0, if ww == 127 { i128::MAX } else { (1i128 << ww) - 1 })
                                     };
                                     cvar_names.push(name.clone());
                                     cvar_dom.push((lo, hi));
@@ -75821,7 +75824,12 @@ impl Simulator {
                         (1i128 << (w.saturating_sub(1))) - 1,
                     )
                 } else {
-                    (0, (1i128 << w) - 1)
+                    // §18.4: an unsigned domain of width w spans [0, 2^w - 1].
+                    // For w == 127 that bound is i128::MAX, but the
+                    // shift-then-subtract form underflows: `1i128 << 127` is
+                    // i128::MIN (bit 127 is the sign bit), so `- 1` overflows
+                    // in debug builds. Use the constant directly.
+                    (0, if w == 127 { i128::MAX } else { (1i128 << w) - 1 })
                 };
                 let (mut lo, mut hi) = (dlo, dhi);
                 let mut bounded = false;
@@ -76227,7 +76235,10 @@ impl Simulator {
                             (1i128 << ww.saturating_sub(1)) - 1,
                         )
                     } else {
-                        (0, (1i128 << ww) - 1)
+                        // §18.4: unsigned domain [0, 2^ww - 1]; for ww == 127
+                        // that bound is i128::MAX, and the shift form
+                        // underflows in debug builds.
+                        (0, if ww == 127 { i128::MAX } else { (1i128 << ww) - 1 })
                     };
                     cvar_names.push(name.clone());
                     cvar_dom.push((lo, hi));


### PR DESCRIPTION
## Summary

An unsigned random field of width ≥ 128 has its solve domain clamped to `[0, 2^127 - 1]`. The upper bound was computed as `(1i128 << 127) - 1`, but `1i128 << 127` is `i128::MIN` (bit 127 is the sign bit), so the subtract overflows. In debug builds this panics during `randomize()`; the existing test `randomize_fills_fields_wider_than_64_bits` exercises exactly this and fails in CI.

## Change

Use `i128::MAX` directly for the width-127 bound — which is precisely `2^127 - 1`, the intended domain — instead of the shift-then-subtract form. Two other identical sites in the solver are updated the same way.

## Verification

- The wide-rand regression test now passes in a debug build (the configuration that previously panicked).
- The classes and misc suites show no new failures relative to current main.

## Notes

Per IEEE 1800 §18.4, an unsigned domain of width *w* spans `[0, 2^w - 1]`; for *w* = 127 that equals `i128::MAX`.