### PR TITLE
fix: avoid i128 underflow for unsigned rand domains at width 127

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -56419,7 +56419,10 @@ impl Simulator {
                                             (1i128 << ww.saturating_sub(1)) - 1,
                                         )
                                     } else {
-                                        (0, (1i128 << ww) - 1)
+                                        // §18.4: unsigned domain [0, 2^ww - 1];
+                                        // for ww == 127 that bound is i128::MAX,
+                                        // and the shift form underflows in debug.
+                                        (0, if ww == 127 { i128::MAX } else { (1i128 << ww) - 1 })
                                     };
                                     cvar_names.push(name.clone());
                                     cvar_dom.push((lo, hi));
@@ -76812,7 +76815,12 @@ impl Simulator {
                         (1i128 << (w.saturating_sub(1))) - 1,
                     )
                 } else {
-                    (0, (1i128 << w) - 1)
+                    // §18.4: an unsigned domain of width w spans [0, 2^w - 1].
+                    // For w == 127 that bound is i128::MAX, but the
+                    // shift-then-subtract form underflows: `1i128 << 127` is
+                    // i128::MIN (bit 127 is the sign bit), so `- 1` overflows
+                    // in debug builds. Use the constant directly.
+                    (0, if w == 127 { i128::MAX } else { (1i128 << w) - 1 })
                 };
                 let (mut lo, mut hi) = (dlo, dhi);
                 let mut bounded = false;
@@ -77218,7 +77226,10 @@ impl Simulator {
                             (1i128 << ww.saturating_sub(1)) - 1,
                         )
                     } else {
-                        (0, (1i128 << ww) - 1)
+                        // §18.4: unsigned domain [0, 2^ww - 1]; for ww == 127
+                        // that bound is i128::MAX, and the shift form
+                        // underflows in debug builds.
+                        (0, if ww == 127 { i128::MAX } else { (1i128 << ww) - 1 })
                     };
                     cvar_names.push(name.clone());
                     cvar_dom.push((lo, hi));


### PR DESCRIPTION
# fix: avoid i128 underflow for unsigned rand domains at width 127

## Problem

An unsigned rand field of width >= 128 clamps its domain to
`[0, 2^127 - 1]` per §18.4. The upper bound was computed as
`(1i128 << 127) - 1`, which underflows in debug builds: `1i128 << 127`
sets the sign bit (i128::MIN), so `- 1` wraps to i128::MAX - 1 but
panics as an arithmetic underflow. This caused the native test
`randomize_fills_fields_wider_than_64_bits` to fail on the CI.

## Fix

At the three domain-computation sites, use `i128::MAX` directly when
`width == 127`. The bound is mathematically correct (`2^127 - 1 ==
i128::MAX`) and avoids the underflow.

## Verification

The previously failing test `randomize_fills_fields_wider_than_64_bits`
now passes. All other tests unchanged — same failure set as upstream
minus the one fixed test.

```diff
- test result: FAILED. 585 passed; 1 failed; 9 ignored
+ test result: ok. 586 passed; 0 failed; 9 ignored
```
