### PR TITLE
fix: preserve virtual-interface bindings through uvm_resource_db operations

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -49023,11 +49023,11 @@ impl Simulator {
                 } else {
                     None
                 };
-                if let Some(cn) = cls_name {
+                if let Some(cn) = &cls_name {
                     let cls_has_vif = self
                         .module
                         .classes
-                        .get(&cn)
+                        .get(cn)
                         .map(|c| c.virtual_iface_properties.contains_key(segs[0]))
                         .unwrap_or(false);
                     if cls_has_vif {
@@ -65300,14 +65300,38 @@ impl Simulator {
         method_name: &str,
         args: &[Expression],
     ) -> Option<Value> {
-        // Intercept uvm_config_db static methods to ensure config_db works correctly
-        // This is needed because the regular method call interception doesn't catch
-        // static method calls like `uvm_config_db#(int)::set(...)`
-        if class_name == "uvm_config_db" {
+        // Intercept uvm_config_db / uvm_resource_db static methods so the
+        // config DB keeps working correctly — and, critically, so a
+        // virtual-interface reference written into a class property through
+        // `::set` + `::get`/`::read_by_name` records a virtual_iface_bindings
+        // entry. Per IEEE 1800-2017 §25.9 an interface reference is a binding
+        // to a structural interface instance, not a value copy; the inout-arg
+        // write-back of the genuine UVM `read()` path bypasses
+        // `try_bind_virtual_iface`, so a later `@(posedge vif.clk)` resolved
+        // to an EMPTY sensitivity and fired immediately (§9.4.2) — the
+        // zero-delay storm in passive-monitor forever loops. The scope-aware
+        // store keeps set/get round-trips distinct per UVM scope.
+        if class_name == "uvm_config_db" || class_name == "uvm_resource_db" {
+            // uvm_resource_db uses `(scope, name, val[, accessor])` while
+            // uvm_config_db uses `(cntxt, inst_name, field_name, value)`.
+            // Normalize resource_db's layout to the config_db one —
+            // `(scope, name, name, val)` — so `exec_config_db`'s field key
+            // (arg[2]) and value destination (arg[3]) line up.
+            let norm = |a: &[Expression]| -> Vec<Expression> {
+                if class_name != "uvm_resource_db" || a.len() < 3 {
+                    return a.to_vec();
+                }
+                let mut v = a.to_vec();
+                let val = v[2].clone();
+                v[2] = v[1].clone(); // field_name = name
+                v.push(val);         // value = val
+                v
+            };
             match method_name {
                 "set" => {
                     // Store in xezim's config DB (handles scope matching correctly)
-                    let result = self.exec_config_db("set", args);
+                    let ga = norm(args);
+                    let result = self.exec_config_db("set", &ga);
                     // Also call UVM's implementation to populate resource pool
                     // (bypass our interception to avoid infinite recursion)
                     let saved = self.pure_sv_lrm;
@@ -65318,7 +65342,24 @@ impl Simulator {
                 }
                 "get" | "exists" => {
                     // Try xezim's config DB first
-                    let xezim_result = self.exec_config_db(method_name, args);
+                    let ga = norm(args);
+                    let xezim_result = self.exec_config_db(method_name, &ga);
+                    if xezim_result.to_u64().unwrap_or(0) == 1 {
+                        return Some(xezim_result);
+                    }
+                    // Fall back to UVM's resource pool
+                    let saved = self.pure_sv_lrm;
+                    self.pure_sv_lrm = true;
+                    let result = self.exec_static_method_internal(class_name, method_name, args);
+                    self.pure_sv_lrm = saved;
+                    return result;
+                }
+                "read_by_name" => {
+                    // Same `(scope, name, val)` layout as set: route through
+                    // exec_config_db's get so the destination vif property gets
+                    // BOTH its value and its virtual-interface binding.
+                    let ga = norm(args);
+                    let xezim_result = self.exec_config_db("get", &ga);
                     if xezim_result.to_u64().unwrap_or(0) == 1 {
                         return Some(xezim_result);
                     }


### PR DESCRIPTION
# Fix: Preserve Virtual-Interface Bindings Across Resource Database Operations

## Summary
This change ensures virtual-interface bindings are correctly recorded when interface references flow through the UVM resource database (`uvm_resource_db#(T)::set/get/read_by_name`), preventing zero-delay event storms in sensitivity lists that reference virtual-interface clock/reset members.

## Problem
When a virtual interface is stored via `uvm_resource_db#(T)::set` and later retrieved through `::get` or `::read_by_name`, the destination class property received the interface reference **without recording the binding** in the virtual-interface binding registry (per IEEE 1800-2017 §25.8, an interface reference is a binding to a structural interface instance, not a value copy).

### Root Cause
The Accellera UVM 1.2 reference implementation of `read_by_name` writes the result to an `inout` argument. This `inout`-argument write-back path bypasses the binding logic that normally intercepts direct blocking assignments to virtual-interface properties. Consequently:

- The virtual-interface property holds a valid interface reference
- But the binding registry has no entry for that class property
- A subsequent `@(posedge vif.clk)` event control resolves to an **empty sensitivity list**
- Per IEEE 1800-2017 §9.4.2, an empty sensitivity list behaves as `@*` — firing immediately
- A `forever repeat(N) @(posedge vif.clk)` loop then spins at time 0, consuming all simulation cycles without advancing time

### Affected Constructs
Per Accellera UVM 1.2 Class Reference and IEEE 1800-2017:
- `uvm_resource_db#(T)::set(scope, name, val)` — resource write
- `uvm_resource_db#(T)::get(scope, name, ref val)` — resource read
- `uvm_resource_db#(T)::read_by_name(scope, name, ref val)` — named resource read
- Virtual-interface class properties declared `virtual <iface_t> vif` (IEEE 1800-2017 §25.8)
- Event controls on virtual-interface members: `@(posedge vif.clk)`, `@(negedge vif.rst_n)`

## Solution
Route `uvm_resource_db` static method calls through the same scope-aware resource/config store used by `uvm_config_db`, with argument-layout normalization. The resource database `(scope, name, val[, accessor])` layout is normalized to the config database `(cntxt, inst_name, field_name, value)` layout so field keys and value destinations align:

| Method | Resource DB Layout | Normalized Layout |
|--------|--------------------|-------------------|
| `set` | `(scope, name, val)` | `(scope, name, name, val)` |
| `get` / `exists` | `(scope, name, ref val)` | `(scope, name, name, ref val)` |
| `read_by_name` | `(scope, name, ref val)` | `(scope, name, name, ref val)` |

This reuses the existing scope-aware store which already:
- Records virtual-interface bindings on `set` by resolving the interface reference (IEEE 1800-2017 §25.9)
- Propagates bindings to destination class properties on `get`/`read_by_name`
- Maintains per-UVM-scope isolation so independent environments with the same field name do not collide

### Code Changes
**File: `src/compiler/simulator.rs`**

1. **`exec_static_method()`** — Extended interception from `uvm_config_db` to also cover `uvm_resource_db`, with an argument-normalization closure that maps the resource database layout onto the config database layout before dispatch.
2. **`resolve_hier_name()`** — Adjusted a borrow (`&cls_name` instead of consuming the value) so the class-name lookup used for virtual-interface dispatch does not move the binding.

## Validation
The change was validated across a comprehensive set of UVM 1.2-compliant environments exercising:
- **Active agents** — drivers/sequencers synchronizing on `@(posedge vif.clk)`
- **Passive agents** — monitors using `forever repeat(N) @(posedge vif.clk)` (previously stalled at time 0)
- **Resource database round-trips** — `uvm_resource_db#(T)::set` + `::read_by_name` into virtual-interface properties
- **Config database round-trips** — `uvm_config_db#(T)::set` + `::get` for interface references and configuration objects
- **Scoreboard / monitor / sequencer environments** with virtual-interface clocking
- **Sequence execution** with phase objection management
- **Parameterized virtual interfaces** via typedef specialization (IEEE 1800-2017 §25.8, §6.20)

### Before Fix
- Passive-monitor environment: **zero-delay storm** — simulation never advanced past time 0; clock edges never observed
- Active-agent environment: **passed** — driver activity masked the empty sensitivity by chance

### After Fix
- **All environments complete simulation** at the expected time points
- Virtual-interface clock edges correctly suspend and resume waiting processes
- No regressions in config/resource database semantics
- Per-scope isolation preserved for multi-environment configurations

## SystemVerilog LRM References (IEEE 1800-2017)
- **§9.4.2** — Event control; empty sensitivity list semantics
- **§25.8** — Virtual interface declaration and binding propagation
- **§25.9** — Virtual interface assignment semantics
- **§14.3** — Clocking block event substitution (`@(cb)` synchronizes to the block clock)

## Accellera UVM References
- **UVM 1.2 Class Reference** — `uvm_resource_db#(T)::set/get/read_by_name`
- **UVM 1.2 Class Reference** — `uvm_config_db#(T)::set/get`
- **UVM 1.2 User Guide** — Configuring virtual interfaces through the resource/config database

## Impact
- **No functional change** to environments that already completed correctly
- **Fixes** zero-delay spin in any component that retrieves a virtual interface through the resource database
- **No API changes** — internal dispatch routing only
- **Negligible performance cost** — argument normalization is a single-vector rearrangement

## Testing Notes
Validation covered:
- Virtual-interface clock/reset event controls in `always`/`forever` blocks
- Parameterized virtual interfaces through typedef specialization
- Multi-agent environments sharing a resource database scope
- Phase-objection-managed sequences synchronized on monitor events
- Config and resource database coexistence without field-name collision
