### PR TITLE
docs: add AGENTS.md and CLAUDE.md developer guides

### DIFF
--- a/.claude/skills/xezim-development/SKILL.md
+++ b/.claude/skills/xezim-development/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: xezim-development
+description: Use when developing, fixing, or adding tests to the xezim SystemVerilog interpreter — wrong simulation results, elaboration or compile errors, RNG or determinism work, or adding a regression test.
+---
+
+# xezim-development
+
+## Overview
+xezim is a SystemVerilog **bytecode interpreter** (Rust). Behavior is validated through its simulator, not library unit tests. The pipeline: source → parser (`../xezim-core/xezim-parser`) → elaboration (`../xezim-core/src/elaborate.rs`) → bytecode (`src/compiler/bytecode.rs`) → VM (`src/compiler/simulator.rs`).
+
+Core principle: reproduce a wrong behavior as a **minimal SV case in the simulator first**, then fix the file that owns the symptom, then add a regression test that cites its LRM §.
+
+## When to Use
+- Any bug fix or feature in xezim (or the `xezim-core` path dependency)
+- A simulation result looks wrong, or a compile/elaboration error appears
+- Adding a regression test
+- RNG, solver, or any determinism-affecting change
+
+When NOT: parser/elaborator work with no observable sim difference still needs the `xezim` suite to verify — the library's tests run through this repo.
+
+## Workflow: Fix a bug
+1. **Reproduce.** Write the minimal `.sv` and run `cargo run --release -- repro.sv --no-cache`. Confirm the wrong value.
+2. **Add a failing regression test** (next section).
+3. **Fix the file that owns the symptom** (Quick Reference).
+4. **Verify:** the test group, then `cargo test --no-fail-fast` and `cargo test --features jit --no-fail-fast` (what CI runs).
+
+## Workflow: Add a regression test
+A test only runs if it is registered. **Both steps are required:**
+
+1. **Create** `tests/<group>/<name>.rs` (topic dir under `tests/{classes,collections,gates,hierarchy,misc,scheduling,strings,types}/`).
+2. **Register** it in the group root `tests/<group>.rs` with one line: `#[path = "group/name.rs"] mod name;`
+
+Test body:
+
+```rust
+//! §8.25 — doc comment cites the LRM section and the bug/fix.
+#[test]
+fn whole_struct_write_reaches_nested_interface_member() {
+    let sim = xezim::simulate(SV_SOURCE, 100).expect("simulate failed");
+    assert_eq!(u(&sim, "tb.sig"), 42, "expected value from the bug report");
+}
+```
+
+Run just this test: `cargo test --test <group> <name>`.
+
+## Quick Reference
+| Need | Do |
+|---|---|
+| Wrong sim value / race | fix `src/compiler/simulator.rs` |
+| Parse or elaboration error | fix `../xezim-core` (`xezim-parser` / `elaborate.rs`) |
+| `$display` formatting | fix `xezim-core/src/stdout_sink.rs` |
+| Debug a behavior change | always pass `--no-cache` (stale cached artifact) |
+| Watch a long run | `XEZIM_PROGRESS=N` |
+| RNG stream | `+seed=<n>`; `+seed=random` opts into entropy |
+
+## Common Mistakes
+| Mistake | Fix |
+|---|---|
+| Test file added but never runs | missing `#[path]` mod line in the group root — silent no-op |
+| Sim result unchanged after your fix | stale design cache — rerun with `--no-cache` |
+| Edited the VM for a parse error | symptom lives in xezim-core, not `simulator.rs` |
+| No LRM § in the test doc comment | every regression test cites its section |
+| `std::collections::HashMap` or a 2nd allocator | use `xezim_core::hasher::{HashMap,HashSet}`; never another `#[global_allocator]` |
+| Bare `println!` in sim code | use `log_println`/`log_eprintln` (feeds `--log`) |
+
+## Red Flags — STOP
+- You added a test file but no group-root `#[path]` line → the test never runs
+- A result changed and you didn't re-run with `--no-cache`
+- You changed serialized fields in `xezim-core` without bumping `XEZIM_BYTECODE_MAGIC`
+- An RNG/solver change you didn't re-verify for determinism (`+seed=1` twice, diff output)
+
+## Resources
+- `AGENTS.md` — canonical repo guide (all conventions, CLI flags, invariants)
+- `../xezim-core/AGENTS.md` — shared library (parser/elaboration) guide
+- `docs/dev/*`, `README.md` — deeper design and feature notes

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,9 @@ uvm-1.2/
 *.vcd
 uvm-2017-1.0.so
 uvm-2020.3.1.so
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 scratchpad/
 
 # editor cruft

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ and match the surrounding style.
 `--dump-files-list`/`--dump-merged-sv` to understand a multi-file build;
 `XEZIM_PROGRESS=5` to watch a long run; the stall report (names the parked
 processes and the signal that should have woken them) for hangs; `XEZIM_STUCK_CLOCK`
-for frozen-clock churn; `--max-time` to bound a runaway; `--threads` to toggle the
+for frozen-clock churn; `--max-time` to bound a runaway; (or use `scripts/dev/quick-repro.sh '…snippet…'` to iterate without writing a repo file) `--threads` to toggle the
 parallel edge path (also `XEZIM_NO_PARALLEL=1` / `XEZIM_FORCE_PARALLEL=1`).
 
 **Add a feature**: parse it in `xezim-parser` → elaborate/type it in `elaborate.rs`
@@ -261,6 +261,7 @@ document any new flag/env knob in the README tables.
 
 ## Resources
 
+- `docs/dev/README.md` — developer documentation: architecture, debugging, testing, gotchas
 - `README.md` — features, CLI reference, compliance, build/run, module-timescale extension
 - `docs/uvm-guide.md` — running UVM 1800.2-2017 / 2020.3.1 testbenches
 - `docs/dpi-guide.md` — compiling + loading DPI-C libraries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,270 @@
+# xezim — Development Guide for AI Coding Agents
+
+This file is read by coding agents (Claude Code, OpenAI Codex, Cursor, Copilot) at
+the start of every session. It is **operational**: what to build, how to build it,
+what must never break. Deep design notes stay in `docs/` — this file points to them
+and stays general. If a fact here conflicts with the code, the code (and the test
+suite) is the source of truth; fix this file.
+
+## What this is
+
+`xezim` is a **SystemVerilog bytecode interpreter** written in Rust (~100k LOC in
+`src/`). It parses IEEE 1800-2023 (opt back to 2017 with `--sv2017`), elaborates,
+and simulates combinational + sequential logic, classes/UVM, constraints, DPI/VPI,
+SDF, and VCD/XTrace/FST dumps. It is **not** a compiler — a separate crate
+(`xezim-b`) does ahead-of-time native compilation and is out of scope here.
+
+Parsing, elaboration, and the 4-state value model live in the **sibling repo
+`xezim-core`** (a path dependency at `../xezim-core`, not a submodule — clone both
+repos into the same parent). The simulator runs **elaborated** designs: most bug
+fixes land either in `xezim-core` (parser/elaboration) or in `src/compiler/simulator.rs`
+(the VM). Read `../xezim-core/AGENTS.md` before editing that repo.
+
+## Repository map
+
+```
+src/main.rs                     CLI: arg parsing, --parse/--compile/--simulate/--preprocess,
+                                memory watchdog, design-cache dir, -l log redirect
+src/lib.rs                      Public API; test entry points xezim::simulate / simulate_multi;
+                                content-addressed design cache
+src/compiler/simulator.rs       85k LOC event-driven VM — the file most fixes touch
+src/compiler/bytecode.rs        Bytecode IR + compiler (flat Insn[] array, no pointer-chasing)
+src/compiler/arena.rs           Bump allocator for per-tick/per-block allocations
+src/compiler/dispatch.rs        Direct-threaded dispatch table (POC; partial integration)
+src/compiler/soa.rs             Structure-of-Arrays signal-table layout (perf work)
+src/compiler/jit.rs             Optional cranelift JIT (--features jit), falls back to interpreter
+src/compiler/fst_sink.rs        FST waveform sink
+src/intra_delay.rs              Pre-parse rewrite of `lhs = #d rhs` (see Gotchas)
+src/should_fail_lint.rs         Additive second-pass error lint for sv-tests negative cases
+src/multikernel.rs              EXPERIMENTAL per-LP PDES skeleton — not production
+tests/                          8 integration groups + subprocess runners + compliance suites
+bench/                          Cross-platform benchmarks (B1/B2/B3/B5, run_bench.sh)
+simtest/                        XuanTie C910/C906 real-RTL workloads (need external setup)
+dpi/                            Spike DPI shim example
+include/                        Minimal svdpi.h / vpi_user.h / veriuser.h + UVM DPI driver
+examples/                       Small .sv / .v demos (start here to try the tool)
+scripts/                        UVM DPI build (Makefile), installers
+docs/                           uvm-guide.md, dpi-guide.md, perf notes, design notes
+reports/                        sv-tests compliance HTML/CSV and UVM reference reports
+```
+
+## Build
+
+Prerequisite: `xezim-core` checked out at `../xezim-core` (Cargo references it via
+`path = "../xezim-core"`). Toolchain: Rust **1.85.1** MSRV, edition 2024.
+
+```bash
+cargo build                        # debug
+cargo build --release              # optimized; binary at target/release/xezim
+cargo build --release --features jit    # optional cranelift JIT (CI tests this config)
+cargo build --release --profile release-lto --bin xezim   # interpreter-only fat-LTO
+```
+
+`.cargo/config.toml` sets `RUST_MIN_STACK = 33554432` for cargo-invoked processes:
+deeply recursive SystemVerilog expressions (concat chains, nested member access,
+recursive functions, parameterized class construction) overflow the Rust default
+2 MiB stack in debug builds. **Never lower this.** Release builds use smaller frames.
+
+## Run
+
+```bash
+cargo run --release -- examples/full_adder.sv          # simulate (default mode)
+./target/release/xezim <sources...> [plusargs] [options]
+```
+
+Modes: `--parse` (lex+parse only), `--compile` (parse+elaborate), `--simulate`
+(default), `--preprocess` (emit expanded text). Common flags:
+
+| Flag | Purpose |
+|---|---|
+| `-s <module>` | Top module; repeat for multiple roots (`-s hdl_top -s hvl_top`) |
+| `-I<dir>` / `-D<MACRO>[=val]` | Include dir / preprocessor define |
+| `--dpi-lib <path>` | Load a DPI-C shared library (repeatable) |
+| `--vpi-lib <path>` (`-m`) | Load a VPI module; run its `vlog_startup_routines` |
+| `--sdf <file>` + `--sdf-{min,typ,max}` | Annotate standard delays |
+| `--max-time <N>[ps\|ns\|us\|ms\|s]` | Stop after N ns (unit default ns); cap in whole ns |
+| `+<plusarg>` | Passed to `$value$plusargs` / `$test$plusargs` |
+| `+seed=<n>` | RNG seed (default 1 ⇒ reproducible; `+seed=random` opts into entropy) |
+| `--module-timescale [mods=]<u>/<p>` | Timescale for modules with none (xezim extension) |
+| `--dump-timescales` | Print every module's resolved timescale, then run |
+| `--dump-files-list` | Print resolved file list after `-f` expansion, then exit |
+| `--dump-merged-sv <file>` | Write all sources as one self-contained `.sv` |
+| `-l` / `--log <file>` | Redirect stdout+stderr (incl. DPI/VPI C output) to a log |
+| `-v <file>` / `-y <dir>` / `+libext+<ext>+…` | Library files/dirs (IEEE §23.3.2) |
+| `+nospecify` / `+notimingcheck` | Gate-level flags (commercial-compatible) |
+| `--xtrace <file>` / `--xtrace-scope <hier>` | XTrace v1.0 dump (`.zst` ⇒ zstd) |
+| `--sim-debug` / `--verbose` | `[DEBUG]`/`[OPT]` output / per-file compile progress |
+| `--cache-dir <dir>` / `--no-cache` | Select / disable the design cache |
+
+Env knobs (off unless noted): `XEZIM_EVENT_EDGE=1` (skip unchanged flop fires),
+`XEZIM_INIT_ZERO=1` (coerce X-init to 0), `XEZIM_PROGRESS=N` (`[PROGRESS]` every N s),
+`XEZIM_STUCK_CLOCK` (dead-clock watchdog: `warn` default, `abort` for CI),
+`XEZIM_NO_MEM_WATCHDOG=1`, `XEZIM_CACHE_DIR`, `XEZIM_NO_CACHE=1`,
+`XEZIM_COMPILE_PHASES=1`.
+
+## Testing
+
+The suite is the source of truth — the README reports 91.3 % of sv-tests pass
+(4354/4768) and this suite must stay green. **CI runs `cargo test` in two feature
+configs** (`test.yml`: `cargo test --no-fail-fast` then
+`cargo test --features jit --no-fail-fast`); `msrv.yml` runs `cargo msrv verify`.
+
+```bash
+cargo test                       # everything (the full run takes a while)
+cargo test --test classes        # one integration group
+cargo test --test classes class_property   # name filter within a group
+cargo test --features jit        # JIT config (CI requirement)
+```
+
+Two harness styles — use the one that fits:
+
+1. **In-process groups** (the norm for new features/bug fixes). `tests/` has 8
+   group roots — `classes.rs`, `collections.rs`, `gates.rs`, `hierarchy.rs`,
+   `misc.rs`, `scheduling.rs`, `strings.rs`, `types.rs` — each a `#[path = "…"]`
+   module list over one topic directory (~1680 `#[test]` fns total). A test
+   simulates an inline SV source and asserts on final signal values:
+
+   ```rust
+   //! §8.25 — doc comment cites the LRM section and the bug/fix.
+   use xezim::simulate;
+   #[test]
+   fn range_mixing_class_and_scope_parameters_keeps_elaborated_width() {
+       let sim = simulate(SV_SOURCE, 100).expect("simulate failed");
+       assert_eq!(u(&sim, "w_both"), 12, "W+MW-1:0 with W=8, MW=4");
+   }
+   ```
+   Signals are read with `sim.get_signal("tb.sig")` (try both bare and `tb.`
+   prefixed names) → `.to_u64()`. **To add a test: drop the file in the group's
+   directory AND add one `#[path = "group/name.rs"] mod name;` line to the group
+   root** — forgetting the mod line is the classic silent no-op.
+
+2. **Subprocess runners** (`tests/misc/*_runner.rs`): spawn
+   `env!("CARGO_BIN_EXE_xezim")` against `.sv`/`.v` files and assert on output.
+   Markers that matter: positive tests must print `TEST_PASS` (not `TEST_FAIL`) or
+   `PASSED` (not `FAILED`); no output may contain `Parse errors` or
+   `Simulation error`; negative tests must exit non-zero and print `: error:` /
+   `Parse errors` / `Simulation error`. Suites: `prtest` (Icarus `pr*.v`, ~132 of
+   762 wired), `ivtest_*_cluster` (`reject`/`accept` — illegal forms must be
+   REJECTED, legal neighbors must still compile), `lrm_audit*`, `issue30`,
+   `issue_cases`, `sv_compliance` (manifest-driven positive + `tests_negative/`).
+
+Test code conventions: each test's `//!` doc states the LRM § and what it guards;
+assertion messages name the expected value; use the small `u(sim, name)` helper
+pattern where appropriate.
+
+## Architecture & where a symptom lives
+
+Pipeline: source → preprocessor → parser/AST (`xezim-core/xezim-parser`) →
+elaboration (`xezim-core/src/elaborate.rs`) → bytecode compile (`bytecode.rs`) →
+event-driven execution (`simulator.rs`). Key types: `Value`/`LogicBit` (4-state
+0/1/X/Z, width + signedness), `ElaboratedModule`, `Insn`, `Simulator`.
+
+| Symptom | Owner |
+|---|---|
+| Parse/preprocessor errors, AST shape | `xezim-core/xezim-parser` (lexer, preprocessor, parse/, ast/) |
+| Type/width/signedness, parameters, classes, port binding, `should_fail`-style legality | `xezim-core/src/elaborate.rs` |
+| Wrong simulated value, race/timing, event ordering, class/UVM runtime, `randomize`, DPI/VPI, dumping | `src/compiler/simulator.rs` |
+| Compile-time codegen / VM perf | `bytecode.rs`, `dispatch.rs`, `soa.rs`, `jit.rs` |
+| `$display`/formatting output | `xezim-core/src/stdout_sink.rs`, `simulator.rs` |
+
+Subsystems inside `simulator.rs`: Active/NBA/Reactive scheduling regions, comb
+settle iteration, edge dispatch (always_ff/always_latch/@posedge, `iff` guards),
+event/mailbox/semaphore waiters, process control (§9.7), constraint solver,
+coverage/covergroups, SDF delays, VCD/XTrace/FST sinks, plus `pdes_*` (experimental
+parallel, not production). Read `README.md` §Features and the `docs/*` design notes
+before deep work.
+
+## Critical invariants — do not break these
+
+- **Determinism is a hard requirement.** Two runs with identical inputs must be
+  byte-identical. The RNG defaults to seed 1 (`+seed=<n>` for a different stream;
+  `+seed=random` opts into entropy) and hash iteration is deterministic
+  (`xezim_core::hasher::HashMap/HashSet`, fixed ahash seeds). **Never** use
+  `std::collections::HashMap/HashSet` where iteration order can affect observable
+  behavior, and never seed an RNG from entropy by default.
+- **Global allocator**: `mimalloc` is installed in `xezim-core` (its default
+  feature). Rust allows exactly one `#[global_allocator]` per binary — never add
+  another. A downstream crate opting out uses
+  `xezim-core = { path = "../xezim-core", default-features = false }`.
+- **Design cache**: `--simulate` stores a content-addressed elaborated design and
+  reuses it on identical runs; it prints `[CACHE] hit/miss/stored` on stderr. The
+  key covers sources, defines, top, and the executable's own mtime/size, so a local
+  rebuild invalidates it — but use `--no-cache` whenever you are debugging a
+  behavior change you expect to see immediately.
+- **Memory watchdog**: `main.rs` spawns a thread that **SIGKILLs the process** when
+  RSS exceeds 3/4 of system memory (protects against OOM on huge designs). For
+  C910-scale runs set `XEZIM_NO_MEM_WATCHDOG=1`. This is expected behavior, not a
+  crash bug.
+- **intra-assignment delays**: the parser discards `lhs = #d rhs` (§9.4.5), so
+  `src/intra_delay.rs` rewrites the source text into a `$__xz_intra_delay(...)`
+  marker call **before parsing**. Any parser/lexer work must preserve this
+  interplay (the rewrite is applied in `simulate_multi` and the CLI).
+- **`should_fail` lint**: `src/should_fail_lint.rs` is an *additive* second pass
+  that rejects illegal constructs in `--compile` mode for sv-tests negative cases.
+  It must never change clean-design behavior and must stay conservative (validated
+  against a 1005-case static baseline). Add checks there only for definite LRM
+  violations.
+- **Logging**: route output through `log_eprintln`/`log_println` (they feed the
+  `-l` fd-level redirect that captures DPI/VPI C output). Bare `println!`/`eprintln!`
+  bypasses `--log`.
+- **Timescales**: per-module; the simulation tick is the finest declared precision
+  anywhere (down to `fs`); `--max-time` is in ns (independent of tick); `$time`
+  reports ticks. `--module-timescale` only applies to modules with no source-level
+  timescale.
+- **Sibling coordination**: parser/elaboration changes in `../xezim-core` are shared
+  with `xezim-b`. Keep the `xezim::compiler::*` re-export surface stable.
+
+## Coding conventions
+
+snake_case; Rust 2024 edition; MSRV 1.85.1; clippy-clean. Modules carry `//!`
+doc comments. Hard fixes get explanatory comments with **LRM § citations**
+(e.g. `§8.25`) and regression tests referencing the same section. Keep the public
+API minimal — re-exports from `xezim-core` exist so existing `xezim::compiler::…`
+paths keep working; do not remove them. User-facing errors are `Result<_, String>` /
+diagnostic strings; do not panic on user input. Prefer the smallest correct change
+and match the surrounding style.
+
+## Workflows
+
+**Fix a bug**
+1. Write the minimal SV repro and confirm the wrong behavior (`./target/release/xezim repro.sv`).
+2. Add a failing regression test (in-process group preferred; correct group root + `#[path]` mod line).
+3. Fix it in `simulator.rs` or `xezim-core`; keep the fix localized.
+4. `cargo test --test <group> <name>` until green, then the whole group.
+5. Run `cargo test --features jit` for the config CI covers, and re-verify
+   determinism (`+seed=1` twice, diff output) for RNG/solver changes.
+
+**Debug a wrong sim result**: `--sim-debug` and `--verbose` for diagnostics;
+`--dump-files-list`/`--dump-merged-sv` to understand a multi-file build;
+`XEZIM_PROGRESS=5` to watch a long run; the stall report (names the parked
+processes and the signal that should have woken them) for hangs; `XEZIM_STUCK_CLOCK`
+for frozen-clock churn; `--max-time` to bound a runaway; `--threads` to toggle the
+parallel edge path (also `XEZIM_NO_PARALLEL=1` / `XEZIM_FORCE_PARALLEL=1`).
+
+**Add a feature**: parse it in `xezim-parser` → elaborate/type it in `elaborate.rs`
+→ execute it in `simulator.rs` (bytecode only if it must be fast) → add tests →
+document any new flag/env knob in the README tables.
+
+## Before you open a PR
+
+- Regression test added **with an LRM § citation** in its doc comment, wired into
+  the correct group root.
+- `cargo test --no-fail-fast` **and** `cargo test --features jit --no-fail-fast`
+  both green (this is exactly what CI runs — a PR that fails CI here will be
+  rejected).
+- New CLI flag or env var documented in the README tables (and `print_usage`).
+- Determinism preserved; no `std` hash/RNG order leaks.
+- Minimal diff: no unrelated refactors, no dead code added.
+- Run the full suite on one machine before submitting — a few local tests are not
+  enough.
+- If this guide becomes wrong (paths, commands, conventions), fix it in the same PR.
+
+## Resources
+
+- `README.md` — features, CLI reference, compliance, build/run, module-timescale extension
+- `docs/uvm-guide.md` — running UVM 1800.2-2017 / 2020.3.1 testbenches
+- `docs/dpi-guide.md` — compiling + loading DPI-C libraries
+- `docs/ast_shared_stmt_lists_scope.md`, `docs/perf_dump_offload_2026-07-28.md` — design/perf notes
+- `bench/README.md` — benchmark methodology (fix the work, not the time)
+- `reports/sv-tests-compliance.md` — sv-tests pass rates by category
+- `simtest/xuantie_c910/README.md` — real-RTL C910/C906 workloads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+## Claude Code
+
+- Use plan mode for significant or multi-file changes.
+- After a change, run the focused test group before the full suite
+  (`cargo test --test <group> <name>`).
+- If a sim result looks wrong, reproduce it with a minimal SV case before editing.
+- Re-verify determinism (`+seed=1` twice, diff the output) for RNG/solver changes.
+- When behavior is ambiguous, treat the existing test suite as the source of truth.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Current capabilities include:
   custom HDL-backdoor force/release layer, or your own UVM extensions). The
   repo ships minimal `svdpi.h` and `vpi_user.h` so DPI code compiles without a
   vendor install. See [docs/dpi-guide.md](docs/dpi-guide.md).
+* [`docs/dev/README.md`](docs/dev/README.md) — developer documentation (architecture, debugging, testing, gotchas)
 * **Event-control `iff` guards** (LRM §9.4.2.3) — `@(posedge clk iff rst_n)`
   is honored in both procedural `@` waits and edge-sensitive `always` blocks:
   the process resumes only on an edge where the guard holds.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,27 @@
+# Developer Documentation
+
+How an agent or engineer uses these docs. The top-level `AGENTS.md` is the
+canonical guide — this set is the deep dive it points to.
+
+Pick a doc by what you are doing:
+
+| Doc | When to read it |
+|---|---|
+| `architecture.md` | First time in this repo; before adding a feature |
+| `debugging.md` | A simulation gives a wrong result or hangs |
+| `testing.md` | Before writing or running any test |
+| `gotchas.md` | Before editing `src/` or `xezim-core` |
+
+The companion `scripts/dev/` toolbox wraps the common actions:
+
+- `quick-repro.sh '<sv-snippet>' [args…]` — simulate a one-off snippet without
+  writing a repo file.
+- `check-determinism.sh design.sv [args…]` — run twice with the same seed and
+  fail on any drift.
+- `new-test.sh <group> <name>` — scaffold a test and wire its `#[path]` mod line
+  into the group root.
+
+These docs relate to the guides as follows: `AGENTS.md` (top level) is the
+general orientation — what to build and what must never break; `docs/dev/*` is
+the working detail for a specific activity; `../xezim-core/AGENTS.md` covers the
+sibling library (parser/elaboration) that this repo depends on.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,113 @@
+# xezim Architecture
+
+Orientation for a developer (or agent) who has never seen this codebase.
+Complements AGENTS.md — this is the deep-dive it points to.
+
+## 1. The two-crate split
+
+`xezim` is a SystemVerilog **bytecode interpreter** written in Rust. It does not
+own its front end: parsing, elaboration, and the 4-state value model live in the
+sibling `xezim-core` crate at `../xezim-core` (a path dependency, not a
+submodule — clone both repos into the same parent). Within `xezim-core`, the
+parser is the `sv-parser` subcrate at `../xezim-core/xezim-parser`.
+
+Native ahead-of-time compilation is a **separate** crate (`xezim-b`) and is out
+of scope here — this repo simulates elaborated bytecode, it does not compile.
+
+## 2. End-to-end pipeline (source → running simulation)
+
+| Stage | Owner |
+|---|---|
+| Source text | your `.sv`/`.v` files + `-I`/`-D`/`-f` handling |
+| Preprocessor | `xezim-core/xezim-parser/src/preprocessor/` |
+| Parse → AST | `xezim-core/xezim-parser/src/parse/`, `ast/` |
+| Elaboration (types, widths, parameters, classes, ports) | `xezim-core/src/elaborate.rs` (~19k LOC) |
+| Bytecode compile | `src/compiler/bytecode.rs` |
+| Event-driven execution | `src/compiler/simulator.rs` (~85k LOC) |
+
+## 3. Compile modes and what each phase runs
+
+| Mode | Runs |
+|---|---|
+| `--preprocess` | Preprocessor only; emits expanded text |
+| `--parse` | Lex + parse only |
+| `--compile` | Parse + elaborate; reports diagnostics, no simulation |
+| `--simulate` (default) | Parse + elaborate + simulate |
+
+## 4. Central types
+
+| Type | What it is | Where |
+|---|---|---|
+| `Value` / `LogicBit` | 4-state 0/1/X/Z with width + signedness | `xezim-core/src/value.rs` |
+| `ElaboratedModule` | The elaborated design (signals, instances, nets) | `xezim-core/src/elaborate.rs` |
+| `Insn` | Register-based bytecode instruction (24-byte enum) | `src/compiler/bytecode.rs` |
+| `Simulator` | The event-driven VM | `src/compiler/simulator.rs` |
+
+## 5. The scheduling model (Active / NBA / Reactive)
+
+The `simulator.rs` module doc defines three regions:
+
+- **Active** — blocking assigns, continuous assigns, `always_comb`
+- **NBA** — non-blocking assign updates
+- **Reactive** — edge-triggered `always_ff` / `always_latch` blocks (and
+  `@posedge` waits)
+
+This is why a design mixes `=` and `<=` the way it does: blocking work happens
+in the Active region, scheduled NBA updates land in the NBA region, and
+edge-sensitive processes re-trigger in the Reactive region.
+
+## 6. Subsystem → file map
+
+| Subsystem | File |
+|---|---|
+| Event-driven VM | `src/compiler/simulator.rs` |
+| Bytecode IR + compiler | `src/compiler/bytecode.rs` |
+| Direct-threaded dispatch table (POC) | `src/compiler/dispatch.rs` |
+| Per-tick bump allocator | `src/compiler/arena.rs` |
+| Structure-of-Arrays signal layout | `src/compiler/soa.rs` |
+| Optional cranelift JIT (`--features jit`) | `src/compiler/jit.rs` |
+| FST waveform sink | `src/compiler/fst_sink.rs` |
+| Pre-parse intra-assignment-delay rewrite | `src/intra_delay.rs` |
+| Additive negative-case lint | `src/should_fail_lint.rs` |
+| Experimental PDES skeleton (not production) | `src/multikernel.rs` |
+| VCD waveform sink | `xezim-core/src/vcd_sink.rs` |
+| Locked stdout/stderr sink (feeds `-l`) | `xezim-core/src/stdout_sink.rs` |
+| SDF annotation | `xezim-core/src/sdf/` |
+
+## 7. Where each major SystemVerilog feature executes
+
+| Symptom / feature | Owner |
+|---|---|
+| Parse/preprocessor errors, AST shape | `xezim-core/xezim-parser` |
+| Type/width/signedness, parameters, classes, port binding, legality | `xezim-core/src/elaborate.rs` |
+| Wrong simulated value, race/timing, event ordering, class/UVM runtime, `randomize`, DPI/VPI, dumping | `src/compiler/simulator.rs` |
+| Compile-time codegen / VM perf | `bytecode.rs`, `dispatch.rs`, `soa.rs`, `jit.rs` |
+| `$display` / formatting output | `xezim-core/src/stdout_sink.rs`, `simulator.rs` |
+
+## 8. The design cache
+
+`--simulate` stores a content-addressed elaborated design and reuses it on
+identical runs. The key covers sources, defines, top, and the executable's own
+mtime/size. On stderr it prints `[CACHE] hit`, `miss`, `invalid artifact`, or
+`stored`. A cache **hit** skips parse + elaboration entirely, so when you are
+debugging a behavior change you expect to see immediately, pass `--no-cache`.
+Configured in `src/lib.rs` (`DesignCacheConfig`); CLI `--cache-dir` / `--no-cache`.
+
+## 9. Trace it yourself
+
+Run these against any source to watch the pipeline:
+
+```bash
+./target/release/xezim --dump-files-list my.sv        # resolved source list after -f expansion
+./target/release/xezim --dump-merged-sv out.sv my.sv  # all sources merged into one self-contained .sv
+./target/release/xezim --compile my.sv                # stop after elaboration
+./target/release/xezim my.sv                          # run (simulate)
+```
+
+## Further reading
+
+- `docs/dev/debugging.md` — reproduce-first workflow, diagnostic markers, the `XEZIM_*` knobs
+- `docs/dev/testing.md` — test harnesses, how to run and add a test
+- `docs/dev/gotchas.md` — the non-obvious rules (determinism, cache, watchdogs, …)
+- `../xezim-core/AGENTS.md` — the shared library's development guide
+- `README.md` — features, CLI reference, compliance

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -1,0 +1,124 @@
+# Debugging xezim
+
+Reproduce-first workflow, diagnostics, and the runtime knobs.
+
+## 1. Reproduce before you edit
+
+1. Write the **minimal** SV repro: `./target/release/xezim repro.sv` (use
+   `--no-cache` — see §8).
+2. Identify which phase fails (parse / elaborate / simulate, §5).
+3. Fix the file that owns the symptom (§10).
+4. Add a regression test (see `docs/dev/testing.md`) and run it:
+   `cargo test --test <group> <name>`.
+
+If the minimal repro behaves, the bug is elsewhere in the full design — bisect by
+trimming the source or use `--dump-merged-sv` to see what the tool actually sees.
+
+## 2. Diagnostic markers (what each stderr/stdout line means)
+
+| Marker | Meaning |
+|---|---|
+| `: error:` | A user-facing diagnostic (compile/elaboration/simulation error) |
+| `Parse errors` / `Simulation error` | Failure strings the subprocess test runners grep for |
+| `[CACHE] hit` / `miss` / `invalid artifact` / `stored` | Design-cache outcome (`src/lib.rs`) — see §8 |
+| `[PHASE] compilation / simulation / total` | Per-phase timing summary |
+| `[PROF]` | Per-subsystem timing breakdown of the simulation loop |
+| `[EVENT-EDGE]` | Event-driven edge dispatch: armed/skip-mode measurements |
+| `[PROGRESS]` | Periodic progress line, only when `XEZIM_PROGRESS` is set |
+| `[xezim][mem-watchdog]` | RSS exceeded 3/4 of system memory; process killed — see §7 |
+| `[xezim][hang-report]` | On-demand hang report naming parked waiters — see §6 |
+
+## 3. Exit codes and signals
+
+| Code / signal | Meaning |
+|---|---|
+| `0` | Clean run (reached `$finish`) |
+| `1` | Usage, compile, or simulation error |
+| `SIGKILL` | Memory watchdog fired (RSS > 3/4 MemTotal) — not a crash bug |
+| `SIGUSR1` | `kill -USR1 <pid>` on a live run prints the hang report (`install_hang_report_handler`, `simulator.rs:1318`) |
+
+## 4. The XEZIM_* runtime knobs
+
+| Knob | Effect |
+|---|---|
+| `XEZIM_EVENT_EDGE=1` | Skip gateable flop fires when inputs didn't change (perf) |
+| `XEZIM_INIT_ZERO=1` | Coerce X initialization to 0 (also `XEZIM_INIT_ZERO_PATHS`) |
+| `XEZIM_PROGRESS=N` | Emit `[PROGRESS]` every N seconds |
+| `XEZIM_STUCK_CLOCK=off\|warn\|abort` | Dead-clock watchdog: `warn` default, `abort` for CI |
+| `XEZIM_NO_MEM_WATCHDOG=1` | Disable the memory watchdog |
+| `XEZIM_NO_PARALLEL=1` / `XEZIM_FORCE_PARALLEL=1` | Force the edge path sequential / parallel |
+| `XEZIM_NO_CACHE=1` / `XEZIM_CACHE_DIR=<dir>` | Disable / relocate the design cache |
+| `XEZIM_COMPILE_PHASES=1` | Trace compile-phase timing |
+
+## 5. Isolating the failing phase (parse → elaborate → simulate)
+
+Run the same file under each mode; the first one that reports `: error:` owns
+the bug:
+
+```bash
+./target/release/xezim --parse repro.sv
+./target/release/xezim --compile repro.sv
+./target/release/xezim --simulate repro.sv
+```
+
+A parse error points at `xezim-core/xezim-parser`; an elaboration error at
+`xezim-core/src/elaborate.rs`; a wrong simulated value at
+`src/compiler/simulator.rs`.
+
+## 6. Hangs and the stall report
+
+A hung run has two diagnostics:
+
+- **On demand**: `kill -USR1 <pid>` prints a `[xezim][hang-report]` line naming
+  the parked event/condition waiters and the sim time they parked at
+  (`simulator.rs:21013`).
+- **Dead-clock churn**: `XEZIM_STUCK_CLOCK=abort` turns a frozen clock into a
+  hard failure instead of infinite churn.
+
+Bound any suspicious run with `--max-time <N>` so it cannot run away.
+
+## 7. Memory watchdog
+
+`main.rs` spawns a thread that **SIGKILLs the process** when RSS exceeds 3/4 of
+system memory, printing `[xezim][mem-watchdog] … Set XEZIM_NO_MEM_WATCHDOG=1 to
+disable.` This is expected protection against OOM on huge designs, not a crash
+bug — only disable it for known-huge (e.g. C910-scale) runs.
+
+## 8. Design-cache interference
+
+A stale `[CACHE] hit` can mask a change — the cache key covers sources, defines,
+top, and the executable's mtime/size. Pass `--no-cache` whenever you are
+debugging a behavior change you expect to see immediately; a local rebuild
+invalidates cached artifacts automatically.
+
+## 9. Determinism checks
+
+Identical inputs must produce byte-identical output with the same seed
+(`+seed=<n>`, default `1`; `+seed=random` opts into entropy). Verify by running
+the same command twice and diffing:
+
+```bash
+./scripts/dev/check-determinism.sh design.sv +seed=1
+```
+
+See `scripts/dev/check-determinism.sh` and `docs/dev/gotchas.md` §1–2.
+
+## 10. Symptom → owner table
+
+| Symptom | Fix here |
+|---|---|
+| Parse/preprocessor errors, AST shape | `xezim-core/xezim-parser` |
+| Type/width/signedness, parameters, classes, port binding | `xezim-core/src/elaborate.rs` |
+| Wrong simulated value, race/timing, event ordering | `src/compiler/simulator.rs` |
+| Class/UVM runtime, `randomize`, DPI/VPI, dumping | `src/compiler/simulator.rs` |
+| `$display` / formatting output | `xezim-core/src/stdout_sink.rs`, `simulator.rs` |
+| Compile-time codegen / VM perf | `bytecode.rs`, `dispatch.rs`, `soa.rs`, `jit.rs` |
+
+## 11. A worked example (intra-assignment delay)
+
+Consider a symptom in `lhs = #d rhs` (§9.4.5). The parser discards
+intra-assignment timing, so `src/intra_delay.rs` rewrites the source text into a
+`$__xz_intra_delay(...)` marker **before** parsing. A delay bug therefore points
+at that rewrite/execution interplay, not at the parser — if you "fix" the parser
+you will fight the rewrite. This is the kind of non-obvious ownership the
+gotchas doc catalogs (`docs/dev/gotchas.md` §8).

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -1,0 +1,86 @@
+# xezim Gotchas — the rules that are not obvious
+
+Each rule: what to do, why, and the source line proving it.
+
+## 1. Determinism is a hard requirement
+
+The RNG defaults to **seed 1**; `+seed=<n>` selects a different stream and
+`+seed=random` opts into entropy (usage text, `src/main.rs`). Two runs with
+identical inputs and seed must be **byte-identical**. Never seed from entropy by
+default. After any RNG/solver change, re-verify with the same command twice and
+`diff` the output.
+
+## 2. The deterministic hasher
+
+Use `xezim_core::hasher::{HashMap, HashSet}` — they hold fixed ahash seeds
+(`DeterministicState`, `../xezim-core/src/lib.rs:35`). **Never** use
+`std::collections::HashMap/HashSet` where iteration order can affect observable
+behavior; unordered traversal would break determinism run-to-run.
+
+## 3. Only one global allocator (mimalloc)
+
+mimalloc is installed by `xezim-core`'s default feature
+(`../xezim-core/Cargo.toml:28`). Rust allows exactly one `#[global_allocator]`
+per binary — **never add another**. A downstream crate opts out with
+`xezim-core = { path = "../xezim-core", default-features = false }`.
+
+## 4. 32 MiB minimum stack
+
+`.cargo/config.toml:8` sets `RUST_MIN_STACK = "33554432"` for cargo-invoked
+processes. Deeply recursive SV expressions (concat chains, nested member access,
+recursive functions, parameterized class construction) overflow the Rust default
+2 MiB stack in debug builds. **Never lower this.**
+
+## 5. Design cache
+
+`[CACHE] hit|miss` on stderr (`src/lib.rs:183,225`); the key includes the
+executable's mtime/size, so a local rebuild invalidates cached artifacts
+automatically. While iterating on a behavior change, pass `--no-cache` — a
+stale `[CACHE] hit` can mask your edit.
+
+## 6. Memory watchdog
+
+`main.rs:79` SIGKILLs the process when RSS exceeds 3/4 of system memory,
+printing `[xezim][mem-watchdog] …`. Expected protection, not a crash bug. Only
+disable for known-huge runs: `XEZIM_NO_MEM_WATCHDOG=1`.
+
+## 7. Dead-clock watchdog
+
+`XEZIM_STUCK_CLOCK=off|warn|abort` (`simulator.rs:22447`) turns a frozen-clock
+churn into a hard failure. Default `warn`; use `abort` for CI.
+
+## 8. Intra-assignment-delay pre-parse rewrite
+
+The parser discards `lhs = #d rhs` (§9.4.5), so `src/intra_delay.rs` rewrites the
+source text into a `$__xz_intra_delay(...)` marker **before** parsing. Any
+parser/lexer work must preserve this interplay — a delay symptom points at the
+rewrite, not the parser.
+
+## 9. should_fail lint is additive
+
+`src/should_fail_lint.rs` is an additive second pass that rejects illegal
+constructs in `--compile` mode for sv-tests negative cases. It is validated
+against a 1005-case static baseline (`src/should_fail_lint.rs:12`). It must
+never change clean-design behavior and must stay conservative — add checks there
+only for definite LRM violations.
+
+## 10. Logging routing
+
+Route output through `log_println` / `log_eprintln`
+(`../xezim-core/src/lib.rs:2171-2172`) so the `-l` fd-level redirect works —
+it captures DPI/VPI C output too. Bare `println!` / `eprintln!` bypasses `--log`.
+
+## 11. Per-module timescales
+
+The simulation tick is the finest declared precision anywhere (down to `fs`);
+`--max-time` is in ns (independent of tick); `$time` reports ticks.
+`--module-timescale` applies only to modules with no source-level timescale.
+
+## 12. xezim-core artifact versioning
+
+`XEZIM_BYTECODE_MAGIC = b"XEZIMBC\x0c"` — the last byte is the serialized-format
+version (`../xezim-core/src/lib.rs:73`). When you add or change a serialized
+field in `ElaboratedModule` (or any bincode-serialized type), **bump `\x0c` to
+`\x0d`** and add one line to the version-ladder comment above it. Stale
+artifacts then fail with a clear "recompile with current xezim" error instead of
+deserializing garbage.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,94 @@
+# Testing xezim
+
+How the suite is organized, how to run it, and how to add a test.
+
+## 1. The two harness styles
+
+**In-process groups** (the norm for new features/bug fixes). Eight integration
+group roots in `tests/` — `classes.rs`, `collections.rs`, `gates.rs`,
+`hierarchy.rs`, `misc.rs`, `scheduling.rs`, `strings.rs`, `types.rs` — each a
+flat list of `#[path = "<group>/<name>.rs"] mod <name>;` declarations (no `{}`
+wrapper) over one topic directory. ~1680 `#[test]` fns total. A test simulates
+an inline SV source and asserts on final signal values.
+
+**Subprocess runners** (in `tests/misc/`). They spawn
+`env!("CARGO_BIN_EXE_xezim")` against `.sv`/`.v` files and assert on the output.
+Suites: `prtest_runner.rs` (Icarus `pr*.v`, ~132 of 762 wired),
+`ivtest_{ce,misc,tail,tail2}_cluster.rs` (CE cluster has `reject(name, src)` /
+`accept(name, src)` helpers — illegal forms must be REJECTED, legal neighbors
+must still compile), `lrm_audit{,2,3}_runner.rs`, `issue30_runner.rs`,
+`issue_cases_runner.rs`, `sv_compliance_runner.rs`, `sv2023_compliance_runner.rs`.
+
+## 2. Running tests
+
+```bash
+cargo test                          # everything (the full run takes a while)
+cargo test --test classes           # one integration group
+cargo test --test classes class_property   # name filter within a group
+cargo test --features jit           # the JIT config CI also covers
+```
+
+CI (`test.yml`) runs `cargo test --no-fail-fast` **and**
+`cargo test --features jit --no-fail-fast` — both must stay green.
+
+## 3. Adding an in-process test
+
+Manually, or with `scripts/dev/new-test.sh <group> <snake_case_name>`.
+
+**Both of these are required:**
+
+1. Create `tests/<group>/<name>.rs`.
+2. Add `#[path = "<group>/<name>.rs"] mod <name>;` to the group root
+   `tests/<group>.rs`.
+
+The test body looks like this:
+
+```rust
+//! §8.25 — doc comment cites the LRM section and the bug/fix.
+use xezim::simulate;
+
+#[test]
+fn the_bug_under_test() {
+    let sim = simulate(SV_SOURCE, 100).expect("simulate failed");
+    assert_eq!(u(&sim, "tb.sig"), 42, "expected value");
+}
+```
+
+`u` is a small local helper that tries `sim.get_signal(n)` then the
+`tb.`-prefixed form — see the real `fn u` in
+`tests/classes/issue4_coupled_constraints.rs:21` and
+`tests/classes/class_property_param_width.rs:145`.
+
+## 4. Conventions for a good test
+
+- The `//!` doc comment cites the LRM § and the bug/fix (e.g.
+  `tests/classes/class_property_param_width.rs` cites `§8.25 / §6.9.1`).
+- The assertion message names the expected value.
+- Use `xezim::simulate_multi` when you need multiple sources / include dirs /
+  defines (see `tests/classes/uvm_config_db_tests.rs`).
+- Signals are read with `sim.get_signal("tb.sig")` (try both bare and `tb.`
+  prefixed names) → `.to_u64()`.
+
+## 5. The subprocess runner suites and their stdout markers
+
+Markers that matter:
+
+- Positive tests must print `TEST_PASS` (not `TEST_FAIL`) or `PASSED` (not
+  `FAILED`).
+- No output may contain `Parse errors` or `Simulation error`.
+- Negative tests must exit non-zero and print `: error:` / `Parse errors` /
+  `Simulation error`.
+
+## 6. Common pitfalls
+
+- **Missing mod line**: a test file dropped in a topic directory but never
+  registered in the group root compiles silently and never runs. This is the
+  classic silent no-op.
+- **Wrong group**: pick the topic directory that matches the feature.
+- **Signal path**: read signals by their hierarchical name (`tb.` prefix) — a
+  bare name may not resolve.
+- **4-state X where 2-state is expected**: X-init can leak into asserted values;
+  use `XEZIM_INIT_ZERO=1` only when X-init coercion is the point.
+- **Random data without a fixed seed**: a test that collects random packets
+  (`$urandom`) must not assert an exact count unless it fixes `+seed` — the
+  default seed is 1, but an explicit `+seed` makes the intent obvious.

--- a/docs/superpowers/plans/2026-08-06-dev-assistance-package.md
+++ b/docs/superpowers/plans/2026-08-06-dev-assistance-package.md
@@ -1,0 +1,662 @@
+# Developer Assistance Package for xezim — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a developer-assistance package for the `xezim` repo — a `docs/dev/` reference set (architecture, debugging, testing, gotchas) plus a `scripts/dev/` shell toolbox (quick-repro, check-determinism, new-test) — so anyone using Claude Code or OpenAI Codex can understand, develop, and fix the simulator without re-deriving its non-obvious rules.
+
+**Architecture:** Three layers that reference each other. (1) `docs/dev/*.md` — the "understand/fix/develop" reference, written from facts already verified against the repo (the AGENTS.md/CLAUDE.md work this session captured them; every fact below has its source). (2) `scripts/dev/*.sh` — small bash tools that wrap common agent actions; they resolve the repo root relative to themselves so they work from any CWD, and each has a smoke test. (3) `AGENTS.md` — extended so its "Resources" and "Workflows" sections link to the new docs and scripts ("AGENTS stays general, internals stays deep").
+
+**Tech Stack:** bash (matching the existing `scripts/` precedent: `Makefile`, `build_uvm_dpi.sh`, `install_xezim_on_mac.sh`, `run_cv32e40p_uvm.sh`), Markdown, `cargo test` + `target/release/xezim` for verification.
+
+## Global Constraints
+
+- **No changes to `src/`, `xezim-core/`, or any existing test file.** Docs and tooling only. The one exception is `tests/*.rs` group roots, appended to only by `scripts/dev/new-test.sh` when invoked.
+- **Every doc fact must be verified** against the repo before being written — no invented flags, paths, or API names. Sources are given per fact below; re-run the commands to confirm.
+- Scripts must work from any CWD (resolve repo root from `$(dirname "$0")`), must be `set -uo pipefail` (no `-e` — they report failures), and must pass `bash -n` syntax check.
+- Scripts must not modify the repo (except `new-test.sh`, whose whole job is scaffolding a test file + one append to a group root).
+- Docs are tool-agnostic: no mention of skills, plugins, or tool-specific plumbing.
+- `.claude/` is gitignored — leave it alone. Agent configuration for Claude Code and an MCP server are **out of scope** for this plan (follow-ups).
+- Everything is committed to the `xezim` repo (`git config user.name`/`user.email` already set this session). Commit messages use the repo's `prefix: subject` style and end with the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: `docs/dev/architecture.md` — the "understand" doc
+
+**Files:**
+- Create: `docs/dev/architecture.md`
+- Test: none (reference doc) — verified via Step 2 commands
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the file `docs/dev/architecture.md` that later tasks link to. Its final section links to `debugging.md`, `testing.md`, `gotchas.md` (created in Tasks 2–4), `docs/dev/README.md` (Task 5), and the top-level `AGENTS.md`.
+
+- [ ] **Step 1: Write `docs/dev/architecture.md`** with this exact outline and content:
+
+```
+# xezim Architecture
+
+Orientation for a developer (or agent) who has never seen this codebase.
+Complements AGENTS.md — this is the deep-dive it points to.
+
+## 1. The two-crate split
+## 2. End-to-end pipeline (source → running simulation)
+## 3. Compile modes and what each phase runs
+## 4. Central types
+## 5. The scheduling model (Active / NBA / Reactive)
+## 6. Subsystem → file map
+## 7. Where each major SystemVerilog feature executes
+## 8. The design cache
+## 9. Further reading
+```
+
+The doc **must** state these verified facts (source in parens — keep the fact, drop the source from prose):
+
+1. `xezim` is a SystemVerilog **bytecode interpreter**; parsing/elaboration/4-state value model live in the sibling `xezim-core` crate at `../xezim-core` (path dependency, not a submodule) — verified in `Cargo.toml` (`xezim-core = { path = "../xezim-core" }`, `sv-parser = { path = "../xezim-core/xezim-parser" }`). Native AOT compilation is a separate `xezim-b` crate.
+2. Pipeline stages and their owners: source → preprocessor (`xezim-core/xezim-parser/src/preprocessor/`) → parser/AST (`xezim-core/xezim-parser/src/parse/`, `ast/`) → elaboration (`xezim-core/src/elaborate.rs`, 19k LOC) → bytecode compile (`src/compiler/bytecode.rs`) → event-driven execution (`src/compiler/simulator.rs`, 85k LOC).
+3. CLI modes `--parse` / `--compile` / `--simulate` (default) / `--preprocess` — verified in `src/main.rs` (Mode enum) and the usage text.
+4. Central types: `Value`/`LogicBit` — 4-state 0/1/X/Z with width + signedness (`xezim-core/src/value.rs`); `ElaboratedModule` (`xezim-core/src/elaborate.rs`); `Insn` — register-based bytecode, 24-byte instructions (`src/compiler/bytecode.rs`); `Simulator` (`src/compiler/simulator.rs`).
+5. Scheduling regions: Active (blocking assigns, continuous assigns, always_comb), NBA (non-blocking updates), Reactive (edge-triggered always_ff/always_latch, @posedge, wait forks) — quoted from the `simulator.rs` module doc (`//!` header).
+6. Subsystem→file map (table): simulator VM `src/compiler/simulator.rs`; bytecode `bytecode.rs`; dispatch table `dispatch.rs`; arena `arena.rs`; soa signal layout `soa.rs`; optional cranelift JIT `jit.rs` (`--features jit`); FST sink `fst_sink.rs`; pre-parse intra-assignment-delay rewrite `src/intra_delay.rs`; additive negative-case lint `src/should_fail_lint.rs`; experimental PDES `src/multikernel.rs` (not production); VCD sink `xezim-core/src/vcd_sink.rs`; stdout/log sink `xezim-core/src/stdout_sink.rs`; SDF `xezim-core/src/sdf/`.
+7. Feature→owner table (parse error → sv-parser; type/width/parameter/class/port → elaborate.rs; wrong sim value/race/event ordering/class-UVM runtime/randomize/DPI-VPI/dumping → simulator.rs; `$display` formatting → stdout_sink.rs).
+8. Design cache: content-addressed, keyed on sources+defines+top+exe mtime/size, prints `[CACHE] hit/miss/stored` on stderr, skips parse+elab on hit; config in `src/lib.rs` (`DesignCacheConfig`), CLI `--cache-dir`/`--no-cache`.
+9. A "trace it yourself" section: `--dump-files-list` shows resolved sources; `--dump-merged-sv out.sv` writes all sources merged; `--compile` stops after elaboration; `--simulate` runs.
+10. Final section "Further reading" lists `docs/dev/debugging.md`, `docs/dev/testing.md`, `docs/dev/gotchas.md`, `../xezim-core/AGENTS.md`, `README.md`.
+
+- [ ] **Step 2: Verify the doc references nothing that doesn't exist**
+
+```bash
+# every path the doc names must exist; every command must run
+test -d docs/dev
+test -f src/compiler/simulator.rs && test -f src/compiler/bytecode.rs
+test -f src/intra_delay.rs && test -f src/should_fail_lint.rs
+test -f ../xezim-core/src/elaborate.rs && test -f ../xezim-core/src/value.rs
+printf 'module tb; initial $display("x"); endmodule\n' >/tmp/xz_arch_check.sv
+./target/release/xezim --dump-files-list /tmp/xz_arch_check.sv >/dev/null 2>&1 && echo "trace commands OK"
+rm -f /tmp/xz_arch_check.sv
+```
+Expected: all `test` lines succeed; "trace commands OK" printed. If `target/release/xezim` is stale, rebuild first (`cargo build --release`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/architecture.md
+git commit -m "docs(dev): architecture deep-dive
+
+Two-crate split, end-to-end pipeline, scheduling model, subsystem and
+feature-to-owner maps, design cache.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `docs/dev/debugging.md` — the "fix" doc
+
+**Files:**
+- Create: `docs/dev/debugging.md`
+- Test: none (reference doc) — verified via Step 2 commands
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `docs/dev/debugging.md`, referenced from `docs/dev/README.md` (Task 5) and `architecture.md` (Task 1).
+
+- [ ] **Step 1: Write `docs/dev/debugging.md`** with this outline:
+
+```
+# Debugging xezim
+
+Reproduce-first workflow, diagnostics, and the runtime knobs.
+
+## 1. Reproduce before you edit
+## 2. Diagnostic markers (what each stderr/stdout line means)
+## 3. Exit codes and signals
+## 4. The XEZIM_* runtime knobs
+## 5. Isolating the failing phase (parse → elaborate → simulate)
+## 6. Hangs and the stall report
+## 7. Memory watchdog
+## 8. Design-cache interference
+## 9. Determinism checks
+## 10. Symptom → owner table
+## 11. A worked example (walk one real past fix: intra-assignment delay)
+```
+
+The doc **must** state these verified facts:
+
+1. Workflow: write the minimal SV repro → run `./target/release/xezim repro.sv` → identify phase → fix in the owner → add regression test (see `testing.md`) → `cargo test --test <group> <name>`.
+2. Markers verified in code: `: error:` (diagnostics), `Parse errors` / `Simulation error` (strings the test runners grep for — `tests/misc/*_runner.rs`), `[CACHE] hit|miss|invalid artifact|stored` (`src/lib.rs`), `[PROF]` per-phase timing (`simulator.rs`), `[PHASE]`, `[EVENT-EDGE]` (armed/skip mode), `[PROGRESS]` (when `XEZIM_PROGRESS` set), `[xezim][mem-watchdog]` (kills pid, `src/main.rs:79`).
+3. Exit codes: 0 = clean `$finish`; 1 = usage/compile/simulation error; SIGKILL from the memory watchdog (RSS > 3/4 of MemTotal — message points at `XEZIM_NO_MEM_WATCHDOG=1`); SIGUSR1 installs a hang-report handler (`install_hang_report_handler`, `simulator.rs:1318`).
+4. XEZIM_* table — each verified in code: `XEZIM_EVENT_EDGE=1` (`simulator.rs:380` area), `XEZIM_INIT_ZERO=1`, `XEZIM_PROGRESS=N`, `XEZIM_STUCK_CLOCK=off|warn|abort` (`simulator.rs:22447`), `XEZIM_NO_MEM_WATCHDOG=1` (`src/main.rs:64`), `XEZIM_NO_PARALLEL=1` / `XEZIM_FORCE_PARALLEL=1` (`simulator.rs:29578`), `XEZIM_NO_CACHE=1`, `XEZIM_CACHE_DIR`, `XEZIM_COMPILE_PHASES=1`.
+5. Phase isolation: run the same file under `--parse`, then `--compile`, then `--simulate`; whichever first reports `: error:` owns the bug.
+6. Hangs: the terminal stall report names the parked processes and the signal that should have woken them (`simulator.rs:21420`); `XEZIM_STUCK_CLOCK=abort` turns dead-clock churn into a hard failure; bound runs with `--max-time`.
+7. Memory watchdog: kill at 3/4 MemTotal is expected, not a crash; disable only for known-huge runs.
+8. Cache: a stale `[CACHE] hit` can mask a change — pass `--no-cache` while iterating; a local rebuild invalidates automatically (exe mtime/size is part of the key).
+9. Determinism: run the same command twice, `diff` the output — must be identical with the same seed (`+seed=1` default; `+seed=random` opts into entropy). See `scripts/dev/check-determinism.sh`.
+10. Symptom→owner table (same as AGENTS.md §Architecture, expanded with one-line how-to for each).
+11. Worked example: intra-assignment delay — `lhs = #d rhs` is rewritten to a `$__xz_intra_delay` marker by `src/intra_delay.rs` **before** parsing; a symptom in delays points at that interplay, not the parser.
+
+- [ ] **Step 2: Verify every command the doc tells the reader to run actually works**
+
+```bash
+# phase isolation on a trivial design
+printf 'module tb; initial $display("x"); endmodule\n' >/tmp/xz_dbg_check.sv
+./target/release/xezim --parse /tmp/xz_dbg_check.sv >/dev/null 2>&1 && echo "parse OK"
+./target/release/xezim --compile /tmp/xz_dbg_check.sv >/dev/null 2>&1 && echo "compile OK"
+./target/release/xezim --simulate /tmp/xz_dbg_check.sv >/dev/null 2>&1 && echo "simulate OK"
+# determinism on the doc's own example
+a=$(./target/release/xezim /tmp/xz_dbg_check.sv 2>/dev/null); b=$(./target/release/xezim /tmp/xz_dbg_check.sv 2>/dev/null)
+[ "$a" = "$b" ] && echo "determinism OK"
+rm -f /tmp/xz_dbg_check.sv
+```
+Expected: all three phase lines and "determinism OK" print.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/debugging.md
+git commit -m "docs(dev): debugging handbook
+
+Diagnostic markers, exit codes, XEZIM_* runtime knobs, phase isolation,
+hang/stall debugging, memory watchdog, cache and determinism gotchas.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `docs/dev/testing.md` — the "develop" doc
+
+**Files:**
+- Create: `docs/dev/testing.md`
+- Test: none (reference doc) — verified via Step 2 command
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `docs/dev/testing.md`, referenced from `docs/dev/README.md` (Task 5) and `architecture.md` (Task 1). Task 8's `new-test.sh` targets the exact conventions this doc defines.
+
+- [ ] **Step 1: Write `docs/dev/testing.md`** with this outline:
+
+```
+# Testing xezim
+
+How the suite is organized, how to run it, and how to add a test.
+
+## 1. The two harness styles (in-process groups / subprocess runners)
+## 2. Running tests (group, filter, both feature configs)
+## 3. Adding an in-process test (manual + scripts/dev/new-test.sh)
+## 4. Conventions for a good test
+## 5. The subprocess runner suites and their stdout markers
+## 6. Common pitfalls
+```
+
+The doc **must** state these verified facts:
+
+1. Eight integration group roots in `tests/`: `classes.rs`, `collections.rs`, `gates.rs`, `hierarchy.rs`, `misc.rs`, `scheduling.rs`, `strings.rs`, `types.rs`; each is a flat list of `#[path = "<group>/<name>.rs"] mod <name>;` declarations (no `{}` wrapper). ~1680 `#[test]` fns total (`grep -rc '#\[test\]' tests/`).
+2. In-process pattern (verbatim-shaped): `use xezim::simulate;` then `let sim = simulate(SV, max_time).expect("simulate failed");` and `assert_eq!(u(&sim, "sig"), N, "…")` where `u` is a local helper that tries `sim.get_signal(n)` then `sim.get_signal(&format!("tb.{n}"))` — see the real `fn u` in `tests/classes/issue4_coupled_constraints.rs:21` and the `.or_else(|| sim.get_signal(&format!("tb.{}", n)))` pattern in `tests/classes/class_property_param_width.rs:145-146`.
+3. Subprocess runners live in `tests/misc/` (`prtest_runner.rs`, `ivtest_*_cluster.rs`, `lrm_audit*`, `issue30`, `issue_cases`, `sv_compliance_runner.rs`, `sv2023_compliance_runner.rs`); they spawn `env!("CARGO_BIN_EXE_xezim")`. Positive tests must print `TEST_PASS` (not `TEST_FAIL`) or `PASSED` (not `FAILED`); no output may contain `Parse errors` or `Simulation error`; negative tests must exit non-zero and print a diagnostic. The `ivtest` CE clusters use `reject(name, src)` / `accept(name, src)` helpers.
+4. Run commands: `cargo test`; `cargo test --test classes`; `cargo test --test classes class_property` (name filter); `cargo test --features jit`; CI (`test.yml`) runs `cargo test --no-fail-fast` and `cargo test --features jit --no-fail-fast`.
+5. Adding a test manually: drop `tests/<group>/<name>.rs` **and** add `#[path = "<group>/<name>.rs"] mod <name>;` to the group root. The doc must call out: forgetting the mod line compiles silently and the test never runs.
+6. Conventions: `//!` doc comment cites the LRM section and the bug/fix (e.g. `tests/classes/class_property_param_width.rs` cites `§8.25 / §6.9.1`); assertion message names the expected value; use `simulate_multi` for multiple sources/includes/defines (see `tests/classes/uvm_config_db_tests.rs`).
+7. Common pitfalls: missing mod line; wrong group; signal path (`tb.` prefix); 4-state X where a 2-state value is expected (use `XEZIM_INIT_ZERO=1` only if X-init is the point); default seed — a test that collects random packets must not assert an exact count without fixing `+seed`.
+
+- [ ] **Step 2: Verify the run commands the doc documents**
+
+```bash
+cargo test --test classes class_property_param_width 2>&1 | tail -2
+```
+Expected: `test result: ok. 5 passed; 0 failed; …; 196 filtered out`. (This proves the group + name-filter commands.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/testing.md
+git commit -m "docs(dev): test-authoring guide
+
+Two harness styles, run commands, add-a-test flow, conventions and the
+classic missing-mod-line pitfall.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `docs/dev/gotchas.md` — the invariant reference
+
+**Files:**
+- Create: `docs/dev/gotchas.md`
+- Test: none — verified via Step 2 greps
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `docs/dev/gotchas.md`, referenced from `docs/dev/README.md` (Task 5).
+
+- [ ] **Step 1: Write `docs/dev/gotchas.md`** with this outline:
+
+```
+# xezim Gotchas — the rules that are not obvious
+
+Each rule: what to do, why, and the source line proving it.
+
+## 1. Determinism is a hard requirement
+## 2. The deterministic hasher
+## 3. Only one global allocator (mimalloc)
+## 4. 32 MiB minimum stack
+## 5. Design cache
+## 6. Memory watchdog
+## 7. Dead-clock watchdog
+## 8. Intra-assignment-delay pre-parse rewrite
+## 9. should_fail lint is additive
+## 10. Logging routing (log_println/log_eprintln)
+## 11. Per-module timescales
+## 12. xezim-core artifact versioning
+```
+
+Each entry must carry its verified source (command or file:line):
+1. RNG defaults to seed 1 → `+seed=<n>` for another stream, `+seed=random` for entropy (usage text in `src/main.rs`); two identical runs must be byte-identical.
+2. `xezim_core::hasher::{HashMap, HashSet}` use fixed ahash seeds (`../xezim-core/src/lib.rs` `DeterministicState`); never use `std::collections::HashMap/HashSet` where iteration order is observable.
+3. mimalloc is installed by `xezim-core`'s default feature; exactly one `#[global_allocator]` per binary; opt-out via `default-features = false` (comment in `../xezim-core/Cargo.toml`).
+4. `.cargo/config.toml` sets `RUST_MIN_STACK=33554432` for cargo-invoked processes — deep SV recursion overflows the 2 MiB default in debug; never lower.
+5. Cache markers `[CACHE] hit|miss`; key includes exe mtime/size; `--no-cache` while iterating (`src/lib.rs`).
+6. Watchdog SIGKILLs at RSS > 3/4 MemTotal (`src/main.rs:79`); `XEZIM_NO_MEM_WATCHDOG=1`.
+7. `XEZIM_STUCK_CLOCK=off|warn|abort` (`simulator.rs:22447`).
+8. Parser discards `lhs = #d rhs`; `src/intra_delay.rs` rewrites the text to a `$__xz_intra_delay` marker before parsing; keep the interplay when touching the parser.
+9. `should_fail` is an additive second pass, validated to a 1005-case baseline (`src/should_fail_lint.rs:12`); never changes clean-design behavior.
+10. Route output through `log_println`/`log_eprintln` (`../xezim-core/src/lib.rs:2171-2172`) so the `-l` fd-level redirect (which captures DPI/VPI C output) works.
+11. Tick = finest declared precision (down to fs); `--max-time` in ns; `$time` reports ticks.
+12. `XEZIM_BYTECODE_MAGIC = b"XEZIMBC\x0c"` — the last byte is the serialized-format version; bump it (and the ladder comment above it) when adding a serialized field in `ElaboratedModule` (`../xezim-core/src/lib.rs:73`).
+
+- [ ] **Step 2: Verify each source reference exists**
+
+```bash
+grep -q 'RUST_MIN_STACK' .cargo/config.toml && echo "stack OK"
+grep -q 'XEZIM_NO_MEM_WATCHDOG' src/main.rs && echo "watchdog OK"
+grep -q '1005' src/should_fail_lint.rs && echo "lint OK"
+grep -q 'XEZIMBC' ../xezim-core/src/lib.rs && echo "magic OK"
+grep -q 'fn log_println' ../xezim-core/src/lib.rs && echo "logging OK"
+```
+Expected: all five "OK" lines print.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/gotchas.md
+git commit -m "docs(dev): gotchas reference
+
+Determinism, hasher, allocator, stack, caches, watchdogs, the
+intra-delay rewrite, the additive should_fail lint, logging, timescales,
+and artifact versioning — each with its source.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `docs/dev/README.md` index + wire into AGENTS.md
+
+**Files:**
+- Create: `docs/dev/README.md`
+- Modify: `AGENTS.md` (Resources section — add `docs/dev/README.md` line; Workflows "Debug a wrong sim result" line — mention `scripts/dev/quick-repro.sh`)
+
+**Interfaces:**
+- Consumes: `docs/dev/architecture.md` (Task 1), `debugging.md` (Task 2), `testing.md` (Task 3), `gotchas.md` (Task 4).
+- Produces: the index doc that makes the package discoverable, and AGENTS.md links that let agents find it.
+
+- [ ] **Step 1: Write `docs/dev/README.md`** — index with:
+
+```
+# Developer Documentation
+
+How an agent or engineer uses these docs. One paragraph: which doc for which
+situation (architecture = understand, debugging = fix, testing = develop,
+gotchas = before you edit anything). A table:
+
+| Doc | When to read it |
+| architecture.md | First time in this repo; before adding a feature |
+| debugging.md | A simulation gives a wrong result or hangs |
+| testing.md | Before writing or running any test |
+| gotchas.md | Before editing src/ or xezim-core |
+
+Final section: how these relate to AGENTS.md (top-level, general) and
+../xezim-core/AGENTS.md (the sibling library). Link all four docs by filename.
+```
+
+- [ ] **Step 2: Add the two AGENTS.md references** (exact edits):
+
+In the `## Resources` section of `AGENTS.md`, insert as the first bullet:
+```markdown
+- `docs/dev/README.md` — developer documentation: architecture, debugging, testing, gotchas
+```
+In the `## Workflows` → "**Debug a wrong sim result**" sentence, after "…`--max-time` to bound a runaway;", insert:
+```markdown
+ (or use `scripts/dev/quick-repro.sh '…snippet…'` to iterate without writing a repo file)
+```
+
+- [ ] **Step 3: Verify links resolve and docs render**
+
+```bash
+for f in architecture debugging testing gotchas; do test -f "docs/dev/$f.md" && echo "$f OK"; done
+grep -q 'docs/dev/README.md' AGENTS.md && echo "AGENTS link OK"
+grep -q 'quick-repro' AGENTS.md && echo "workflow link OK"
+```
+Expected: four "OK" lines plus the two link checks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/dev/README.md AGENTS.md
+git commit -m "docs(dev): dev-docs index and wire it into AGENTS.md
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `scripts/dev/quick-repro.sh`
+
+**Files:**
+- Create: `scripts/dev/quick-repro.sh` (executable)
+
+**Interfaces:**
+- Consumes: `target/release/xezim` (must be built).
+- Produces: an executable script at `scripts/dev/quick-repro.sh`, referenced by `docs/dev/debugging.md` (Task 2) and `AGENTS.md` (Task 5). Signature: `scripts/dev/quick-repro.sh '<sv-snippet>' [xezim args...]` — stdout/stderr pass through from xezim; exit code = xezim's.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Simulate a one-off SystemVerilog snippet without writing a repo file.
+#
+#   scripts/dev/quick-repro.sh 'module tb; initial $display("hi"); endmodule'
+#   scripts/dev/quick-repro.sh 'module tb; ... endmodule' --max-time 50 +seed=2
+#
+# The snippet is written to a temp .sv file, simulated with the release
+# binary, and the temp file is removed on exit. Exit code = xezim's.
+set -uo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $(basename "$0") '<sv-snippet>' [xezim args...]" >&2
+  exit 2
+fi
+snippet="$1"
+shift
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo/target/release/xezim"
+if [ ! -x "$bin" ]; then
+  echo "release binary missing — run: cargo build --release" >&2
+  exit 2
+fi
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/xz-repro-XXXXXX.sv")"
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' "$snippet" >"$tmp"
+exec "$bin" "$tmp" "$@"
+```
+
+- [ ] **Step 2: Smoke-test it**
+
+```bash
+chmod +x scripts/dev/quick-repro.sh
+bash -n scripts/dev/quick-repro.sh && echo "syntax OK"
+out=$(scripts/dev/quick-repro.sh 'module tb; initial $display("GREET=%0d", 42); endmodule' 2>/dev/null | grep GREET)
+[ "$out" = "GREET=42" ] && echo "happy path OK"
+scripts/dev/quick-repro.sh >/dev/null 2>&1; [ "$?" -eq 2 ] && echo "usage error OK"
+sleep 0.1   # let the EXIT trap run
+test -z "$(ls /tmp/xz-repro-*.sv 2>/dev/null)" && echo "temp cleaned OK"
+```
+Expected: "syntax OK", "happy path OK", "usage error OK", "temp cleaned OK".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/dev/quick-repro.sh
+git commit -m "tools(dev): quick-repro script to simulate an SV snippet
+
+Writes the snippet to a temp file, simulates with the release binary,
+cleans up on exit. Works from any CWD.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `scripts/dev/check-determinism.sh`
+
+**Files:**
+- Create: `scripts/dev/check-determinism.sh` (executable)
+
+**Interfaces:**
+- Consumes: `target/release/xezim`.
+- Produces: an executable script `scripts/dev/check-determinism.sh`, referenced by `docs/dev/debugging.md`. Signature: `scripts/dev/check-determinism.sh <sv-file> [xezim args...]` — runs the design twice with the same seed and exits 1 with a diff if the two runs differ; prints `DETERMINISM OK: byte-identical` otherwise.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Verify a design is deterministic: run it twice with the same seed and fail
+# if the outputs differ. Identical inputs must give byte-identical output.
+#
+#   scripts/dev/check-determinism.sh design.sv
+#   scripts/dev/check-determinism.sh design.sv +seed=7 --max-time 200
+#
+# Pass +seed=<n> (default is seed 1). Use +seed=random only if you want to
+# confirm your analysis ignores entropy — two random runs SHOULD differ.
+set -uo pipefail
+
+if [ "$#" -lt 1 ] || [ ! -f "$1" ]; then
+  echo "usage: $(basename "$0") <design.sv> [xezim args...]" >&2
+  exit 2
+fi
+design="$1"
+shift
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo/target/release/xezim"
+if [ ! -x "$bin" ]; then
+  echo "release binary missing — run: cargo build --release" >&2
+  exit 2
+fi
+
+r1="$(mktemp)"; r2="$(mktemp)"
+trap 'rm -f "$r1" "$r2"' EXIT
+
+"$bin" "$design" "$@" 2>&1 >"$r1"; s1=$?
+"$bin" "$design" "$@" 2>&1 >"$r2"; s2=$?
+
+if [ "$s1" -ne "$s2" ]; then
+  echo "DETERMINISM FAILURE: exit codes differ ($s1 vs $s2)" >&2
+  exit 1
+fi
+if ! diff -q "$r1" "$r2" >/dev/null; then
+  echo "DETERMINISM FAILURE: two identical runs produced different output" >&2
+  diff -u "$r1" "$r2" >&2
+  exit 1
+fi
+echo "DETERMINISM OK: byte-identical (exit $s1)"
+```
+
+- [ ] **Step 2: Smoke-test it**
+
+```bash
+chmod +x scripts/dev/check-determinism.sh
+bash -n scripts/dev/check-determinism.sh && echo "syntax OK"
+printf 'module tb; initial $display("n=%0d", $urandom()); endmodule\n' >/tmp/xz_det_check.sv
+./scripts/dev/check-determinism.sh /tmp/xz_det_check.sv | grep -q 'DETERMINISM OK' && echo "deterministic design OK"
+./scripts/dev/check-determinism.sh >/dev/null 2>&1; [ "$?" -eq 2 ] && echo "usage error OK"
+rm -f /tmp/xz_det_check.sv
+```
+Expected: "syntax OK", "deterministic design OK", "usage error OK". (The design uses `$urandom` to prove the check holds even when random values are involved — same seed ⇒ identical stream.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/dev/check-determinism.sh
+git commit -m "tools(dev): determinism check script
+
+Runs a design twice with the same seed and diffs the output; fails on
+any drift. Works from any CWD.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: `scripts/dev/new-test.sh`
+
+**Files:**
+- Create: `scripts/dev/new-test.sh` (executable)
+
+**Interfaces:**
+- Consumes: `docs/dev/testing.md` conventions (Task 3) — same group names, same `#[path]` + `mod` shape.
+- Produces: an executable scaffold script. Signature: `scripts/dev/new-test.sh <group> <name>` — creates `tests/<group>/<name>.rs` from a template and **appends** the `#[path = "<group>/<name>.rs"]` + `mod <name>;` lines to `tests/<group>.rs`. Exits 2 on bad usage, 1 on a group/name that can't be used, 0 on success.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Scaffold a new integration test in a group and wire it into the group root.
+#
+#   scripts/dev/new-test.sh scheduling regress_foo
+#   cargo test --test scheduling regress_foo
+#
+# Creates tests/<group>/<name>.rs and appends the #[path] + mod lines to
+# tests/<group>.rs. The classic failure is forgetting the mod line — this
+# script makes it impossible.
+set -uo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $(basename "$0") <group> <snake_case_name>" >&2
+  exit 2
+fi
+group="$1"
+name="$2"
+
+case "$group" in
+  classes|collections|gates|hierarchy|misc|scheduling|strings|types) ;;
+  *) echo "unknown group '$group' (expected one of: classes collections gates hierarchy misc scheduling strings types)" >&2; exit 1 ;;
+esac
+if ! printf '%s' "$name" | grep -qE '^[a-z][a-z0-9_]*$'; then
+  echo "invalid test name '$name' (use snake_case, lowercase start)" >&2
+  exit 1
+fi
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+root="$repo/tests/$group.rs"
+file="$repo/tests/$group/$name.rs"
+
+if [ -e "$file" ]; then
+  echo "already exists: $file" >&2
+  exit 1
+fi
+
+cat >"$file" <<EOF
+//! <LRM § + what this guards> — see docs/dev/testing.md for conventions.
+use xezim::simulate;
+
+#[test]
+fn $name() {
+    let sim = simulate(
+        r#"
+module tb;
+  // minimal repro
+endmodule
+"#,
+        100,
+    )
+    .expect("simulate failed");
+    // assert_eq!(u(&sim, "tb.sig"), N, "expected value");
+}
+EOF
+
+printf '#[path = "%s/%s.rs"]\nmod %s;\n' "$group" "$name" "$name" >>"$root"
+
+echo "created $file"
+echo "appended mod line to $root"
+echo "run it with: cargo test --test $group $name"
+```
+
+- [ ] **Step 2: Smoke-test it**
+
+```bash
+chmod +x scripts/dev/new-test.sh
+bash -n scripts/dev/new-test.sh && echo "syntax OK"
+./scripts/dev/new-test.sh scheduling zz_probe_scaffold
+grep -q 'zz_probe_scaffold' tests/scheduling/zz_probe_scaffold.rs && echo "file created OK"
+tail -2 tests/scheduling.rs | grep -q 'zz_probe_scaffold' && echo "mod line appended OK"
+cargo test --test scheduling zz_probe_scaffold 2>&1 | tail -1 | grep -q 'test result: ok' && echo "test compiles+passes OK"
+./scripts/dev/new-test.sh bogus x 2>/dev/null; [ "$?" -eq 1 ] && echo "bad group OK"
+./scripts/dev/new-test.sh scheduling NotSnake 2>/dev/null; [ "$?" -eq 1 ] && echo "bad name OK"
+```
+Expected: "syntax OK", "file created OK", "mod line appended OK", "test compiles+passes OK", "bad group OK", "bad name OK".
+
+- [ ] **Step 3: Remove the smoke-test scaffold, then commit the script only**
+
+The smoke test above proved the script works; the junk `zz_probe_scaffold` test must not land in the repo (a committed test needs a real LRM citation and a real assertion, per `docs/dev/testing.md`).
+
+```bash
+git restore tests/scheduling.rs            # discard the appended mod line
+rm tests/scheduling/zz_probe_scaffold.rs   # remove the scaffold test file
+git status --short                         # only scripts/dev/new-test.sh may remain untracked
+git add scripts/dev/new-test.sh
+git commit -m "tools(dev): new-test scaffold script
+
+Creates a test file in a group and appends its #[path] mod line, so a
+new test can never silently not run.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Final verification and README pointer
+
+**Files:**
+- Modify: `README.md` — add a "Developer documentation" link near the existing docs references (the README already links `docs/uvm-guide.md` and `docs/dpi-guide.md`; add `docs/dev/README.md` beside them).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–8.
+- Produces: a verified, committed package.
+
+- [ ] **Step 1: Add the README pointer**
+
+Find the README line that links `docs/uvm-guide.md` and `docs/dpi-guide.md` and add after it:
+```markdown
+* [`docs/dev/README.md`](docs/dev/README.md) — developer documentation (architecture, debugging, testing, gotchas)
+```
+
+- [ ] **Step 2: End-to-end verification**
+
+```bash
+bash -n scripts/dev/*.sh && echo "all scripts: syntax OK"
+# every doc file exists
+for f in README architecture debugging testing gotchas; do test -f "docs/dev/$f.md" && echo "docs/dev/$f.md OK"; done
+# every doc references only existing paths (spot-check the four files' code spans and file refs)
+grep -l 'docs/dev' AGENTS.md README.md docs/dev/README.md >/dev/null && echo "package is linked"
+# scripts are referenced where claimed
+grep -q 'check-determinism' docs/dev/debugging.md && grep -q 'new-test' docs/dev/testing.md && echo "scripts referenced in docs"
+# full-suite sanity on the touched area
+cargo test --test scheduling 2>&1 | tail -2
+```
+Expected: all scripts pass `bash -n`; all five doc files exist; "package is linked"; "scripts referenced in docs"; `test result: ok` for the scheduling group.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: link the developer documentation from README
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Confirm clean tree**
+
+```bash
+git status --short   # only the files listed in these tasks may appear; nothing in src/ or xezim-core
+```
+
+---
+
+## Out of scope / follow-ups (separate plans)
+
+- **Agent configuration** (`.codex/config.toml` permissions; Claude Code `.claude/settings.json` — currently gitignored, needs an un-ignore decision). Intentionally deferred so no unverified config schema is committed.
+- **MCP server for xezim** — a separate software project (compile/elaborate/simulate snippets, read signals, run tests via MCP tools).
+- **xezim-core docs package** — a parallel `docs/dev/` set for `../xezim-core` if wanted.

--- a/scripts/dev/check-determinism.sh
+++ b/scripts/dev/check-determinism.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify a design is deterministic: run it twice with the same seed and fail
+# if the outputs differ. Identical inputs must give byte-identical output.
+#
+#   scripts/dev/check-determinism.sh design.sv
+#   scripts/dev/check-determinism.sh design.sv +seed=7 --max-time 200
+#
+# Pass +seed=<n> (default is seed 1). Use +seed=random only if you want to
+# confirm your analysis ignores entropy — two random runs SHOULD differ.
+set -uo pipefail
+
+if [ "$#" -lt 1 ] || [ ! -f "$1" ]; then
+  echo "usage: $(basename "$0") <design.sv> [xezim args...]" >&2
+  exit 2
+fi
+design="$1"
+shift
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo/target/release/xezim"
+if [ ! -x "$bin" ]; then
+  echo "release binary missing — run: cargo build --release" >&2
+  exit 2
+fi
+
+r1="$(mktemp)"; r2="$(mktemp)"
+trap 'rm -f "$r1" "$r2"' EXIT
+
+"$bin" "$design" "$@" 2>&1 >"$r1"; s1=$?
+"$bin" "$design" "$@" 2>&1 >"$r2"; s2=$?
+
+if [ "$s1" -ne "$s2" ]; then
+  echo "DETERMINISM FAILURE: exit codes differ ($s1 vs $s2)" >&2
+  exit 1
+fi
+if ! diff -q "$r1" "$r2" >/dev/null; then
+  echo "DETERMINISM FAILURE: two identical runs produced different output" >&2
+  diff -u "$r1" "$r2" >&2
+  exit 1
+fi
+echo "DETERMINISM OK: byte-identical (exit $s1)"

--- a/scripts/dev/new-test.sh
+++ b/scripts/dev/new-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Scaffold a new integration test in a group and wire it into the group root.
+#
+#   scripts/dev/new-test.sh scheduling regress_foo
+#   cargo test --test scheduling regress_foo
+#
+# Creates tests/<group>/<name>.rs and appends the #[path] + mod lines to
+# tests/<group>.rs. The classic failure is forgetting the mod line — this
+# script makes it impossible.
+set -uo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $(basename "$0") <group> <snake_case_name>" >&2
+  exit 2
+fi
+group="$1"
+name="$2"
+
+case "$group" in
+  classes|collections|gates|hierarchy|misc|scheduling|strings|types) ;;
+  *) echo "unknown group '$group' (expected one of: classes collections gates hierarchy misc scheduling strings types)" >&2; exit 1 ;;
+esac
+if ! printf '%s' "$name" | grep -qE '^[a-z][a-z0-9_]*$'; then
+  echo "invalid test name '$name' (use snake_case, lowercase start)" >&2
+  exit 1
+fi
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+root="$repo/tests/$group.rs"
+file="$repo/tests/$group/$name.rs"
+
+if [ -e "$file" ]; then
+  echo "already exists: $file" >&2
+  exit 1
+fi
+
+cat >"$file" <<EOF
+//! <LRM § + what this guards> — see docs/dev/testing.md for conventions.
+use xezim::simulate;
+
+#[test]
+fn $name() {
+    let sim = simulate(
+        r#"
+module tb;
+  // minimal repro
+endmodule
+"#,
+        100,
+    )
+    .expect("simulate failed");
+    // assert_eq!(u(&sim, "tb.sig"), N, "expected value");
+}
+EOF
+
+printf '#[path = "%s/%s.rs"]\nmod %s;\n' "$group" "$name" "$name" >>"$root"
+
+echo "created $file"
+echo "appended mod line to $root"
+echo "run it with: cargo test --test $group $name"

--- a/scripts/dev/quick-repro.sh
+++ b/scripts/dev/quick-repro.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Simulate a one-off SystemVerilog snippet without writing a repo file.
+#
+#   scripts/dev/quick-repro.sh 'module tb; initial $display("hi"); endmodule'
+#   scripts/dev/quick-repro.sh 'module tb; ... endmodule' --max-time 50 +seed=2
+#
+# The snippet is written to a temp .sv file, simulated with the release
+# binary, and the temp file is removed on exit. Exit code = xezim's.
+set -uo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $(basename "$0") '<sv-snippet>' [xezim args...]" >&2
+  exit 2
+fi
+snippet="$1"
+shift
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo/target/release/xezim"
+if [ ! -x "$bin" ]; then
+  echo "release binary missing — run: cargo build --release" >&2
+  exit 2
+fi
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/xz-repro-XXXXXX.sv")"
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' "$snippet" >"$tmp"
+# Note: no `exec` here — the EXIT trap would never fire once the shell is
+# replaced, leaking the temp file. The bin's exit status is preserved because
+# it is the script's last command, and the trap runs after it exits.
+"$bin" "$tmp" "$@"


### PR DESCRIPTION
Adds canonical agent guides (AGENTS.md) and thin CLAUDE.md wrappers for both xezim and xezim-core repositories.

**xezim/AGENTS.md** (~280 lines): Complete developer guide covering repo map, build/run/test commands, architecture + symptom→owner map, critical invariants (determinism, mimalloc, design cache, memory watchdog, intra-assignment delays, should_fail lint, logging, timescales, sibling coordination), coding conventions, workflows, and a pre-PR checklist.

**xezim/CLAUDE.md**: Imports AGENTS.md + 8 lines of Claude Code workflow notes.

**xezim-core/AGENTS.md** (~190 lines): Scoped to the shared library (parser, elaboration, value model, artifact format). Covers sv-parser crate, elaborate.rs, deterministic hasher, artifact format versioning, and mirrors the pre-PR checklist.

**xezim-core/CLAUDE.md**: Imports AGENTS.md + brief notes.

Also includes a new development skill at `.claude/skills/xezim-development/SKILL.md` for agent assistance.

No *.rs changes — documentation only.