### PR TITLE
sim: recover the tag of a tagged-union pattern literal (IEEE1800-2017 §7.3.1)

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -42340,8 +42340,26 @@ impl Simulator {
                 if let ExprKind::Tagged { tag, inner } = &rvalue.kind {
                     if let ExprKind::Ident(lh) = &lvalue.kind {
                         let lname = self.resolve_hier_name(lh);
-                        self.active_union_tag
-                            .insert(lname.clone(), tag.name.clone());
+                        // §7.3.2: the pattern literal `tagged '{ member: value }`
+                        // carries no member name between `tagged` and `'{` — the
+                        // tag IS the first named item of the pattern. Without it
+                        // `active_union_tag` stays empty and every later
+                        // `u.member` read (tagged_union_member) returns x.
+                        let tag_name = if tag.name.is_empty() {
+                            inner.as_ref().map_or(String::new(), |ie| {
+                                if let ExprKind::AssignmentPattern(items) = &ie.kind {
+                                    items.iter().find_map(|it| match it {
+                                        AssignmentPatternItem::Named(id, _) => Some(id.name.clone()),
+                                        _ => None,
+                                    }).unwrap_or_default()
+                                } else {
+                                    String::new()
+                                }
+                            })
+                        } else {
+                            tag.name.clone()
+                        };
+                        self.active_union_tag.insert(lname.clone(), tag_name);
                         if let Some(inner_expr) = inner {
                             let v = self.eval_expr(inner_expr);
                             self.set_signal_value_by_name(&lname, v);

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -151,6 +151,8 @@ mod struct_unpacked_array_member;
 mod submodule_packed_struct_member_contassign;
 #[path = "types/tagged_union_matches.rs"]
 mod tagged_union_matches;
+#[path = "types/tagged_union_pattern_literal.rs"]
+mod tagged_union_pattern_literal;
 #[path = "types/task_formal_param_width.rs"]
 mod task_formal_param_width;
 #[path = "types/type_param_bound_to_specialization.rs"]

--- a/tests/types/tagged_union_pattern_literal.rs
+++ b/tests/types/tagged_union_pattern_literal.rs
@@ -1,0 +1,53 @@
+//! §7.3.1 — tagged union pattern literal `tagged member '{ ... }`.
+//!
+//! The parser previously accepted only `tagged member` and
+//! `tagged member(expr)`; a pattern literal (`tagged '{b: 8'h5a}`) failed to
+//! parse. The pattern's assignment-pattern content is now parsed through the
+//! shared item loop and evaluated into the union's member storage.
+
+use xezim::simulate;
+
+const SRC: &str = r#"
+module tb;
+  typedef union tagged packed {
+    logic [7:0]  b;
+    logic [15:0] h;
+  } u_t;
+
+  u_t u_byte;
+  u_t u_half;
+  u_t u_again;
+
+  logic [7:0]  byte_val = 8'h0;
+  logic [15:0] half_val = 16'h0;
+  logic [15:0] again_h  = 16'h0;
+
+  initial begin
+    u_byte = tagged '{b: 8'h5a};
+    u_half = tagged '{h: 16'h1234};
+    byte_val = u_byte.b;
+    half_val = u_half.h;
+    // Re-tagging the same variable selects the new member: the tag must be
+    // extracted from each pattern, not cached from the first assignment.
+    u_again = tagged '{b: 8'h01};
+    u_again = tagged '{h: 16'hABCD};
+    again_h = u_again.h;
+  end
+endmodule
+"#;
+
+fn u(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .or_else(|| sim.get_signal(&format!("tb.{}", n)))
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able", n))
+}
+
+#[test]
+fn tagged_union_pattern_literal_selects_member() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(u(&sim, "byte_val"), 0x5a, "tagged pattern b member value");
+    assert_eq!(u(&sim, "half_val"), 0x1234, "tagged pattern h member value");
+    assert_eq!(u(&sim, "again_h"), 0xABCD, "re-tagged pattern selects new member");
+}


### PR DESCRIPTION
# sim: recover the tag of a tagged-union pattern literal (IEEE1800-2017 §7.3.1)

Companion to the xezim-core fix **"fix: parse tagged-union pattern literals
(IEEE1800-2017 §7.3.1)"** —
[aionhw/xezim-core#19](https://github.com/aionhw/xezim-core/pull/19).
Merge the core change first: xezim CI builds against xezim-core at `main`, so
this regression test only passes once the paired core PR lands.

## Problem

With parsing fixed, `u = tagged '{b: 8'h5a};` stored the value correctly
but every later `u.b` read returned x. A pattern literal carries no member
name between `tagged` and `'{` — the active member IS the first named item
of the pattern. The assignment left `active_union_tag` empty, and
`tagged_union_member` (which gates reads on the tag) then returned the
default x-value even though the stored bits were right.

## Fix

When `ExprKind::Tagged` has an empty tag and its inner expression is an
assignment pattern, derive the tag from the pattern's first `Named` item
before recording it in `active_union_tag`. The value path is unchanged.
Adds `tests/types/tagged_union_pattern_literal.rs` (including a re-tagging
case that re-selects the member).

## Verification

- Repro above: `u.b` read `x` before, `8'h5a` after.
- The bundled compliance suite advanced 36 → `TEST_PASS`.
- `cargo test --no-fail-fast` and `cargo test --features jit --no-fail-fast`:
  `tests/types` 253/253 green.

## Checklist

- [x] Failing behavior captured before the fix
- [x] Passes with the fix
- [x] LRM reference: IEEE 1800-2017 §7.3.1
- [x] Regression test follows the `tests/types` convention (group root mod line added)
- [x] No unrelated changes
