### PR TITLE
docs: add AGENTS.md, CLAUDE.md, dev docs and agent tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,282 @@
+# xezim — Development Guide for AI Coding Agents
+
+This file is read by coding agents (Claude Code, OpenAI Codex, Cursor, Copilot) at
+the start of every session. It is **operational**: what to build, how to build it,
+what must never break. Deep design notes stay in `docs/` — this file points to them
+and stays general. If a fact here conflicts with the code, the code (and the test
+suite) is the source of truth; fix this file.
+
+## What this is
+
+`xezim` is a **SystemVerilog bytecode interpreter** written in Rust (~100k LOC in
+`src/`). It parses IEEE 1800-2023 (opt back to 2017 with `--sv2017`), elaborates,
+and simulates combinational + sequential logic, classes/UVM, constraints, DPI/VPI,
+SDF, and VCD/XTrace/FST dumps. It is **not** a compiler — a separate crate
+(`xezim-b`) does ahead-of-time native compilation and is out of scope here.
+
+Parsing, elaboration, and the 4-state value model live in the **sibling repo
+`xezim-core`** (a path dependency at `../xezim-core`, not a submodule — clone both
+repos into the same parent). The simulator runs **elaborated** designs: most bug
+fixes land either in `xezim-core` (parser/elaboration) or in `src/compiler/simulator.rs`
+(the VM). Read `../xezim-core/AGENTS.md` before editing that repo.
+
+## Repository map
+
+```
+src/main.rs                     CLI: arg parsing, --parse/--compile/--simulate/--preprocess,
+                                memory watchdog, design-cache dir, -l log redirect
+src/lib.rs                      Public API; test entry points xezim::simulate / simulate_multi;
+                                content-addressed design cache
+src/compiler/simulator.rs       Event-driven VM — the repo's largest file; most fixes touch it
+src/compiler/bytecode.rs        Bytecode IR + compiler (flat Insn[] array, no pointer-chasing)
+src/compiler/arena.rs           Bump allocator for per-tick/per-block allocations
+src/compiler/dispatch.rs        Direct-threaded dispatch table (POC; partial integration)
+src/compiler/soa.rs             Structure-of-Arrays signal-table layout (perf work)
+src/compiler/jit.rs             Optional cranelift JIT (--features jit), falls back to interpreter
+src/compiler/fst_sink.rs        FST waveform sink
+src/intra_delay.rs              Pre-parse rewrite of `lhs = #d rhs` (see Gotchas)
+src/should_fail_lint.rs         Additive second-pass error lint for sv-tests negative cases
+src/multikernel.rs              EXPERIMENTAL per-LP PDES skeleton — not production
+tests/                          8 integration groups + subprocess runners + compliance suites
+bench/                          Cross-platform benchmarks (B1/B2/B3/B5, run_bench.sh)
+simtest/                        XuanTie C910/C906 real-RTL workloads (need external setup)
+dpi/                            Spike DPI shim example
+include/                        Minimal svdpi.h / vpi_user.h / veriuser.h + UVM DPI driver
+examples/                       Small .sv / .v demos (start here to try the tool)
+scripts/                        UVM DPI build (Makefile), installers
+docs/                           uvm-guide.md, dpi-guide.md, perf notes, design notes
+reports/                        sv-tests compliance HTML/CSV and UVM reference reports
+```
+
+## Build
+
+Prerequisite: `xezim-core` checked out at `../xezim-core` (Cargo references it via
+`path = "../xezim-core"`). Toolchain: Rust **1.92** MSRV (`rust-version` in
+`Cargo.toml`), edition 2024.
+
+```bash
+cargo build                        # debug
+cargo build --release              # optimized; binary at target/release/xezim
+cargo build --release --features jit    # optional cranelift JIT (CI tests this config)
+cargo build --release --profile release-lto --bin xezim   # interpreter-only fat-LTO
+```
+
+`.cargo/config.toml` sets `RUST_MIN_STACK = 33554432` for cargo-invoked processes:
+deeply recursive SystemVerilog expressions (concat chains, nested member access,
+recursive functions, parameterized class construction) overflow the Rust default
+2 MiB stack in debug builds. **Never lower this.** Release builds use smaller frames.
+
+## Run
+
+```bash
+cargo run --release -- examples/full_adder.sv          # simulate (default mode)
+./target/release/xezim <sources...> [plusargs] [options]
+```
+
+Modes: `--parse` (lex+parse only), `--compile` (parse+elaborate), `--simulate`
+(default), `--preprocess` (emit expanded text). Common flags:
+
+| Flag | Purpose |
+|---|---|
+| `-s <module>` | Top module; repeat for multiple roots (`-s hdl_top -s hvl_top`) |
+| `-I<dir>` / `-D<MACRO>[=val]` | Include dir / preprocessor define |
+| `--dpi-lib <path>` | Load a DPI-C shared library (repeatable) |
+| `--vpi-lib <path>` (`-m`) | Load a VPI module; run its `vlog_startup_routines` |
+| `--sdf <file>` + `--sdf-{min,typ,max}` | Annotate standard delays |
+| `--max-time <N>[ps\|ns\|us\|ms\|s]` | Stop after N ns (unit default ns); cap in whole ns |
+| `+<plusarg>` | Passed to `$value$plusargs` / `$test$plusargs` |
+| `+seed=<n>` | RNG seed (default 1 ⇒ reproducible; `+seed=random` opts into entropy) |
+| `--module-timescale [mods=]<u>/<p>` | Timescale for modules with none (xezim extension) |
+| `--dump-timescales` | Print every module's resolved timescale, then run |
+| `--dump-files-list` | Print resolved file list after `-f` expansion, then exit |
+| `--dump-merged-sv <file>` | Write all sources as one self-contained `.sv` |
+| `-l` / `--log <file>` | Redirect stdout+stderr (incl. DPI/VPI C output) to a log |
+| `-v <file>` / `-y <dir>` / `+libext+<ext>+…` | Library files/dirs (IEEE §23.3.2) |
+| `+nospecify` / `+notimingcheck` | Gate-level flags (commercial-compatible) |
+| `--xtrace <file>` / `--xtrace-scope <hier>` | XTrace v1.0 dump (`.zst` ⇒ zstd) |
+| `--sim-debug` / `--verbose` | `[DEBUG]`/`[OPT]` output / per-file compile progress |
+| `--cache-dir <dir>` / `--no-cache` | Select / disable the design cache |
+
+Env knobs (off unless noted): `XEZIM_EVENT_EDGE=1` (skip unchanged flop fires),
+`XEZIM_INIT_ZERO=1` (coerce X-init to 0), `XEZIM_PROGRESS=N` (`[PROGRESS]` every N s),
+`XEZIM_STUCK_CLOCK` (dead-clock watchdog: `warn` default, `abort` for CI),
+`XEZIM_NO_MEM_WATCHDOG=1`, `XEZIM_CACHE_DIR`, `XEZIM_NO_CACHE=1`,
+`XEZIM_COMPILE_PHASES=1`.
+
+## Testing
+
+The suite is the source of truth — the README reports 91.3 % of sv-tests pass
+(4354/4768) and this suite must stay green. **CI runs `cargo test` in two feature
+configs** (`test.yml`: `cargo test --no-fail-fast` then
+`cargo test --features jit --no-fail-fast`); `msrv.yml` runs `cargo msrv verify`.
+
+```bash
+cargo test                       # everything (the full run takes a while)
+cargo test --test classes        # one integration group
+cargo test --test classes class_property   # name filter within a group
+cargo test --features jit        # JIT config (CI requirement)
+```
+
+Two harness styles — use the one that fits:
+
+1. **In-process groups** (the norm for new features/bug fixes). `tests/` has 8
+   group roots — `classes.rs`, `collections.rs`, `gates.rs`, `hierarchy.rs`,
+   `misc.rs`, `scheduling.rs`, `strings.rs`, `types.rs` — each a `#[path = "…"]`
+   module list over one topic directory (~1680 `#[test]` fns total). A test
+   simulates an inline SV source and asserts on final signal values:
+
+   ```rust
+   //! §8.25 — doc comment cites the LRM section and the bug/fix.
+   use xezim::simulate;
+   #[test]
+   fn range_mixing_class_and_scope_parameters_keeps_elaborated_width() {
+       let sim = simulate(SV_SOURCE, 100).expect("simulate failed");
+       assert_eq!(u(&sim, "w_both"), 12, "W+MW-1:0 with W=8, MW=4");
+   }
+   ```
+   Signals are read with `sim.get_signal("tb.sig")` (try both bare and `tb.`
+   prefixed names) → `.to_u64()`. **To add a test: drop the file in the group's
+   directory AND add one `#[path = "group/name.rs"] mod name;` line to the group
+   root** — forgetting the mod line is the classic silent no-op.
+
+2. **Subprocess runners** (`tests/misc/*_runner.rs`): spawn
+   `env!("CARGO_BIN_EXE_xezim")` against `.sv`/`.v` files and assert on output.
+   Markers that matter: positive tests must print `TEST_PASS` (not `TEST_FAIL`) or
+   `PASSED` (not `FAILED`); no output may contain `Parse errors` or
+   `Simulation error`; negative tests must exit non-zero and print `: error:` /
+   `Parse errors` / `Simulation error`. Suites: `prtest` (Icarus `pr*.v`, ~132 of
+   762 wired), `ivtest_*_cluster` (`reject`/`accept` — illegal forms must be
+   REJECTED, legal neighbors must still compile), `lrm_audit*`, `issue30`,
+   `issue_cases`, `sv_compliance` (manifest-driven positive + `tests_negative/`).
+
+Test code conventions: each test's `//!` doc states the LRM § and what it guards;
+assertion messages name the expected value; use the small `u(sim, name)` helper
+pattern where appropriate.
+
+## Architecture & where a symptom lives
+
+Pipeline: source → preprocessor → parser/AST (`xezim-core/xezim-parser`) →
+elaboration (`xezim-core/src/elaborate.rs`) → bytecode compile (`bytecode.rs`) →
+event-driven execution (`simulator.rs`). Key types: `Value`/`LogicBit` (4-state
+0/1/X/Z, width + signedness), `ElaboratedModule`, `Insn`, `Simulator`.
+
+| Symptom | Owner |
+|---|---|
+| Parse/preprocessor errors, AST shape | `xezim-core/xezim-parser` (lexer, preprocessor, parse/, ast/) |
+| Type/width/signedness, parameters, classes, port binding, `should_fail`-style legality | `xezim-core/src/elaborate.rs` |
+| Wrong simulated value, race/timing, event ordering, class/UVM runtime, `randomize`, DPI/VPI, dumping | `src/compiler/simulator.rs` |
+| Compile-time codegen / VM perf | `bytecode.rs`, `dispatch.rs`, `soa.rs`, `jit.rs` |
+| `$display`/formatting output | `xezim-core/src/stdout_sink.rs`, `simulator.rs` |
+
+Subsystems inside `simulator.rs`: Active/NBA/Reactive scheduling regions, comb
+settle iteration, edge dispatch (always_ff/always_latch/@posedge, `iff` guards),
+event/mailbox/semaphore waiters, process control (§9.7), constraint solver,
+coverage/covergroups, SDF delays, VCD/XTrace/FST sinks, plus `pdes_*` (experimental
+parallel, not production). Read `README.md` §Features and the `docs/*` design notes
+before deep work.
+
+## Critical invariants — do not break these
+
+- **Determinism is a hard requirement.** Two runs with identical inputs must be
+  byte-identical. The RNG defaults to seed 1 (`+seed=<n>` for a different stream;
+  `+seed=random` opts into entropy) and hash iteration is deterministic
+  (`xezim_core::hasher::HashMap/HashSet`, fixed ahash seeds). **Never** use
+  `std::collections::HashMap/HashSet` where iteration order can affect observable
+  behavior, and never seed an RNG from entropy by default.
+- **Global allocator**: `mimalloc` is installed in `xezim-core` (its default
+  feature). Rust allows exactly one `#[global_allocator]` per binary — never add
+  another. A downstream crate opting out uses
+  `xezim-core = { path = "../xezim-core", default-features = false }`.
+- **Design cache**: `--simulate` stores a content-addressed elaborated design and
+  reuses it on identical runs; it prints `[CACHE] hit/miss/stored` on stderr. The
+  key covers sources, defines, top, and the executable's own mtime/size, so a local
+  rebuild invalidates it — but use `--no-cache` whenever you are debugging a
+  behavior change you expect to see immediately.
+- **Memory watchdog**: `main.rs` spawns a thread that **SIGKILLs the process** when
+  RSS exceeds 3/4 of system memory (protects against OOM on huge designs). For
+  C910-scale runs set `XEZIM_NO_MEM_WATCHDOG=1`. This is expected behavior, not a
+  crash bug.
+- **intra-assignment delays**: the parser discards `lhs = #d rhs` (§9.4.5), so
+  `src/intra_delay.rs` rewrites the source text into a `$__xz_intra_delay(...)`
+  marker call **before parsing**. Any parser/lexer work must preserve this
+  interplay (the rewrite is applied in `simulate_multi` and the CLI).
+- **`should_fail` lint**: `src/should_fail_lint.rs` is an *additive* second pass
+  that rejects illegal constructs in **both `--compile` and `--simulate` modes**
+  (see `src/lib.rs:748`) for sv-tests negative cases. It must never change clean-design
+  behavior and must stay conservative (validated against a 1005-case static baseline).
+  Add checks there only for definite LRM violations.
+- **Logging**: route output through `log_eprintln`/`log_println` (they feed the
+  `-l` fd-level redirect that captures DPI/VPI C output). Bare `println!`/`eprintln!`
+  bypasses `--log`.
+- **Timescales**: per-module; the simulation tick is the finest declared precision
+  anywhere (down to `fs`); `--max-time` is in ns (independent of tick); `$time`
+  reports ticks. `--module-timescale` only applies to modules with no source-level
+  timescale.
+- **Sibling coordination**: parser/elaboration changes in `../xezim-core` are shared
+  with `xezim-b`. Keep the `xezim::compiler::*` re-export surface stable.
+
+## Coding conventions
+
+snake_case; Rust 2024 edition; MSRV 1.92 (`rust-version` in `Cargo.toml`);
+clippy-clean. Modules carry `//!`
+doc comments. Hard fixes get explanatory comments with **LRM § citations**
+(e.g. `§8.25`) and regression tests referencing the same section. Keep the public
+API minimal — re-exports from `xezim-core` exist so existing `xezim::compiler::…`
+paths keep working; do not remove them. User-facing errors are `Result<_, String>` /
+diagnostic strings; do not panic on user input. Prefer the smallest correct change
+and match the surrounding style.
+
+## Workflows
+
+**Fix a bug**
+1. Write the minimal SV repro and confirm the wrong behavior (`./target/release/xezim repro.sv`).
+2. Add a failing regression test (in-process group preferred; correct group root + `#[path]` mod line).
+3. Fix it in `simulator.rs` or `xezim-core`; keep the fix localized.
+4. `cargo test --test <group> <name>` until green, then the whole group.
+5. Run `cargo test --features jit` for the config CI covers, and re-verify
+   determinism (`+seed=1` twice, diff output) for RNG/solver changes.
+
+**Debug a wrong sim result**: `--sim-debug` and `--verbose` for diagnostics;
+`--dump-files-list`/`--dump-merged-sv` to understand a multi-file build;
+`XEZIM_PROGRESS=5` to watch a long run; the stall report (names the parked
+processes and the signal that should have woken them) for hangs; `XEZIM_STUCK_CLOCK`
+for frozen-clock churn; `--max-time` to bound a runaway; (or use `scripts/dev/quick-repro.sh '…snippet…'` to iterate without writing a repo file) `--threads` to toggle the
+parallel edge path (also `XEZIM_NO_PARALLEL=1` / `XEZIM_FORCE_PARALLEL=1`).
+
+**Add a feature**: parse it in `xezim-parser` → elaborate/type it in `elaborate.rs`
+→ execute it in `simulator.rs` (bytecode only if it must be fast) → add tests →
+document any new flag/env knob in the README tables.
+
+## No machine-specific or confidential content
+
+PRs are public and permanent. Never include absolute filesystem paths
+(`/home/...`, `/root/...`, `C:\Users\...`), local usernames, hostnames, IP
+addresses, environment-variable values, tokens, or other machine-specific
+details in docs, code, commit messages, or PR descriptions. Use repo-relative
+paths only and keep everything reproducible from the repository itself. Before
+submitting, scan your added files for local paths and secrets.
+
+## Before you open a PR
+
+- Regression test added **with an LRM § citation** in its doc comment, wired into
+  the correct group root.
+- `cargo test --no-fail-fast` **and** `cargo test --features jit --no-fail-fast`
+  both green (this is exactly what CI runs — a PR that fails CI here will be
+  rejected).
+- New CLI flag or env var documented in the README tables (and `print_usage`).
+- Determinism preserved; no `std` hash/RNG order leaks.
+- Minimal diff: no unrelated refactors, no dead code added.
+- Run the full suite on one machine before submitting — a few local tests are not
+  enough.
+- If this guide becomes wrong (paths, commands, conventions), fix it in the same PR.
+
+## Resources
+
+- `docs/dev/README.md` — developer documentation: architecture, debugging, testing, gotchas
+- `README.md` — features, CLI reference, compliance, build/run, module-timescale extension
+- `docs/uvm-guide.md` — running UVM 1800.2-2017 / 2020.3.1 testbenches
+- `docs/dpi-guide.md` — compiling + loading DPI-C libraries
+- `docs/ast_shared_stmt_lists_scope.md`, `docs/perf_dump_offload_2026-07-28.md` — design/perf notes
+- `bench/README.md` — benchmark methodology (fix the work, not the time)
+- `reports/sv-tests-compliance.md` — sv-tests pass rates by category
+- `simtest/xuantie_c910/README.md` — real-RTL C910/C906 workloads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+## Claude Code
+
+- Use plan mode for significant or multi-file changes.
+- After a change, run the focused test group before the full suite
+  (`cargo test --test <group> <name>`).
+- If a sim result looks wrong, reproduce it with a minimal SV case before editing.
+- Re-verify determinism (`+seed=1` twice, diff the output) for RNG/solver changes.
+- When behavior is ambiguous, treat the existing test suite as the source of truth.

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -1,0 +1,88 @@
+# xezim Gotchas — the rules that are not obvious
+
+Each rule: what to do, why, and the source that proves it.
+
+## 1. Determinism is a hard requirement
+
+The RNG defaults to **seed 1**; `+seed=<n>` selects a different stream and
+`+seed=random` opts into entropy (usage text, `src/main.rs`). Two runs with
+identical inputs and seed must be **byte-identical**. Never seed from entropy by
+default. After any RNG/solver change, re-verify with the same command twice and
+`diff` the output.
+
+## 2. The deterministic hasher
+
+Use `xezim_core::hasher::{HashMap, HashSet}` — they hold fixed ahash seeds
+(`DeterministicState`, `../xezim-core/src/lib.rs`). **Never** use
+`std::collections::HashMap/HashSet` where iteration order can affect observable
+behavior; unordered traversal would break determinism run-to-run.
+
+## 3. Only one global allocator (mimalloc)
+
+mimalloc is installed by `xezim-core`'s default feature
+(`../xezim-core/Cargo.toml`). Rust allows exactly one `#[global_allocator]`
+per binary — **never add another**. A downstream crate opts out with
+`xezim-core = { path = "../xezim-core", default-features = false }`.
+
+## 4. 32 MiB minimum stack
+
+`.cargo/config.toml` sets `RUST_MIN_STACK = "33554432"` for cargo-invoked
+processes. Deeply recursive SV expressions (concat chains, nested member access,
+recursive functions, parameterized class construction) overflow the Rust default
+2 MiB stack in debug builds. **Never lower this.**
+
+## 5. Design cache
+
+`[CACHE] hit|miss|stored` on stderr (`src/lib.rs`, design-cache module); the key
+includes the executable's mtime/size, so a local rebuild invalidates cached
+artifacts automatically. While iterating on a behavior change, pass `--no-cache`
+— a stale `[CACHE] hit` can mask your edit.
+
+## 6. Memory watchdog
+
+`main.rs` SIGKILLs the process when RSS exceeds 3/4 of system memory,
+printing `[xezim][mem-watchdog] …`. Expected protection, not a crash bug. Only
+disable for known-huge runs: `XEZIM_NO_MEM_WATCHDOG=1`.
+
+## 7. Dead-clock watchdog
+
+`XEZIM_STUCK_CLOCK=off|warn|abort` (`simulator.rs`, dead-clock watchdog
+setup) turns a frozen-clock churn into a hard failure. Default `warn`; use
+`abort` for CI.
+
+## 8. Intra-assignment-delay pre-parse rewrite
+
+The parser discards `lhs = #d rhs` (§9.4.5), so `src/intra_delay.rs` rewrites the
+source text into a `$__xz_intra_delay(...)` marker **before** parsing. Any
+parser/lexer work must preserve this interplay — a delay symptom points at the
+rewrite, not the parser.
+
+## 9. should_fail lint is additive
+
+`src/should_fail_lint.rs` is an additive second pass that rejects illegal
+constructs in **both `--compile` and `--simulate` modes** (see `src/lib.rs:748`
+for the simulate path invocation) for sv-tests negative cases. It is validated
+against a 1005-case static baseline (documented in the module header,
+`src/should_fail_lint.rs`). It must never change clean-design behavior and must
+stay conservative — add checks there only for definite LRM violations.
+
+## 10. Logging routing
+
+Route output through `log_println` / `log_eprintln`
+(`../xezim-core/src/lib.rs`) so the `-l` fd-level redirect works —
+it captures DPI/VPI C output too. Bare `println!` / `eprintln!` bypasses `--log`.
+
+## 11. Per-module timescales
+
+The simulation tick is the finest declared precision anywhere (down to `fs`);
+`--max-time` is in ns (independent of tick); `$time` reports ticks.
+`--module-timescale` applies only to modules with no source-level timescale.
+
+## 12. xezim-core artifact versioning
+
+`XEZIM_BYTECODE_MAGIC = b"XEZIMBC\x0c"` — the last byte is the serialized-format
+version (`../xezim-core/src/lib.rs`). When you add or change a serialized
+field in `ElaboratedModule` (or any bincode-serialized type), **bump `\x0c` to
+`\x0d`** and add one line to the version-ladder comment above it. Stale
+artifacts then fail with a clear "recompile with current xezim" error instead of
+deserializing garbage.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,101 @@
+# Testing xezim
+
+How the suite is organized, how to run it, and how to add a test.
+
+## 1. The two harness styles
+
+**In-process groups** (the norm for new features/bug fixes). Nine integration
+group roots in `tests/` — `classes.rs`, `collections.rs`, `gates.rs`,
+`hierarchy.rs`, `misc.rs`, `perf.rs`, `scheduling.rs`, `strings.rs`, `types.rs` — each a
+flat list of `#[path = "<group>/<name>.rs"] mod <name>;` declarations (no `{}`
+wrapper) over one topic directory. ~1680 `#[test]` fns total. A test simulates
+an inline SV source and asserts on final signal values.
+
+**Subprocess runners** (in `tests/misc/` and other groups). They spawn
+`env!("CARGO_BIN_EXE_xezim")` against `.sv`/`.v` files and assert on the output.
+Suites: `prtest_runner.rs` (Icarus `pr*.v`, ~132 of 762 wired),
+`ivtest_{ce,misc,tail,tail2}_cluster.rs` (CE cluster has `reject(name, src)` /
+`accept(name, src)` helpers — illegal forms must be REJECTED, legal neighbors
+must still compile), `lrm_audit{,2,3}_runner.rs`, `issue30_runner.rs`,
+`issue_cases_runner.rs`, `sv_compliance_runner.rs`, `sv2023_compliance_runner.rs`.
+
+The ivtest clusters live across multiple groups:
+- `tests/types/ivtest_cast_cluster.rs`
+- `tests/classes/ivtest_class_struct_cluster.rs`
+- `tests/hierarchy/ivtest_port_cluster.rs`
+- `tests/scheduling/ivtest_always_cluster.rs`
+- `tests/misc/ivtest_ce_cluster.rs`, `ivtest_misc_cluster.rs`, `ivtest_tail_cluster.rs`, `ivtest_tail2_cluster.rs`
+
+## 2. Running tests
+
+```bash
+cargo test                          # everything (the full run takes a while)
+cargo test --test classes           # one integration group
+cargo test --test classes class_property   # name filter within a group
+cargo test --features jit           # the JIT config CI also covers
+```
+
+CI (`test.yml`) runs `cargo test --no-fail-fast` **and**
+`cargo test --features jit --no-fail-fast` — both must stay green.
+
+## 3. Adding an in-process test
+
+Manually, or with `scripts/dev/new-test.sh <group> <snake_case_name>`.
+
+**Both of these are required:**
+
+1. Create `tests/<group>/<name>.rs`.
+2. Add `#[path = "<group>/<name>.rs"] mod <name>;` to the group root
+   `tests/<group>.rs`.
+
+The test body looks like this:
+
+```rust
+//! §8.25 — doc comment cites the LRM section and the bug/fix.
+use xezim::simulate;
+
+#[test]
+fn the_bug_under_test() {
+    let sim = simulate(SV_SOURCE, 100).expect("simulate failed");
+    assert_eq!(u(&sim, "tb.sig"), 42, "expected value");
+}
+```
+
+`u` is a small local helper that tries `sim.get_signal(n)` then the
+`tb.`-prefixed form — see the real `fn u` in
+`tests/classes/issue4_coupled_constraints.rs` and
+`tests/classes/class_property_param_width.rs`.
+
+## 4. Conventions for a good test
+
+- The `//!` doc comment cites the LRM § and the bug/fix (e.g.
+  `tests/classes/class_property_param_width.rs` cites `§8.25 / §6.9.1`).
+- The assertion message names the expected value.
+- Use `xezim::simulate_multi` when you need multiple sources / include dirs /
+  defines (see `tests/classes/uvm_config_db_tests.rs`).
+- Signals are read with `sim.get_signal("tb.sig")` (try both bare and `tb.`
+  prefixed names) → `.to_u64()`.
+
+## 5. The subprocess runner suites and their stdout markers
+
+Markers that matter:
+
+- Positive tests must print `TEST_PASS` (not `TEST_FAIL`) or `PASSED` (not
+  `FAILED`).
+- No output may contain `Parse errors` or `Simulation error`.
+- Negative tests must exit non-zero and print `: error:` / `Parse errors` /
+  `Simulation error`.
+
+## 6. Common pitfalls
+
+- **Missing mod line**: a test file dropped in a topic directory but never
+  registered in the group root compiles silently and never runs. This is the
+  classic silent no-op.
+- **Wrong group**: pick the topic directory that matches the feature.
+- **Signal path**: read signals by their hierarchical name (`tb.` prefix) — a
+  bare name may not resolve.
+- **4-state X where 2-state is expected**: X-init can leak into asserted values;
+  use `XEZIM_INIT_ZERO=1` only when X-init coercion is the point.
+- **Random data without a fixed seed**: a test that collects random packets
+  (`$urandom`) must not assert an exact count unless it fixes `+seed` — the
+  default seed is 1, but an explicit `+seed` makes the intent obvious.

--- a/scripts/dev/check-determinism.sh
+++ b/scripts/dev/check-determinism.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify a design is deterministic: run it twice with the same seed and fail
+# if the outputs differ. Identical inputs must give byte-identical output.
+#
+#   scripts/dev/check-determinism.sh design.sv
+#   scripts/dev/check-determinism.sh design.sv +seed=7 --max-time 200
+#
+# Pass +seed=<n> (default is seed 1). Use +seed=random only if you want to
+# confirm your analysis ignores entropy — two random runs SHOULD differ.
+set -uo pipefail
+
+if [ "$#" -lt 1 ] || [ ! -f "$1" ]; then
+  echo "usage: $(basename "$0") <design.sv> [xezim args...]" >&2
+  exit 2
+fi
+design="$1"
+shift
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo/target/release/xezim"
+if [ ! -x "$bin" ]; then
+  echo "release binary missing — run: cargo build --release" >&2
+  exit 2
+fi
+
+r1="$(mktemp)"; r2="$(mktemp)"
+trap 'rm -f "$r1" "$r2"' EXIT
+
+"$bin" "$design" "$@" --no-cache >"$r1" 2>&1; s1=$?
+"$bin" "$design" "$@" --no-cache >"$r2" 2>&1; s2=$?
+
+if [ "$s1" -ne "$s2" ]; then
+  echo "DETERMINISM FAILURE: exit codes differ ($s1 vs $s2)" >&2
+  exit 1
+fi
+if ! diff -q "$r1" "$r2" >/dev/null; then
+  echo "DETERMINISM FAILURE: two identical runs produced different output" >&2
+  diff -u "$r1" "$r2" >&2
+  exit 1
+fi
+echo "DETERMINISM OK: byte-identical (exit $s1)"

--- a/scripts/dev/new-test.sh
+++ b/scripts/dev/new-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Scaffold a new integration test in a group and wire it into the group root.
+#
+#   scripts/dev/new-test.sh scheduling regress_foo
+#   cargo test --test scheduling regress_foo
+#
+# Creates tests/<group>/<name>.rs and appends the #[path] + mod lines to
+# tests/<group>.rs. The classic failure is forgetting the mod line — this
+# script makes it impossible.
+set -uo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $(basename "$0") <group> <snake_case_name>" >&2
+  exit 2
+fi
+group="$1"
+name="$2"
+
+case "$group" in
+  classes|collections|gates|hierarchy|misc|perf|scheduling|strings|types) ;;
+  *) echo "unknown group '$group' (expected one of: classes collections gates hierarchy misc perf scheduling strings types)" >&2; exit 1 ;;
+esac
+if ! printf '%s' "$name" | grep -qE '^[a-z][a-z0-9_]*$'; then
+  echo "invalid test name '$name' (use snake_case, lowercase start)" >&2
+  exit 1
+fi
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+root="$repo/tests/$group.rs"
+file="$repo/tests/$group/$name.rs"
+
+if [ -e "$file" ]; then
+  echo "already exists: $file" >&2
+  exit 1
+fi
+
+cat >"$file" <<EOF
+//! <LRM § + what this guards> — see docs/dev/testing.md for conventions.
+use xezim::simulate;
+
+#[test]
+fn $name() {
+    let sim = simulate(
+        r#"
+module tb;
+  // minimal repro
+endmodule
+"#,
+        100,
+    )
+    .expect("simulate failed");
+    // assert_eq!(u(&sim, "tb.sig"), N, "expected value");
+}
+EOF
+
+printf '#[path = "%s/%s.rs"]\nmod %s;\n' "$group" "$name" "$name" >>"$root"
+
+echo "created $file"
+echo "appended mod line to $root"
+echo "run it with: cargo test --test $group $name"


### PR DESCRIPTION
## Summary

Adds the developer-assistance package for AI coding agents to `xezim`: a canonical `AGENTS.md` (repo guide), a thin `CLAUDE.md` wrapper, a deep-dive `docs/dev/` reference set (architecture, debugging, testing, gotchas), a `scripts/dev/` shell toolbox, and one shared development skill under `.claude/skills/`.

This is a resubmission of #96, incorporating the review: the dated plan document is removed, the branch is rebased on current `main` (MSRV 1.92), and stale facts are refreshed. **No `*.rs` changes — documentation and tooling only.**

## What's included

| Piece | What it does |
|---|---|
| `AGENTS.md` (~275 lines) | Orientation for any coding agent: repo map, build/run/test commands, symptom→owner map, critical invariants (determinism, mimalloc, design cache, watchdogs, intra-assignment delays, should_fail lint, logging, timescales, sibling coordination), conventions, workflows, pre-PR checklist |
| `CLAUDE.md` | Imports `AGENTS.md` + 8 lines of Claude Code workflow notes |
| `docs/dev/architecture.md` | Deep dive: two-crate split, pipeline, central types, subsystems |
| `docs/dev/debugging.md` | Reproduce-first workflow, diagnostic markers, `XEZIM_*` runtime knobs, exit codes |
| `docs/dev/gotchas.md` | The non-obvious rules (determinism, hasher, allocator, cache, watchdogs, artifact versioning) with the source that proves each |
| `docs/dev/testing.md` | The two harness styles, how to run and how to add a test |
| `scripts/dev/quick-repro.sh` | Simulate a one-off SV snippet without writing a repo file |
| `scripts/dev/check-determinism.sh` | Run twice with the same seed; fail on any drift |
| `scripts/dev/new-test.sh` | Scaffold a test and wire its `#[path]` mod line into the group root |
| `.claude/skills/xezim-development/SKILL.md` | A packaged skill: reproduce → regress → fix → verify, with a symptom→file quick reference |

## Deliberate policy change: `.gitignore` un-ignores `.claude/skills/`

To make the shared development skill version-controlled, `.gitignore` changes from `.claude/` to `.claude/*` with `!.claude/skills/**`:

```diff
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**
```

This is an intentional decision, not a side effect: only the `skills/` subtree becomes repo-tracked, so contributors inherit one evolving, maintained skill rather than private copies. Everything else under `.claude/` (settings, local state) stays local and out of the repo. Contributors who prefer not to carry the skill are unaffected — it is inert unless invoked.

## Why this helps everyone who develops here

- **One read to orient.** A new contributor — human or agent — reads `AGENTS.md` and knows where things live, which file owns which symptom, how to build/test, and which invariants must never break. This encodes knowledge that is otherwise spread across the codebase and tribal.
- **Agents and humans share the same context.** Claude Code, Codex, Cursor, Copilot, and a new team member all get the same accurate starting point, so assistance is consistent and grounded in the repo as it actually is.
- **Reproducible workflows.** The scripts encode the steps agents otherwise re-derive each time (determinism check, quick repro, test scaffolding) — small, reviewed, and composable.

## Scoped, and open to iteration

This is a **first, foundational pass** — deliberately small and reviewable. It makes no behavior changes. Many things can be layered on later, and we'd welcome the maintainer's direction on them: a `CONTRIBUTING.md` that links these guides, further skills, deeper subsystem docs, or CI that lints doc claims against the code. Happy to adjust scope, tone, or content to fit the project's conventions.

A companion, matching guide for the sibling `xezim-core` library is prepared in a separate PR (aionhw/xezim-core) so the cross-references in these docs resolve.

## Verification

- Rebased on current `main`; all doc facts (commands, flags, env knobs, file paths, MSRV) checked against the tree.
- `scripts/dev/*.sh` pass `bash -n` and functional smoke tests (scaffold, usage, validation paths).
- The `.gitignore` change was tested: the skill is committable, other `.claude/` content remains ignored.
- No `*.rs` changes.

@aionhw 