### PR TITLE
simulator: instance_assoc_member uses runtime class, not lexical stack

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -73803,7 +73803,17 @@ impl Simulator {
         if handle == 0 {
             return None;
         }
-        let ctx = self.class_context_stack.last().cloned().flatten()?;
+        // Use the runtime class of `this` (from the heap) rather than the
+        // lexical class_context_stack.  When a bare method call (e.g. `body()`)
+        // is inlined without updating class_context_stack, the stack still
+        // holds the CALLER's class (e.g. "uvm_sequence_base"), so a foreach
+        // over a member array declared in the concrete subclass ("my_seq")
+        // would fail to resolve.  The heap always knows the actual type.
+        let ctx = self
+            .heap
+            .get(handle)
+            .and_then(|x| x.as_ref())
+            .map(|i| i.class_name.clone())?;
         let mut cur = Some(ctx);
         while let Some(cn) = cur {
             let cd = self.module.classes.get(&cn)?;


### PR DESCRIPTION
foreach over a class-member fixed/associative/queue array declared in a concrete subclass failed to resolve when the enclosing method was called bare and unqualified (e.g. UVM's `seq.start()` -> `body()`), because Stage 1b inlining doesn't update class_context_stack for that call form -- it's left pointing at the CALLER's class (uvm_sequence_base) instead of the concrete subclass (my_seq).

instance_assoc_member walked class_context_stack to find the array's declaring class, so it looked in the wrong class, found nothing, and foreach_materialize_keys_1d returned None. The async ForeachTail path treats that as "not ready", so exec_park_cont replays the same iteration forever (i=0 repeating) instead of erroring or completing.

Fix: look up the class via the heap's runtime type (heap[handle].class_name), which is always the concrete instantiated class regardless of how the containing method was invoked.

Repro: repros/foreach_int_repro.sv (all 3 items must flow through the driver instead of stalling at i=0).