### PR TITLE
sim: struct-formal binding, foreach-over-string-collections, and randomize-solver fixes

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -48097,6 +48097,103 @@ impl Simulator {
                         while let ExprKind::Index { expr: inner, .. } = &root.kind {
                             root = inner.as_ref();
                         }
+                        // §4c/: `obj.member[k] = new(...)` — the collection is
+                        // a MEMBER of a class handle (`mid.base[i] = new(...)`
+                        // in do_unpack, or the flattened nested
+                        // `a.mid.base[i] = new(...)`). The root unwraps to a
+                        // MemberAccess or a flattened >=3-seg Ident. Resolve
+                        // the element class from the RECEIVER's runtime class
+                        // property so the bare `new(...)` constructs the
+                        // declared element type instead of the enclosing
+                        // `this` class (which would run a component ctor and
+                        // trip the UVM ILLCRT guard deep inside the library).
+                        let recv_member: Option<(Expression, String)> = match &root.kind {
+                            ExprKind::MemberAccess { expr: recv, member } => {
+                                Some(((**recv).clone(), member.name.clone()))
+                            }
+                            ExprKind::Ident(ih) if ih.path.len() >= 3 => {
+                                let mut p = ih.clone();
+                                let member = p.path.pop().unwrap().name.name.clone();
+                                p.cached_signal_id = std::cell::Cell::new(None);
+                                Some((Expression::new(ExprKind::Ident(p), lvalue.span), member))
+                            }
+                            _ => None,
+                        };
+                        if let Some((recv, member_name)) = recv_member {
+                            let this_recv = matches!(&recv.kind, ExprKind::Ident(rh)
+                                if rh.path.len() == 1 && rh.path[0].name.name == "this");
+                            let handle = if this_recv {
+                                self.this_stack.last().copied().flatten().unwrap_or(0)
+                            } else {
+                                self.eval_handle_expr(&recv).unwrap_or(0)
+                            };
+                            if handle != 0 {
+                                let hcn = self
+                                    .heap
+                                    .get(handle)
+                                    .and_then(|o| o.as_ref())
+                                    .map(|i| i.class_name.clone());
+                                let mut mtn: Option<String> = None;
+                                let mut cur = hcn;
+                                while let Some(cn) = cur {
+                                    if let Some(cd) = self.module.classes.get(&cn) {
+                                        if let Some(tn) = cd
+                                            .properties
+                                            .get(&member_name)
+                                            .and_then(|s| s.type_name.clone())
+                                        {
+                                            mtn = Some(tn);
+                                            break;
+                                        }
+                                        cur = cd.extends.clone();
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                if let Some(mcls) = mtn
+                                    .as_deref()
+                                    .and_then(|t| {
+                                        self.resolve_typedef_spec(t)
+                                            .map(|(b, s)| (b.clone(), Some((b, s))))
+                                            .or_else(|| {
+                                                self.resolve_simple_typedef_class(t)
+                                                    .filter(|c| self.module.classes.contains_key(c))
+                                                    .map(|c| (c, None))
+                                            })
+                                            .or_else(|| {
+                                                self.extract_spec_from_string(t)
+                                                    .filter(|(b, _)| self.module.classes.contains_key(b))
+                                                    .map(|(b, s)| (b.clone(), Some((b, s))))
+                                            })
+                                            .or_else(|| {
+                                                self.module
+                                                    .classes
+                                                    .contains_key(t)
+                                                    .then(|| (t.to_string(), None))
+                                            })
+                                    })
+                                {
+                                    let ctor_args: &[Expression] = match &rvalue.kind {
+                                        ExprKind::Call { args, .. } => args,
+                                        _ => &[],
+                                    };
+                                    let (cn, spec) = mcls;
+                                    if let Some(cd) = self.module.classes.get(&cn).cloned() {
+                                        let v = if let Some((b, s)) = spec {
+                                            let saved = self.current_spec.take();
+                                            self.current_spec = Some((b, s));
+                                            let r = self.instantiate_class(&cd, ctor_args);
+                                            self.current_spec = saved;
+                                            r
+                                        } else {
+                                            self.instantiate_class(&cd, ctor_args)
+                                        };
+                                        self.assign_value(lvalue, &v);
+                                        return;
+                                    }
+                                }
+                            }
+                        }
                         if let ExprKind::Ident(bh) = &root.kind {
                             let bname = bh
                                 .path
@@ -48445,11 +48542,51 @@ impl Simulator {
                     if is_new && args.len() == 1 {
                         if let ExprKind::Ident(lh) = &lvalue.kind {
                             let mut lname = self.resolve_hier_name(lh);
-                            if let Some(s) = self.instance_assoc_member(&lname) {
-                                lname = s;
+                            if !(self.module.dynamic_arrays.contains(&lname)
+                                || self.module.arrays.contains_key(&lname))
+                            {
+                                // A class-member dynamic array reached either
+                                // via the CURRENT instance (`base` → this
+                                // context) or through an OBJECT HANDLE path
+                                // (`a.mid.base`, a flattened 3+ segment Ident).
+                                // Per-instance storage is `<handle>#member`,
+                                // not a module-scope array. Resolve that
+                                // scoped name so `= new[size]` sizes the right
+                                // instance's collection.
+                                let member = lh.path.last().map(|s| s.name.name.clone());
+                                let scoped: Option<String> = self
+                                    .instance_assoc_member(&lname)
+                                    .or_else(|| {
+                                        // Receiver path = all-but-last segment:
+                                        // `a.mid.base` → receiver `a.mid`.
+                                        let recv: Option<Expression> = if lh.path.len() >= 2 {
+                                            let mut p = lh.clone();
+                                            p.path.pop();
+                                            p.cached_signal_id =
+                                                std::cell::Cell::new(None);
+                                            Some(Expression::new(ExprKind::Ident(p), lvalue.span))
+                                        } else {
+                                            None
+                                        };
+                                        let h = recv
+                                            .as_ref()
+                                            .and_then(|r| self.eval_handle_expr(r))
+                                            .unwrap_or(0);
+                                        let m = member.clone().unwrap_or_default();
+                                        if h != 0 {
+                                            self.handle_collection_name(h, &m)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .or_else(|| self.expr_assoc_name(lvalue));
+                                if let Some(s) = scoped {
+                                    lname = s;
+                                }
                             }
                             if self.module.dynamic_arrays.contains(&lname)
                                 || self.module.arrays.contains_key(&lname)
+                                || lname.contains('#')
                             {
                             let size = self.eval_expr(&args[0]).to_u64().unwrap_or(0);
                             let w = self.module.arrays.get(&lname).map(|t| t.2).unwrap_or(32);
@@ -76954,6 +77091,38 @@ impl Simulator {
                     None
                 }
             }
+            // Flattened nested OBJECT handle: `a.mid.base` (path.len() >= 3).
+            // The receiver is an object chain (`a.mid`), not a static handle.
+            // Evaluate the receiver to a handle and scope the leaf member to it.
+            ExprKind::Ident(h)
+                if h.path.len() >= 3
+                    && !self.module.classes.contains_key(&h.path[0].name.name)
+                    && h.path.iter().all(|s| s.selects.is_empty()) =>
+            {
+                let n = h.path.len();
+                let member = h.path[n - 1].name.name.clone();
+                let mut recv = h.clone();
+                recv.path.pop();
+                recv.cached_signal_id = std::cell::Cell::new(None);
+                let recv_expr = Expression::new(ExprKind::Ident(recv), h.span);
+                let hh = self.eval_handle_expr(&recv_expr).unwrap_or(0);
+                if hh != 0 {
+                    if let Some(cn) = self
+                        .heap
+                        .get(hh)
+                        .and_then(|x| x.as_ref())
+                        .map(|i| i.class_name.clone())
+                    {
+                        if self.class_assoc_member(&cn, &member) {
+                            return Some(format!("{}#{}", hh, member));
+                        }
+                        if self.prop_bound_collection(hh, &cn, &member) {
+                            return Some(format!("{}#{}", hh, member));
+                        }
+                    }
+                }
+                None
+            }
             ExprKind::MemberAccess { expr: base, member } => {
                 if let ExprKind::Ident(bh) = &base.kind {
                     if bh.path.len() == 1 {
@@ -77994,6 +78163,7 @@ impl Simulator {
     }
 
     fn eval_call_inner(&mut self, func: &Expression, args: &[Expression]) -> Value {
+
         // Normalize away Specialization wrappers for dispatch shape-matching
         // (the `#(...)` text is retained in the original AST + `current_spec`
         // for per-spec static keying). Keeps pre-Specialization dispatch exact.

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -92595,7 +92595,25 @@ impl Simulator {
                         // start(..., int this_priority = -1): missing arg
                         // must be -1, not 0, else `this_priority < -1`
                         // (read unsigned) fatals SEQPRI.
-                        self.eval_expr(def)
+                        //
+                        // §13.5.3: a default is evaluated at call time IN
+                        // THE CALLEE'S SCOPE, so it may reference `this` /
+                        // call another method on the receiving instance
+                        // (`uvm_event#(T)::trigger(T data =
+                        // get_default_data())`). The instance's `this` and
+                        // class context are only pushed AFTER this binding
+                        // loop, so evaluate the default with them pushed
+                        // (and the partially-bound formals visible) so a
+                        // `this`-dependent method default resolves instead
+                        // of silently evaluating to the type's zero value.
+                        self.this_stack.push(Some(handle));
+                        self.class_context_stack.push(Some(cname.clone()));
+                        self.push_local_frame(locals.clone());
+                        let v = self.eval_expr(def);
+                        self.pop_local_frame();
+                        self.class_context_stack.pop();
+                        self.this_stack.pop();
+                        v
                     } else {
                         Value::zero(32)
                     };

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -93699,6 +93699,20 @@ impl Simulator {
                             }
                         }
                     }
+                    // §6.19/§21.2.1: an ENUM-typed collection element.
+                    // `array_elem_class` only records CLASS element types, so an
+                    // enum array (`numbers numa[]`) fell through to None and
+                    // `.name()`/one enum method rendered the value against a
+                    // GLOBAL scan, emitting a wrong (larger outer-scope) enum's
+                    // label (e.g. UVM_NORADIX for 0). The base array name itself
+                    // resolves to its element typedef (`numa` -> `numbers`), so
+                    // return that when the kernel knows it as an enum.
+                    let base_type = self.get_expr_type_name(cur);
+                    if let Some(t) = base_type {
+                        if self.module.enum_members.contains_key(&t) {
+                            return Some(t);
+                        }
+                    }
                 }
                 None
             }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -3446,6 +3446,20 @@ pub struct Simulator {
     /// `"<subroutine>::<var>"`. Only scalar integral/real statics are tracked;
     /// arrays/queues fall back to per-call storage.
     static_local_vars: HashMap<String, Value>,
+    /// Bare names of `static` subroutine locals that are scalar (tracked in
+    /// `static_local_vars`). Used as a CHEAP gate before the per-subroutine
+    /// `static_local_keys` check, so a bare identifier that is never a static
+    /// anywhere skips the key-building cost. (`static_local_vars` cells are
+    /// still read/written route to each cell's shared value only when the
+    /// SUBROUTINE-PRECISE key below also matches.)
+    static_local_names: HashSet<String>,
+    /// Persistent-cell keys ("`<cls>::<sub>::<nm>`"/"`<sub>::<nm>`") of all
+    /// scalar `static` subroutine locals. A name into `static_local_names`
+    /// only routes to the live shared cell when this key — which embeds the
+    /// declaring subroutine/class/specialization — matches, so a DIFFERENT
+    /// subroutine's same-named (plain/automatic) local is never wrongly
+    /// shared.
+    static_local_keys: HashSet<String>,
     /// True while evaluating elaboration-time constant (local)parameter
     /// initializers that call user functions. Each such constant-function call
     /// is independent (§13.4.3), so `static` locals must NOT share the runtime
@@ -3479,6 +3493,12 @@ pub struct Simulator {
     /// (a stack — a constraint/post_randomize may randomize another object).
     /// `cur_rng` consults the top of this stack first.
     obj_rng_stack: Vec<usize>,
+    /// §18.7 — the receiver NAME (a bare handle variable) of the in-flight
+    /// `obj.randomize() with {…}` call. Inside the randomized frame that
+    /// local is out of scope (eval of it returns 0), so the member-forcing
+    /// solver recognises `recv.member` as the object's own `member` when
+    /// `recv` is this receiver AND `member` is a rand property.
+    rand_receiver: Option<String>,
     /// §8.10: property names declared by MORE than one class of some object's
     /// inheritance chain. Non-leaf declarers' copies are stored under
     /// `"<Class>::<name>"`; the set is the cheap gate that keeps every
@@ -6625,6 +6645,8 @@ impl Simulator {
             pkg_ambiguous_names,
             m_scope_stack: Vec::new(),
             static_local_vars: HashMap::default(),
+            static_local_names: HashSet::default(),
+            static_local_keys: HashSet::default(),
             static_local_syncs: Vec::new(),
             in_const_param_eval: false,
             return_value: None,
@@ -6632,6 +6654,7 @@ impl Simulator {
             proc_rng: HashMap::default(),
             obj_rng: HashMap::default(),
             obj_rng_stack: Vec::new(),
+            rand_receiver: None,
             randomize_subset: None,
             shadowed_prop_names: HashSet::default(),
             settling: false,
@@ -28839,6 +28862,28 @@ impl Simulator {
                             Some((h.path[0].name.name.clone(), h.path[1].name.name.clone()))
                         }
                         ExprKind::MemberAccess { expr: recv, member } => match &recv.kind {
+                            // `C#(T)::method(...)` — the receiver is a
+                            // parameterized static class. Stage 1b's receiver
+                            // is a HANDLE; a `Specialization` receiver is a
+                            // TYPE, so it reaches here (static form). Build
+                            // the concrete specialized class name and classify
+                            // its blocking method like the plain static form.
+                            ExprKind::Specialization { base, type_args_text } => {
+                                let bn = Self::leaf_ident_name(base).unwrap_or_default();
+                                if bn.is_empty() {
+                                    None
+                                } else {
+                                    let spec = format!(
+                                        "{}#({})",
+                                        bn,
+                                        Self::normalize_spec_ws(type_args_text)
+                                    );
+                                    let mut cand = vec![spec.clone(), bn];
+                                    cand.retain(|c| self.module.classes.contains_key(c));
+                                    cand.first()
+                                        .map(|c| (c.clone(), member.name.clone()))
+                                }
+                            }
                             ExprKind::Ident(h)
                                 if h.path.len() == 1
                                     && self
@@ -30651,6 +30696,83 @@ impl Simulator {
 
 
 
+    /// For a statement-position method call (`obj.task(...)`, or `obj.a.task(...)`)
+    /// whose receiver handle resolves to null (0), the call cannot suspend: a
+    /// null handler runs no body, so weaving the loop through the suspend-aware
+    /// runner imprints one recursion per iteration and livelocks (`forever {
+    /// null_handle.wait_trigger(); }` spins at 100% CPU instead of being bounded).
+    /// The reference simulator treats dereferencing `this` of a null handle as a
+    /// runtime fatal and aborts; we mirror that with an explicit error plus
+    /// terminate (not a stall), so the run stops instead of burning the CPU. A
+    /// null receiver on a mailbox `get`/`put`/`peek` is NOT handled here —
+    /// that has its own dedicated null-mailbox diagnostic.
+    fn blocking_call_on_null_receiver(&mut self, s: &Statement) -> bool {
+        let StatementKind::Expr(expr) = &s.kind else {
+            return false;
+        };
+        let ExprKind::Call { func, .. } = &expr.kind else {
+            return false;
+        };
+        let rh = match &func.kind {
+            // `w.m(...)` / `w.a.m(...)` — flattened multi-segment Ident.
+            ExprKind::Ident(h) if h.path.len() >= 2 => {
+                let mut head = h.clone();
+                head.path.pop();
+                let recv = Expression::new(ExprKind::Ident(head), expr.span);
+                self.eval_handle_expr(&recv)
+            }
+            // `w.m(...)` — MemberAccess form.
+            ExprKind::MemberAccess { expr: recv, .. } => self.eval_handle_expr(recv),
+            _ => None,
+        };
+        if rh != Some(0) {
+            return false;
+        }
+        let what = match &func.kind {
+            ExprKind::Ident(h) => h
+                .path
+                .iter()
+                .map(|s| s.name.name.as_str())
+                .collect::<Vec<_>>()
+                .join("."),
+            ExprKind::MemberAccess { expr, member, .. } => format!(
+                "{}.{}",
+                self.span_source_snippet_in(expr.span, None)
+                    .unwrap_or_else(|| "<null>".to_string()),
+                member.name
+            ),
+            _ => "<call>".to_string(),
+        };
+        // Mirror the property-deref path (§8.4): a null `this` deref at the TOP
+        // level (module/TB process body) is the user's bug — fatal, like the
+        // reference simulator aborting. But inside a class method (deep UVM
+        // library code, an emulation gap can leave a handle null) report a
+        // corrected diagnostic and stop just this forever process instead of
+        // killing the whole UVM run.
+        let in_method = self.this_stack.last().copied().flatten().is_some()
+            || self
+                .class_context_stack
+                .last()
+                .cloned()
+                .flatten()
+                .is_some()
+            || !self.local_stack.is_empty();
+        if !in_method {
+            let m = format!(
+                "[xezim][error] null receiver at time {} — task/function call \
+                 `{}` on a null class handle. The reference simulator dereferences \
+                 'this' of null and aborts; a blocking call here cannot suspend, so a \
+                 `forever` around it would spin forever.",
+                self.time, what
+            );
+            self.record_output(m.clone());
+            self.stdout_writeln(&m);
+            self.finished = true;
+            return true;
+        }
+        true
+    }
+
     /// Is `s` a (potentially blocking) mailbox `get`/`peek` call — `mb.get(v)`
     /// or `mb.peek(v)` (either MemberAccess or flattened hier-Ident form)? Such
     /// a call blocks when the mailbox is empty; inside a `forever` it must route
@@ -30778,6 +30900,17 @@ impl Simulator {
             if !matches!(&s.kind, StatementKind::TimingControl { .. })
                 && (self.stmt_is_blocking(s) || Self::stmt_is_mailbox_get(s))
             {
+                // A blocking task/function call on a NULL class-handle receiver
+                // cannot suspend and is a runtime error in the reference
+                // simulator (it dereferences `this` of null and aborts). The
+                // helper has already emitted its diagnostic and terminated (the
+                // whole run at top level, or just this forever process inside
+                // deep library method code). Don't weave the loop through
+                // recursion (which spins on each iteration) or let it fall to
+                // the plain stall report.
+                if !Self::stmt_is_mailbox_get(s) && self.blocking_call_on_null_receiver(s) {
+                    return;
+                }
                 let mut cont: Vec<Statement> = vec![s.clone()];
                 cont.extend_from_slice(&body_stmts[i + 1..]);
                 cont.push(Statement::new(
@@ -37526,7 +37659,20 @@ impl Simulator {
                             } else {
                                 val.clone()
                             };
-                            self.local_stack[last_idx].insert(name.clone(), fitted);
+                            self.local_stack[last_idx].insert(name.clone(), fitted.clone());
+                            // §6.21: write a `static` subroutine local through
+                            // to its live shared cell so other simultaneous
+                            // activations (recursive phase re-entry / method)
+                            // observe the mutation immediately. Skipped during
+                            // elaboration-time constant-function evaluation,
+                            // where each call is independent.
+                            if !self.in_const_param_eval
+                                && self.static_local_names.contains(name.as_str())
+                                && let Some(k) = self.static_local_key_for(name)
+                                && self.static_local_keys.contains(&k)
+                            {
+                                self.static_local_vars.insert(k, fitted);
+                            }
                             return true;
                         }
                     }
@@ -40538,6 +40684,31 @@ impl Simulator {
             if let Some(key) = self.frame_leaf_key_of(expr) {
                 if let Some(v) = self.local_stack.last().and_then(|l| l.get(&key)) {
                     return v.clone();
+                }
+            }
+        }
+        // §6.21: a `static` subroutine local is a LIVE cell shared across ALL
+        // simultaneous activations — including re-entrant/recursive ones. Read
+        // the committed value from `static_local_vars` rather than this
+        // recursion window's snapshot frame, so mutations inside an inner
+        // activation are instantly visible to the caller's frames (otherwise a
+        // recursive phase re-entry / method would reset the static to its
+        // per-window initialiser and livelock). Skipped during elaboration-time
+        // constant-function evaluation, where §13.4.3 makes each such call
+        // independent.
+        if !self.in_const_param_eval && !self.static_local_names.is_empty() {
+            if let ExprKind::Ident(h) = &expr.kind {
+                if h.path.len() == 1 && h.path[0].selects.is_empty() {
+                    let n = &h.path[0].name.name;
+                    if self.static_local_names.contains(n.as_str())
+                        && let Some(k) = self.static_local_key_for(n)
+                    {
+                        if self.static_local_keys.contains(&k)
+                            && let Some(v) = self.static_local_vars.get(&k).cloned()
+                        {
+                            return v;
+                        }
+                    }
                 }
             }
         }
@@ -45204,6 +45375,31 @@ impl Simulator {
                 }
             }
             ExprKind::MemberAccess { expr, member } => {
+                // §18.7 — inside `obj.randomize() with { obj.member … }` the
+                // receiver `obj` is a caller-scope handle that no longer evals
+                // in the randomized frame, so `obj.member` would read 0 and
+                // every prefixed acceptance (`req.addr == start_addr`) failed.
+                // When the receiver is the recorded `rand_receiver` of the
+                // in-flight call and the randomized object has that member,
+                // read the OBJECT's property (mirrors the forcing in
+                // `prefixed_self_member`). Pure read — no scope mutation.
+                if self.rand_receiver.is_some() {
+                    if let Some(rn) = Self::plain_ident_name(expr) {
+                        if self.rand_receiver.as_deref() == Some(&rn) {
+                            if let Some(&obj) = self.obj_rng_stack.last() {
+                                let v = self
+                                    .heap
+                                    .get(obj)
+                                    .and_then(|o| o.as_ref())
+                                    .and_then(|i| i.properties.get(&member.name))
+                                    .cloned();
+                                if let Some(v) = v {
+                                    return v;
+                                }
+                            }
+                        }
+                    }
+                }
                 // §13.4.2: a member of a subroutine-local / formal unpacked
                 // struct is owned by the call frame; read it there before any
                 // module-scope lookup, mirroring the write path. Otherwise a
@@ -47278,41 +47474,72 @@ impl Simulator {
                             // typedefs so the element's type-param members bind.
                             let elem_cls: Option<(String, Option<(String, String)>)> =
                                 match elem_cls {
-                                    Some(cn) => {
-                                        // §6.20.3: the declared element type may
-                                        // be a TYPE PARAMETER (`T pool[string]`
-                                        // in uvm_pool) — resolve through the
-                                        // current spec / instance bindings first.
-                                        let cn = self
-                                            .resolve_type_param_binding(&cn)
-                                            .unwrap_or(cn);
-                                        if self.module.classes.contains_key(&cn) {
-                                            Some((cn, None))
-                                        } else {
-                                            self.resolve_simple_typedef_class(&cn)
-                                                .filter(|c| self.module.classes.contains_key(c))
-                                                .map(|c| (c, None))
-                                                .or_else(|| {
-                                                    self.resolve_typedef_spec(&cn)
-                                                        .filter(|(b, _)| {
-                                                            self.module.classes.contains_key(b)
-                                                        })
-                                                        .map(|(b, s)| (b.clone(), Some((b, s))))
-                                                })
-                                                .or_else(|| {
-                                                    // §8.25: the binding is itself
-                                                    // a SPECIALIZED name
-                                                    // (`queue#(string)` — UVM's
-                                                    // string pool of hdl-path
-                                                    // queues).
-                                                    self.extract_spec_from_string(&cn)
-                                                        .filter(|(b, _)| {
-                                                            self.module.classes.contains_key(b)
-                                                        })
-                                                        .map(|(b, s)| (b.clone(), Some((b, s))))
-                                                })
-                                        }
+                                    Some(cn)
+                                        if self.module.classes.contains_key(&cn) =>
+                                    {
+                                        Some((cn, None))
                                     }
+                                    // §6.20.3: the declared element type is a
+                                    // class TYPE PARAMETER (`PARAM pool[string]`
+                                    // in generic `class Base#(type PARAM)` —
+                                    // i.e. `uvm_pool`'s `T`). It is neither a
+                                    // module.classes key nor a typedef; bind it
+                                    // to the concrete class via the active
+                                    // instance/spec so `pool[key] = new` builds
+                                    // the right element class (e.g. `myitem` for
+                                    // `Base#(myitem)`, or `uvm_event#(uvm_object)`
+                                    // for `uvm_object_string_pool`).
+                                    //
+                                    // evaluate a single time (the bound class's
+                                    // keys would falsify the `contains_key(c)`
+                                    // guard that the typedef arms rely on).
+                                    Some(cn)
+                                        if self
+                                            .resolve_type_param_binding(&cn)
+                                            .map(|b| {
+                                                let base = self
+                                                    .extract_spec_from_string(&b)
+                                                    .map(|(base, _)| base)
+                                                    .unwrap_or(b);
+                                                self.module.classes.contains_key(&base)
+                                            })
+                                            .unwrap_or(false) =>
+                                    {
+                                        let bound = self.resolve_type_param_binding(&cn).unwrap();
+                                        let tup = self
+                                            .extract_spec_from_string(&bound)
+                                            .unwrap_or_else(|| (bound.clone(), String::new()));
+                                        let (base, sig) = tup;
+                                        let spec = if sig.is_empty() {
+                                            None
+                                        } else {
+                                            Some((base.clone(), sig))
+                                        };
+                                        Some((base, spec))
+                                    }
+                                    Some(cn) => self
+                                        .resolve_simple_typedef_class(&cn)
+                                        .filter(|c| self.module.classes.contains_key(c))
+                                        .map(|c| (c, None))
+                                        .or_else(|| {
+                                            self.resolve_typedef_spec(&cn)
+                                                .filter(|(b, _)| {
+                                                    self.module.classes.contains_key(b)
+                                                })
+                                                .map(|(b, s)| (b.clone(), Some((b, s))))
+                                        })
+                                        .or_else(|| {
+                                            // §8.25: the binding is itself
+                                            // a SPECIALIZED name
+                                            // (`queue#(string)` — UVM's
+                                            // string pool of hdl-path
+                                            // queues).
+                                            self.extract_spec_from_string(&cn)
+                                                .filter(|(b, _)| {
+                                                    self.module.classes.contains_key(b)
+                                                })
+                                                .map(|(b, s)| (b.clone(), Some((b, s))))
+                                        }),
                                     None => None,
                                 };
                             if std::env::var("XZ_EC_DBG").is_ok() && bname == "pool" {
@@ -48055,6 +48282,11 @@ impl Simulator {
                 // lvalue's declared type, then construct via
                 // `instantiate_class_with_type_args`.  The bare `new` expression
                 // is `Ident([new])`; `new(args)` is `Call(func=Ident([new]), args=...)`.
+                // §8.7 / §8.8: `c = new;` (bare, no parens) or `c = new(args)` (with
+                // constructor arguments).  Resolve the class type from the
+                // lvalue's declared type, then construct via
+                // `instantiate_class_with_type_args`.  The bare `new` expression
+                // is `Ident([new])`; `new(args)` is `Call(func=Ident([new]), args=...)`.
                 // §8.7 / §8.8: `c = new;` (bare, no parens) or `c = new()`/`c = new(args)`
                 // (with constructor arguments).  When args are non-empty AND the
                 // lvalue is typed as a class handle (not a dynamic array), route
@@ -48131,6 +48363,28 @@ impl Simulator {
                         // it (so the instance's inherited methods resolve `T`
                         // correctly). Mirrors the factory `create` path.
                         if let Some((base, sig)) = self.extract_spec_from_string(&tname) {
+                            if let Some(class_def) = self.module.classes.get(&base).cloned() {
+                                self.ensure_spec_statics(&base, &sig);
+                                let saved_spec = self.current_spec.clone();
+                                self.current_spec = Some((base.clone(), sig));
+                                let handle = self.instantiate_class(&class_def, ctor_args);
+                                self.current_spec = saved_spec;
+                                self.assign_value(lvalue, &handle.resize(w));
+                                self.settle_after_proc_write();
+                                return;
+                            }
+                        }
+                        // A class-MEMBER `prop = new(...)` whose declared type
+                        // is a TYPEDEF ALIAS to a parameterized class (UVM's
+                        // `uvm_component.event_pool` / `uvm_event_pool` =
+                        // `uvm_object_string_pool#(uvm_event#(uvm_object))`).
+                        // `get_expr_type_name` above returned just the BASE
+                        // class (no `#(...)`), so neither `extract_spec_..`
+                        // nor `resolve_ctor_type_args` finds the type args,
+                        // and the pool would be built with `T` = its default
+                        // (`uvm_object`). Recover the spec from the member's
+                        // alias and construct the correct specialization.
+                        if let Some((base, sig)) = self.this_member_typedef_spec(lvalue) {
                             if let Some(class_def) = self.module.classes.get(&base).cloned() {
                                 self.ensure_spec_statics(&base, &sig);
                                 let saved_spec = self.current_spec.clone();
@@ -49833,8 +50087,7 @@ impl Simulator {
                                     .keys()
                                     .filter_map(|k| {
                                         let rest = k.strip_prefix(&prefix)?;
-                                        let end = rest.find(']')?;
-                                        Some(rest[..end].to_string())
+                                        Self::assoc_first_key_seg(rest).map(|s| s.to_string())
                                     })
                                     .collect();
                                 ks.sort();
@@ -50173,6 +50426,9 @@ impl Simulator {
                             // loop — every backdoor access lost its path).
                             && !self.module.dynamic_arrays.contains(&name)
                             && !self.is_associative_array(&name)
+                            && !self.module.arrays.contains_key(&name)
+                            && !self.module.arrays_2d.contains_key(&name)
+                            && !self.module.arrays_nd.contains_key(&name)
                         {
                             // foreach over a STRING iterates its characters
                             // [0..len) by CONTENT length, and must be checked
@@ -50182,6 +50438,17 @@ impl Simulator {
                             // would otherwise send it through the fixed-array
                             // arm iterating 2 instead of the true character
                             // count, truncating UVM's `pack_string` by 8 bytes.
+                            //
+                            // A QUEUE / DYNAMIC / ASSOC ARRAY OF STRINGS
+                            // (`string q[$]`, `string m[int]`) is NOT a scalar
+                            // string: `string_signals` holds the collection name
+                            // but the loop must iterate its ELEMENTS, not its
+                            // characters — treating it as a string here left
+                            // `foreach (name_order[k])` over uvm's string queue
+                            // of field names with zero iterations, so config was
+                            // never applied (`string_signals` won because the
+                            // collection-carried registration; the char count
+                            // of the unbuilt queue was 0).
                             let len = self.eval_expr(array).to_sv_string().len() as u64;
                             for i in 0..len {
                                 if self.finished {
@@ -50219,8 +50486,7 @@ impl Simulator {
                                 .keys()
                                 .filter_map(|k| {
                                     let rest = k.strip_prefix(&prefix)?;
-                                    let end = rest.find(']')?;
-                                    Some(rest[..end].to_string())
+                                    Self::assoc_first_key_seg(rest).map(|s| s.to_string())
                                 })
                                 .collect();
                             keys.sort();
@@ -52569,7 +52835,18 @@ impl Simulator {
                             self.static_local_vars.insert(key.clone(), cur);
                         }
                         if let Some((_n, syncs)) = self.static_local_syncs.last_mut() {
-                            syncs.push((nm.clone(), key));
+                            syncs.push((nm.clone(), key.clone()));
+                        }
+                        // Route to the live shared cell only for scalar
+                        // integral/real statics (the re-entrant/recursive
+                        // case this fixes). Strings and other aggregates keep
+                        // their existing per-call storage semantics and must
+                        // not be intercepted.
+                        if !self.string_signals.contains(nm.as_str())
+                            && !self.module.arrays.contains_key(nm.as_str())
+                        {
+                            self.static_local_names.insert(nm.clone());
+                            self.static_local_keys.insert(key);
                         }
                     }
                 }
@@ -60982,6 +61259,19 @@ impl Simulator {
         {
             return true;
         }
+        // A process parked on a `process::await()` (a forked child waiting on
+        // the producer sequence's process, as `m_safe_select_item`'s re-arbitration
+        // loop does) is SUSPENDED, not finished. Without this it looked FINISHED,
+        // so its ProcessContext (sequencer `this` + the task's `selected_sequence_request`
+        // local) was dropped and it resumed with this=None/lstack=0, dereferencing
+        // the recalled item handle as null.
+        if self
+            .await_waiters
+            .iter()
+            .any(|w| w.waiter_pid == pid)
+        {
+            return true;
+        }
         false
     }
 
@@ -62304,7 +62594,72 @@ impl Simulator {
                 }
             }
         }
+        // Nested associative-array ELEMENT (`base[K1][K2]...[Kn]` with n >= 1):
+        // the receiver is the sub-array obtained by selecting a key from a
+        // MULTIDIMENSIONAL associative array (IEEE 1800 §7.8.1) — e.g.
+        // UVM's `m_recur_states[rhs]` where `m_recur_states[rhs].first(lhs)`
+        // is called on the nested sub-array. The storage name is
+        // `base[K1]...[Kn]`; strip trailing `[key]` segments to the root
+        // declaration, then confirm a stored key exists under the compound
+        // prefix (proving the selected element is itself a collection, not a
+        // scalar). Without this the copier's cycle-detection `first()/exists()`
+        // on a nested assoc silently returns "not found", so deep-clone of a
+        // cyclic object graph recurses forever (stack overflow).
+        if self.is_nested_assoc_elem(name) {
+            return true;
+        }
         false
+    }
+
+    /// Strip trailing `[key]` index segments from a possibly-indexed storage
+    /// name, returning the declaration base (module-level or `<h>#member`).
+    /// `foo[1]` -> `foo`; `h#m[1][2]` -> `h#m`.
+    fn assoc_decl_base(&self, name: &str) -> Option<String> {
+        let mut b = name;
+        loop {
+            match b.rfind('[') {
+                Some(p) if b[p + 1..].ends_with(']') => {
+                    b = &b[..p];
+                }
+                _ => break,
+            }
+        }
+        if b != name { Some(b.to_string()) } else { None }
+    }
+
+    /// Nested associative-array receiver: `name` is `base[K1]...[Kn]` (n >= 1),
+    /// `base` is a registered associative array, and the selected element is
+    /// ITSELF an associative array (a multidimensional assoc, IEEE 1800 §7.8.1)
+    /// — i.e. at least one stored key exists under the compound prefix
+    /// `name[..` (`g[1][2]` proves `g[1]` is a collection). This is exactly the
+    /// shape UVM's copier uses (`m_recur_states[rhs][lhs][policy]`, then
+    /// `m_recur_states[rhs].first(lhs)`), whose cycle guard the deep-clone of
+    /// a CYCLIC object graph depends on. An empty nested sub-array can't be
+    /// proven from a stored key, but `first`/`num`/`size` on an empty array
+    /// return 0 anyway.
+    fn is_nested_assoc_elem(&self, name: &str) -> bool {
+        let Some(base) = self.assoc_decl_base(name) else {
+            return false;
+        };
+        if !self.module.associative_arrays.contains_key(&base) {
+            return false;
+        }
+        let nested_prefix = format!("{name}[");
+        self.signal_name_prefix_present(&nested_prefix)
+    }
+
+    /// True if any stored signal name starts with `prefix`. Mirrors the prefix
+    /// scanning that `assoc_top_level_keys` uses (checks both `signals` ids and
+    /// the `name->id` index), so a nested assoc element (stored as
+    /// `base[k1][k2]...`) is visible.
+    fn signal_name_prefix_present(&self, prefix: &str) -> bool {
+        self.signals
+            .keys()
+            .any(|k| k.starts_with(prefix))
+            || self
+                .signal_name_to_id
+                .keys()
+                .any(|k| k.starts_with(prefix))
     }
 
     /// Resolve a `TypeName` (possibly a scoped/class-local typedef alias) to the
@@ -63036,6 +63391,17 @@ impl Simulator {
         // A STRUCT element stores member-wise leaves (`sa[k].id`), which do
         // not end in `]` — accept any entry whose key bracket closes, else
         // struct-element assoc arrays enumerate as empty (num()/foreach).
+        //
+        // The stored entry is `name + rest` where `rest = KEY`, or
+        // `KEY[K2]...[Kn]` for a MULTIDIM assoc (`arr[k1][k2]`) or an
+        // assoc-of-queue (`arr[key][i]`). Decide which by inspection: a
+        // multi-index entry has an inner `[` immediately after its FIRST
+        // `]` (`k1][k2]`), so the level-0 key = up to that `]`. Otherwise
+        // the array is 1-D and KEY is the WHOLE text, which may itself
+        // contain `]`/`[` (UVM component names like
+        // `special-:{ chars{}[0123456789] _` are legal assoc string keys,
+        // §7.11) — take up to the LAST `]` so such brackets are not mistaken
+        // for an index end.
         let mut keys: Vec<String> = self
             .signals
             .keys()
@@ -63044,7 +63410,7 @@ impl Simulator {
             .filter(|k| k.starts_with(&prefix))
             .filter_map(|k| {
                 let rest = &k[prefix.len()..];
-                rest.find(']').map(|pos| rest[..pos].to_string())
+                Self::assoc_first_key_seg(rest).map(|s| s.to_string())
             })
             .collect();
         keys.sort();
@@ -64042,6 +64408,21 @@ impl Simulator {
     /// Compute the iteration keys for a named array/collection
     /// (`<name>.size` dense fallback, else raw key-scan of `<name>[…]`).
     /// Returns `(keys, is_str)`. Integer keys are sorted numerically.
+    /// Top-level assoc key for a stored entry whose text after the array
+    /// name is `rest`. A MULTIDIM or collection-valued assoc stores
+    /// `arr[k1][k2]...` (an inner `[` right after the FIRST `]`), so the
+    /// level-0 key runs to that `]`. Otherwise the array is 1-D and the key
+    /// is the WHOLE text to the FINAL `]` — a 1-D string key may itself
+    /// contain `]`/`[` (a UVM component name like
+    /// `special-:{ chars{}[0123456789] _` is a legal assoc key, §7.11).
+    fn assoc_first_key_seg(rest: &str) -> Option<&str> {
+        if rest.find(']').map_or(false, |p| rest[p + 1..].starts_with('[')) {
+            rest.find(']').map(|e| &rest[..e])
+        } else {
+            rest.rfind(']').map(|e| &rest[..e])
+        }
+    }
+
     fn array_iter_keys(&self, name: &str) -> (Vec<String>, bool) {
         // A queue / dynamic array carries an authoritative `<name>.size`
         // shadow and is DENSE: iterate the logical range [0, size). Scanning
@@ -64061,13 +64442,18 @@ impl Simulator {
         // is stored as `all[5][0]`, `all[5][1]`, etc. The key must be
         // extracted up to the FIRST `]`, not `k.len()-1` (which would grab
         // `5][0`). Dedup because multiple sub-elements share one key.
+        //
+        // But a 1-D STRING key may itself contain `]`/`[` (e.g. a UVM
+        // component name `special-:{ chars{}[0123456789] _`), stored
+        // verbatim as `arr[KEY]`. Distinguish by shape: a multi-index entry
+        // has an inner `[` right after its first `]` (`k1][k2]`), so extract
+        // up to that `]`; otherwise take the whole key up to the final `]`.
         let mut ks: Vec<String> = self
             .signals
             .keys()
             .filter_map(|k| {
                 let rest = k.strip_prefix(&prefix)?;
-                let end = rest.find(']')?;
-                Some(rest[..end].to_string())
+                Self::assoc_first_key_seg(rest).map(|s| s.to_string())
             })
             .collect();
         ks.sort();
@@ -64557,6 +64943,7 @@ impl Simulator {
                                     &cvar_names,
                                     &cvar_dom,
                                     attempt,
+                                    None,
                                 );
                                 self.constraint_cmp_unsigned = false;
                                 let mut owned_names: HashSet<String> = HashSet::default();
@@ -64667,9 +65054,17 @@ impl Simulator {
                     if handle != 0 {
                         // §18.7.1 `local::` — must be bound in the CALLER's
                         // scope, i.e. before `this` switches to the object.
-                        let bound = self.bind_local_scope_refs(handle, constraints);
+                        let mut items_vec: Option<Vec<crate::ast::decl::ConstraintItem>> =
+                            self.bind_local_scope_refs(handle, constraints);
+                        // §18.7 — also freeze references to the ENCLOSING scope's
+                        // members (still on `this_stack` here) so `obj`'s inline
+                        // can compare against a sequence member (`obj.addr ==
+                        // start_addr`) once `this` moves to `obj`.
+                        if let Some(sub) = self.subst_enclosing_scope_refs(handle, constraints) {
+                            items_vec = Some(sub);
+                        }
                         let items: &[crate::ast::decl::ConstraintItem] =
-                            bound.as_deref().unwrap_or(constraints);
+                            items_vec.as_deref().unwrap_or(constraints);
                         // §18.11 `obj.randomize(null) with {...}` — in-line
                         // constraint CHECKER: nothing is randomized, the
                         // current values are checked against the constraints.
@@ -64679,7 +65074,12 @@ impl Simulator {
                         // §18.7: the inline constraints join the class's set
                         // for this call (sizing, element solving, acceptance).
                         self.obj_rng_stack.push(handle);
+                        let prev_receiver = self.rand_receiver.take();
+                        if let Some(rn) = Self::plain_ident_name(expr) {
+                            self.rand_receiver = Some(rn);
+                        }
                         let r = self.exec_randomize_inner(handle, items);
+                        self.rand_receiver = prev_receiver;
                         self.obj_rng_stack.pop();
                         return r;
                     }
@@ -64821,6 +65221,123 @@ impl Simulator {
         } else {
             None
         }
+    }
+
+    /// §18.7 — inside `obj.randomize() with {…}` the randomized frame's
+    /// `this` is the OBJECT, so a free identifier that names an ENCLOSING
+    /// scope's member (e.g. a sequence's `start_addr` from a `uvm_do` inline
+    /// block) no longer resolves during the solve and reads 0/garbage. Freeze
+    /// every bare identifier that is a member of the enclosing `this` instance
+    /// (still on `this_stack` at the call site, before `this` switches) but is
+    /// NOT a rand member of the randomized object to its current value as a
+    /// literal. Returns a substituted copy only when something changed.
+    fn subst_enclosing_scope_refs(
+        &mut self,
+        handle: usize,
+        items: &[crate::ast::decl::ConstraintItem],
+    ) -> Option<Vec<crate::ast::decl::ConstraintItem>> {
+        use crate::ast::decl::ConstraintItem as CI;
+        let rand_set = self.object_rand_set(handle);
+        // The enclosing scope's instance handle is this_stack's top. If none
+        // (no class `this`), there is nothing to freeze.
+        let Some(Some(enc_h)) = self.this_stack.last().copied() else {
+            return None;
+        };
+        let Some(enc_cd) = self
+            .heap
+            .get(enc_h)
+            .and_then(|o| o.as_ref())
+            .map(|i| i.class_name.clone())
+            .and_then(|cn| self.module.classes.get(&cn).cloned())
+        else {
+            return None;
+        };
+        if enc_cd.properties.is_empty() {
+            return None;
+        }
+        let mut out: Vec<CI> = Vec::with_capacity(items.len());
+        let mut any = false;
+        for item in items {
+            let mut new_item = item.clone();
+            if let CI::Expr(e) = &mut new_item {
+                if self.subst_enclosing_ident(e, enc_h, &enc_cd, &rand_set) {
+                    any = true;
+                }
+            }
+            out.push(new_item);
+        }
+        if any {
+            Some(out)
+        } else {
+            None
+        }
+    }
+
+    /// Walk `e`, replacing bare identifiers that are members of the enclosing
+    /// instance `enc_h` (but not rand members of the object) with their current
+    /// value as a literal. Returns whether anything changed.
+    fn subst_enclosing_ident(
+        &mut self,
+        e: &mut Expression,
+        enc_h: usize,
+        enc_cd: &crate::compiler::elaborate::ElaboratedClass,
+        rand_set: &HashSet<String>,
+    ) -> bool {
+        use crate::ast::expr::{ExprKind, NumberBase, NumberLiteral};
+        let mut hit = false;
+        match &mut e.kind {
+            ExprKind::Ident(h)
+                if h.path.len() == 1 && h.root.is_none() => {
+                    let name = &h.path[0].name.name;
+                    if rand_set.contains(name) {
+                        return false; // the object's own rand member — solve it
+                    }
+                    // Must live on the ENCLOSING instance, not be shadowed by
+                    // an enclosing local of the same name nor be the object's
+                    // own (non-rand) field the inline qualifies via the receiver.
+                    if !enc_cd.properties.contains_key(name) {
+                        return false;
+                    }
+                    if self.local_stack.last().is_some_and(|l| l.contains_key(name)) {
+                        return false;
+                    }
+                    let v = self
+                        .heap
+                        .get(enc_h)
+                        .and_then(|o| o.as_ref())
+                        .and_then(|i| i.properties.get(name))
+                        .cloned();
+                    if let Some(v) = v.as_ref() {
+                        let lit = NumberLiteral::Integer {
+                            size: Some(v.width.max(1)),
+                            signed: v.is_signed,
+                            base: NumberBase::Decimal,
+                            value: v.to_u64().unwrap_or(0).to_string(),
+                            cached_val: Cell::new(None),
+                        };
+                        e.kind = ExprKind::Number(lit);
+                        hit = true;
+                    }
+                }
+            ExprKind::Binary { left, right, .. } => {
+                hit |= self.subst_enclosing_ident(left, enc_h, enc_cd, rand_set);
+                hit |= self.subst_enclosing_ident(right, enc_h, enc_cd, rand_set);
+            }
+            ExprKind::Unary { operand, .. } => hit |= self.subst_enclosing_ident(operand, enc_h, enc_cd, rand_set),
+            ExprKind::Paren(inner) => hit |= self.subst_enclosing_ident(inner, enc_h, enc_cd, rand_set),
+            ExprKind::Inside { expr, ranges } => {
+                hit |= self.subst_enclosing_ident(expr, enc_h, enc_cd, rand_set);
+                for r in ranges {
+                    hit |= self.subst_enclosing_ident(r, enc_h, enc_cd, rand_set);
+                }
+            }
+            ExprKind::Range(lo, hi) => {
+                hit |= self.subst_enclosing_ident(lo, enc_h, enc_cd, rand_set);
+                hit |= self.subst_enclosing_ident(hi, enc_h, enc_cd, rand_set);
+            }
+            _ => {}
+        }
+        hit
     }
 
     /// Bare single-segment identifier name of `e`, if that is what it is.
@@ -65154,6 +65671,23 @@ impl Simulator {
         let mut bn = self.resolve_hier_name(bh);
         if let Some(s) = self.instance_assoc_member(&bn) {
             bn = s;
+        } else if bh.path.len() >= 2 {
+            // `obj.member` accessed from module/lower scope where the first
+            // path segment is an OBJECT handle and the member is an
+            // associative property of that object's class. resolve_hier_name
+            // collapses to the bare `member` (losing the per-instance scope),
+            // so is_associative_array(bare) is false and the multidim helper
+            // bails. Re-derive the per-instance storage `<h>#<member>`.
+            let objnm = &bh.path[0].name.name;
+            let member = &bh.path[bh.path.len() - 1].name.name;
+            if let Some(h) = self.eval_ident_handle(objnm) {
+                if h != 0 {
+                    let cand = format!("{h}#{member}");
+                    if self.is_associative_array(&cand) {
+                        bn = cand;
+                    }
+                }
+            }
         }
         if !self.is_associative_array(&bn) {
             return None;
@@ -66497,6 +67031,7 @@ impl Simulator {
         e: &Expression,
         names: &HashMap<String, usize>,
         ncols: usize,
+        obj_handle: Option<usize>,
     ) -> Option<(Vec<i128>, i128, BinaryOp)> {
         let ExprKind::Binary { op, left, right } = &e.kind else {
             return None;
@@ -66511,6 +67046,22 @@ impl Simulator {
                 | BinaryOp::Neq
         ) {
             return None;
+        }
+        // §18.5: a rand dynamic array's `.size()` is not a settled numeric
+        // operand during the coupled scalar solve (the array is only sized
+        // later) — `arr.size() == N` would pin `N` to the current empty size
+        // (0). The array-sizing solver owns that coupling. Prefer the
+        // randomized object's handle (from the caller) over the this-frame
+        // top, which in a UVM run points at the TEST harness (uvm_root), not
+        // the payload object, so the array lookup would fail and the guard
+        // would let `arr.size()==N` become a spurious `N == 0` row that
+        // contradicts `N == <non-zero>`.
+        let h = obj_handle
+            .or_else(|| self.this_stack.iter().flatten().next().copied());
+        if let Some(h) = h {
+            if self.is_rand_dyn_size_expr(h, left) || self.is_rand_dyn_size_expr(h, right) {
+                return None;
+            }
         }
         let (lc, lk) = self.affine_cols(left, names, ncols)?;
         let (rc, rk) = self.affine_cols(right, names, ncols)?;
@@ -66537,18 +67088,19 @@ impl Simulator {
         item: &crate::ast::decl::ConstraintItem,
         names: &HashMap<String, usize>,
         ncols: usize,
+        obj_handle: Option<usize>,
         out: &mut Vec<(Vec<i128>, i128, BinaryOp)>,
     ) {
         use crate::ast::decl::ConstraintItem as CI;
         match item {
             CI::Expr(e) => {
-                if let Some(con) = self.affine_binary_con(e, names, ncols) {
+                if let Some(con) = self.affine_binary_con(e, names, ncols, obj_handle) {
                     out.push(con);
                 }
             }
             CI::Block(items) => {
                 for it in items {
-                    self.collect_affine_cons(it, names, ncols, out);
+                    self.collect_affine_cons(it, names, ncols, obj_handle, out);
                 }
             }
             _ => {}
@@ -66629,24 +67181,48 @@ impl Simulator {
         names: &HashMap<String, usize>,
         ncols: usize,
         owned: &HashSet<usize>,
+        obj_handle: Option<usize>,
     ) -> bool {
         use crate::ast::decl::ConstraintItem as CI;
-        let touches_owned = |me: &Self, it: &CI| -> bool {
+        let owned_count = |me: &Self, it: &CI| -> usize {
             let mut ids = HashSet::default();
             me.collect_item_idents(it, &mut ids);
             ids.iter()
-                .any(|n| names.get(n).is_some_and(|i| owned.contains(i)))
+                .filter(|n| names.get(n.as_str()).is_some_and(|i| owned.contains(i)))
+                .count()
+        };
+        let touches_owned = |me: &Self, it: &CI| -> bool {
+            owned_count(me, it) > 0
         };
         match item {
             CI::Expr(e) => {
-                if self.affine_binary_con(e, names, ncols).is_some() {
+                // A `.size()` coupling to a rand DYNAMIC array (`arr.size() ==
+                // N`) is sized to the array's length separately; it must not
+                // block the coupled scalar solve even though it touches an
+                // owned variable through the equality.
+                let h = obj_handle
+                    .or_else(|| self.this_stack.iter().flatten().next().copied());
+                if let Some(h) = h {
+                    if self.expr_involves_dyn_size(h, e) {
+                        return true;
+                    }
+                }
+                if self.affine_binary_con(e, names, ncols, obj_handle).is_some() {
                     return true; // fully modeled affine constraint
                 }
-                !touches_owned(self, item)
+                // A non-affine predicate that constrains at most ONE owned
+                // variable (`m % 4 == 0`, `m inside {…}`, a single-var
+                // inequality) cannot take part in the affine coupling, but it
+                // need not abort the whole solve: the assigned value is still
+                // enforced by the trial acceptance check, which retries a
+                // fresh draw if violated. Requiring it to pass here would
+                // abandon coupling for the whole set whenever any scalar has a
+                // modulus/inside guard.
+                owned_count(self, item) <= 1
             }
             CI::Block(items) => items
                 .iter()
-                .all(|it| self.item_ok_for_coupled(it, names, ncols, owned)),
+                .all(|it| self.item_ok_for_coupled(it, names, ncols, owned, obj_handle)),
             // A soft constraint can always be dropped, and `solve` is only an
             // ordering hint — neither blocks the coupled solve.
             CI::Soft(_) | CI::Solve { .. } => true,
@@ -66667,6 +67243,7 @@ impl Simulator {
         var_names: &[String],
         var_dom: &[(i128, i128)],
         attempt: usize,
+        obj_handle: Option<usize>,
     ) -> Option<Vec<(usize, i128)>> {
         use rand::Rng;
         let ncols = var_names.len();
@@ -66680,7 +67257,7 @@ impl Simulator {
         // Extract the affine relational/equality constraints.
         let mut cons: Vec<(Vec<i128>, i128, BinaryOp)> = Vec::new();
         for it in items {
-            self.collect_affine_cons(it, &names, ncols, &mut cons);
+            self.collect_affine_cons(it, &names, ncols, obj_handle, &mut cons);
         }
         // A variable is COUPLED if it shares a constraint with another target.
         let mut owned: HashSet<usize> = HashSet::default();
@@ -66698,7 +67275,7 @@ impl Simulator {
         // Never take ownership of a variable that an unmodeled construct also
         // constrains (preserve existing behavior for such mixed sets).
         for it in items {
-            if !self.item_ok_for_coupled(it, &names, ncols, &owned) {
+            if !self.item_ok_for_coupled(it, &names, ncols, &owned, obj_handle) {
                 return None;
             }
         }
@@ -69303,15 +69880,48 @@ impl Simulator {
     ) -> Option<(String, crate::ast::types::StructUnionType)> {
         // compound key `base[K1][K2]...[Kn]` (assoc key-stringified).
         let key = self.nested_index_name(element)?;
-        // Strip the trailing `[K...]` for the storage base `<handle>#<prop>`.
         let scoped = key.split('[').next().unwrap_or("");
         let (hstr, prop) = scoped.split_once('#')?;
         let handle: usize = hstr.parse().ok()?;
-        let su = self.class_prop_struct(handle, prop)?;
+        // `class_prop_struct` deliberately refuses COLLECTION (assoc/queue)
+        // properties (issue #113: their element leaves go through the
+        // collection machinery). Here the element IS the collection's struct
+        // value, so resolve its declared DataType directly from the
+        // instance's class-chain `property_decl_types` and require it to be
+        // an unpacked struct (spread member-wise).
+        let su = self.collection_elem_struct(handle, prop)?;
         if !Self::spreads_member_wise(&su) {
             return None;
         }
         Some((key, su))
+    }
+
+    /// Unpacked-struct TYPE of a collection property's element. Resolves the
+    /// property's declared (element) DataType over the instance's inheritance
+    /// chain, then reduces typedef aliases to its `Struct` if it is one.
+    fn collection_elem_struct(
+        &self,
+        handle: usize,
+        prop: &str,
+    ) -> Option<crate::ast::types::StructUnionType> {
+        use crate::ast::types::DataType;
+        let inst = self.heap.get(handle)?.as_ref()?;
+        let mut cur = Some(inst.class_name.clone());
+        let mut seen: HashSet<String> = HashSet::default();
+        while let Some(cn) = cur {
+            if !seen.insert(cn.clone()) {
+                break;
+            }
+            let cd = self.module.classes.get(&cn)?;
+            if let Some(dt) = cd.property_types.get(prop).cloned() {
+                if let DataType::Struct(su) = self.resolve_dt(&dt) {
+                    return Some(su.clone());
+                }
+                return None;
+            }
+            cur = cd.extends.clone();
+        }
+        None
     }
 
     /// `element` : resolved as above for a struct element in a class collection,
@@ -76106,7 +76716,7 @@ impl Simulator {
     /// this check the cast only compared the base-class hierarchy (both are
     /// `uvm_resource`) and the value params (none), so it wrongly returned
     /// success, the sequence was never started, and its body messages never
-    /// ran (50phase_controls/01simple ended with message count 0).
+    /// ran (message count 0).
     ///
     /// Mirrors `cast_value_params_ok`: for each TYPE param position the dest
     /// declares, the src instance's `type_bindings` must carry the same
@@ -76307,7 +76917,14 @@ impl Simulator {
                 let c = self.class_of_var(name);
                 let th = self.this_stack.last().copied().flatten();
                 let pt = th.and_then(|hh| self.prop_class_type(hh, name));
-                c.or_else(|| pt)
+                // For a bare member of the current `this` object (`seq.get_type()`
+                // where `seq` is a declared field of the running sequence), the
+                // member's declared type from the object's class chain is
+                // authoritative. `class_of_var` is only a loose heuristic for
+                // locals/module vars and can drift to a base type (e.g. resolves
+                // the `seq` field to `uvm_sequence_item`) — prefer the property
+                // lookup when it resolves, else fall back to the var class.
+                pt.or_else(|| c)
             }
             // `this.req.get_type()` (receiver = `this.req`) — resolve the
             // declared member type through the current `this` class.
@@ -79103,7 +79720,19 @@ impl Simulator {
             // `this` when in an instance method, or as a static method
             // when there is no instance handle.
             if let Some(Some(ctx)) = self.class_context_stack.last().cloned() {
-                if self.class_has_method(&ctx, name) {
+                // A bare `randomize()`/`srandom()`/`get_randstate()`/
+                // `set_randstate()` inside a class method is an implicit
+                // built-in, not a declared method — `class_has_method` reports
+                // false for it (the source never lists it), so the bare call
+                // used to fall through and silently return 0, while the
+                // qualified `this.randomize()` (member-access path) reached
+                // `exec_method_call` -> the §18.11 solver correctly. Route the
+                // built-in names through `exec_method_call` too (it intercepts
+                // them ahead of user dispatch), restoring bare `randomize()`
+                // inside `new`/functions (Questa honors it).
+                if self.class_has_method(&ctx, name)
+                    || matches!(name.as_str(), "randomize" | "srandom" | "get_randstate" | "set_randstate")
+                {
                     let this_handle = self.this_stack.last().copied().flatten().unwrap_or(0);
                     if this_handle != 0 {
                         // IEEE 1800-2017 §8.20: a NON-virtual method (which
@@ -79668,11 +80297,27 @@ impl Simulator {
         let mut leaves = Vec::new();
         self.unpacked_struct_leaves(port_name, arg, &su, 0, &mut leaves);
         locals.insert(format!("{}.", port_name), Value::zero(1));
+        // A positional STRUCT pattern literal actual (`'{a, b}`) can't be read
+        // member-by-member (`.a` on a pattern returns x), so bind its evaluated
+        // parts positionally to the flat leaves when the shape matches.
+        let leaf_count = leaves.iter().filter(|(_, ce, _, _)| {
+            matches!(
+                ce.kind,
+                ExprKind::MemberAccess { .. } | ExprKind::Index { .. }
+            )
+        }).count();
+        let pattern_vals = self.eval_flat_struct_pattern(arg, leaf_count);
+        let mut leaf_pos = 0usize;
         let mut backs = Vec::new();
         for (key, caller_expr, w, is_real) in leaves {
             if copies_in {
-                let v = self.eval_expr(&caller_expr);
+                let v = if let Some(pv) = &pattern_vals {
+                    pv[leaf_pos].clone()
+                } else {
+                    self.eval_expr(&caller_expr)
+                };
                 locals.insert(key.clone(), v);
+                leaf_pos += 1;
             } else {
                 let seed = if is_real {
                     Value::from_f64(0.0)
@@ -79745,6 +80390,33 @@ impl Simulator {
         }
     }
 
+    /// If `arg` is a positional STRUCT ASSIGNMENT-PATTERN literal
+    /// (`'{a, b, c}`) with exactly the given number of flat members, evaluate
+    /// its parts in declaration order. `member-access` on a literal base
+    /// (`('{a,b}).x`) does not evaluate in this simulator, so binding a struct
+    /// formal from a literal via `arg.<member>` reads x — this lets the struct
+    /// bind paths consume a literal directly. Returns `None` when `arg` is not
+    /// a simple ordered pattern (caller falls back to member-access eval).
+    fn eval_flat_struct_pattern(&mut self, arg: &Expression, n: usize) -> Option<Vec<Value>> {
+        let ExprKind::AssignmentPattern(parts) = &arg.kind else {
+            return None;
+        };
+        if parts.len() != n {
+            return None;
+        }
+        let mut out = Vec::with_capacity(n);
+        for p in parts.iter() {
+            // Positional only; keyed (`'{"name": v}`) and `default:` forms are
+            // not positionally ordinal.
+            if let crate::ast::expr::AssignmentPatternItem::Ordered(e) = p {
+                out.push(self.eval_expr(e));
+            } else {
+                return None;
+            }
+        }
+        Some(out)
+    }
+
     fn bind_unpacked_struct_arg(
         &mut self,
         port_name: &str,
@@ -79796,21 +80468,36 @@ impl Simulator {
             return None;
         }
         let mut entries = Vec::new();
+        // A positional STRUCT pattern literal argument (`'{a, b}`) can't be
+        // read member-by-member (`.a` on a pattern returns x), so bind its
+        // evaluated parts positionally when the shape matches the flat members.
+        let flat_names: Vec<String> = su
+            .members
+            .iter()
+            .flat_map(|m| m.declarators.iter().map(|md| md.name.name.clone()))
+            .collect();
+        let pattern_vals = self.eval_flat_struct_pattern(arg, flat_names.len());
+        let mut member_pos = 0usize;
         for m in &su.members {
             for md in &m.declarators {
                 let fname = &md.name.name;
-                let member_expr = Expression::new(
-                    ExprKind::MemberAccess {
-                        expr: Box::new(arg.clone()),
-                        member: crate::ast::Identifier {
-                            name: fname.clone(),
-                            span: arg.span,
-                        },
-                    },
-                    arg.span,
-                );
-                let v = self.eval_expr(&member_expr);
                 let local_key = format!("{}.{}", port_name, fname);
+                let v = if let Some(pv) = &pattern_vals {
+                    pv[member_pos].clone()
+                } else {
+                    let member_expr = Expression::new(
+                        ExprKind::MemberAccess {
+                            expr: Box::new(arg.clone()),
+                            member: crate::ast::Identifier {
+                                name: fname.clone(),
+                                span: arg.span,
+                            },
+                        },
+                        arg.span,
+                    );
+                    self.eval_expr(&member_expr)
+                };
+                member_pos += 1;
                 locals.insert(local_key.clone(), v);
                 // Write-back lvalue: for a plain-identifier actual emit the
                 // hierarchical `Ident([s, a])` form (how source `s.a` parses)
@@ -80119,12 +80806,43 @@ impl Simulator {
         Some(out)
     }
 
+    ///  §6.21: build the shared persistent-cell key for a `static` subroutine
+    /// local, mirroring the key constructed at its declaration site (§8.25/
+    /// §6.21 specialization-aware prefixing). `None` when no sync frame that
+    /// DECLARES this name is open. The key's subroutine is the routine whose
+    /// body declared the static (found by scanning the open sync frames for
+    /// the one that registered `nm`) — NOT the innermost frame, which may be a
+    /// nested helper (e.g. a timing `wait_for` wrapper around a revived task
+    /// body) that merely surrounds the read/write without declaring `nm`.
+    fn static_local_key_for(&self, nm: &str) -> Option<String> {
+        let sub_name = self
+            .static_local_syncs
+            .iter()
+            .rev()
+            .find(|(_, syncs)| syncs.iter().any(|(n, _)| n == nm))
+            .map(|(n, _)| n.clone())?;
+        Some(match (self.class_context_stack.last().and_then(|c| c.as_ref()), self.current_spec.as_ref()) {
+            (Some(cn), Some((spec_base, sig))) if spec_base == cn => {
+                format!("{}#{}::{}::{}", cn, sig, sub_name, nm)
+            }
+            (Some(cn), _) => format!("{}::{}::{}", cn, sub_name, nm),
+            _ => format!("{}::{}", sub_name, nm),
+        })
+    }
+
     /// §6.21: on subroutine return, copy each `static` local's final value from
     /// the (about-to-be-popped) local frame back into the persistent store, then
     /// close this call's sync frame. Called before `local_stack` is popped.
     fn sync_static_locals(&mut self) {
         if let Some((_name, syncs)) = self.static_local_syncs.pop() {
             for (local_name, key) in syncs {
+                // Live-sourced statics keep `static_local_vars` authoritative
+                // (literal write-through + read-through); writing back the
+                // recursion-window snapshot here would clobber the committed
+                // value with a stale frame copy.
+                if self.static_local_names.contains(&local_name) {
+                    continue;
+                }
                 if let Some(v) = self.local_stack.last().and_then(|l| l.get(&local_name)) {
                     self.static_local_vars.insert(key, v.clone());
                 }
@@ -80230,6 +80948,18 @@ impl Simulator {
                     &args[i],
                     &mut locals,
                 ) {
+                    // §13.4.2: struct FORMALS bind member-wise (above) but are
+                    // skipped by the plain-formal registration, so
+                    // `register_formal_type_metadata` below never ran, and a
+                    // whole-struct reference to the formal (`y = arg`,
+                    // `return arg`) had no type, so `p_elem_type` missed it:
+                    // the RHS evaluated to a zeroed container instead of the
+                    // members. Register the same struct metadata here too.
+                    self.register_formal_type_metadata(
+                        &port.name.name,
+                        &port.data_type,
+                        port.dimensions.is_empty(),
+                    );
                     output_bindings.extend(backs);
                     continue;
                 }
@@ -82873,6 +83603,48 @@ impl Simulator {
                     return Some(ta);
                 }
             }
+        }
+        None
+    }
+
+    /// When the lvalue is a class MEMBER whose declared type is a TYPEDEF
+    /// ALIAS to a PARAMETERIZED class — e.g. UVM's
+    /// `typedef uvm_object_string_pool#(uvm_event#(uvm_object))
+    /// uvm_event_pool;  ...  uvm_event_pool event_pool;` — recover the
+    /// target specialization `(base, sig)` so a later
+    /// `event_pool = new(...)` binds the pool's `T` to the concrete
+    /// element (`uvm_event#(uvm_object)`) instead of the class default
+    /// (`uvm_object`). The field's own `#(...)` is empty (the args live on
+    /// the alias target), so `get_expr_type_name` returns just the base
+    /// class and `resolve_ctor_type_args` finds no args.
+    ///
+    /// Returns the specialization only when the member's raw declared type
+    /// is a typedef alias (not a direct class/`#` spelling). Walks the
+    /// `this`-instance inheritance chain so a base-class property (e.g.
+    /// `uvm_component.event_pool`) resolves from a derived component.
+    fn this_member_typedef_spec(&self, lvalue: &Expression) -> Option<(String, String)> {
+        let leaf = match &lvalue.kind {
+            ExprKind::Ident(h) => h.path.last()?.name.name.clone(),
+            ExprKind::MemberAccess { member, .. } => member.name.clone(),
+            _ => return None,
+        };
+        let h = self.this_stack.last().copied().flatten()?;
+        let this_cn = self.heap.get(h).and_then(|o| o.as_ref())?.class_name.clone();
+        let mut cur = Some(this_cn);
+        while let Some(cn) = cur {
+            let cd = self.module.classes.get(&cn)?;
+            if let Some(prop) = cd.properties.get(&leaf) {
+                if let Some(raw) = &prop.type_name {
+                    // `raw` is the declared type name. If it is a typedef
+                    // alias to a parameterized class, `resolve_typedef_spec`
+                    // follows it. Base classes / non-aliases yield None.
+                    if let Some(spec) = self.resolve_typedef_spec(raw) {
+                        return Some(spec);
+                    }
+                }
+                return None;
+            }
+            cur = cd.extends.clone();
         }
         None
     }
@@ -87136,7 +87908,7 @@ impl Simulator {
                     let all_unsigned = cvar_w.iter().all(|(_, s)| !*s);
                     self.constraint_cmp_unsigned = all_unsigned;
                     let coupled =
-                        self.solve_coupled_affine(&citems, &cvar_names, &cvar_dom, _trial);
+                        self.solve_coupled_affine(&citems, &cvar_names, &cvar_dom, _trial, Some(handle));
                     self.constraint_cmp_unsigned = false;
                     if let Some(pairs) = coupled {
                         for (col, val) in pairs {
@@ -87155,35 +87927,6 @@ impl Simulator {
                             }
                         }
                     }
-                }
-            }
-
-            // ---- §18.4 collection pipeline: SIZE, then SEED, then SOLVE ----
-            // A rand dynamic array whose `.size()` is constrained has no
-            // element set until it is sized, so element solving must follow
-            // sizing. `unique {}` runs last over the settled elements.
-            let mut pinned_elems: HashSet<String> = HashSet::default();
-            if !rand_colls.is_empty() {
-                self.solve_array_sizes(&rand_colls, &constraints);
-                // Fresh random baseline for every element of a dynamic /
-                // associative member (fixed arrays keep the legacy pool pass).
-                // §18.4.1: a CLASS-element collection (`rand obj arr[]`) holds
-                // object handles that are randomized RECURSIVELY — never drawn
-                // as scalars, or the handle is overwritten with junk.
-                for c in &rand_colls {
-                    if c.kind == CollKind::Fixed || c.is_object_elem {
-                        continue;
-                    }
-                    for key in self.coll_elem_keys(c) {
-                        let prev = self.read_coll_elem(&key).and_then(|v| v.to_u64());
-                        let v = self.draw_elem(c.width, prev);
-                        self.write_coll_elem(&key, v);
-                    }
-                }
-                self.solve_coll_foreach(handle, &rand_colls, &constraints, &mut pinned_elems);
-                self.solve_top_level_elems(handle, &constraints, &mut pinned_elems);
-                for c in &unique_colls {
-                    self.enforce_unique_coll(c, &constraints, &pinned_elems);
                 }
             }
 
@@ -87286,6 +88029,39 @@ impl Simulator {
                 }
                 if !changed {
                     break;
+                }
+            }
+
+            // ---- §18.4 collection pipeline: SIZE, then SEED, then SOLVE ----
+            // Runs now, AFTER the scalar-equality propagation above. A rand
+            // dynamic array whose `.size()` is tied to a rand SCALAR
+            // (`m_data.size() == m.length` with `m.length == N`) is only
+            // size-able once the propagation has pinned the scalar to its
+            // constrained value; sizing it earlier yields the scalar's raw,
+            // unconstrained draw and the `.size() == m.length` acceptance then
+            // fails. `unique {}` runs last over the settled elements.
+            let mut pinned_elems: HashSet<String> = HashSet::default();
+            if !rand_colls.is_empty() {
+                self.solve_array_sizes(&rand_colls, &constraints);
+                // Fresh random baseline for every element of a dynamic /
+                // associative member (fixed arrays keep the legacy pool pass).
+                // §18.4.1: a CLASS-element collection (`rand obj arr[]`) holds
+                // object handles that are randomized RECURSIVELY — never drawn
+                // as scalars, or the handle is overwritten with junk.
+                for c in &rand_colls {
+                    if c.kind == CollKind::Fixed || c.is_object_elem {
+                        continue;
+                    }
+                    for key in self.coll_elem_keys(c) {
+                        let prev = self.read_coll_elem(&key).and_then(|v| v.to_u64());
+                        let v = self.draw_elem(c.width, prev);
+                        self.write_coll_elem(&key, v);
+                    }
+                }
+                self.solve_coll_foreach(handle, &rand_colls, &constraints, &mut pinned_elems);
+                self.solve_top_level_elems(handle, &constraints, &mut pinned_elems);
+                for c in &unique_colls {
+                    self.enforce_unique_coll(c, &constraints, &pinned_elems);
                 }
             }
 
@@ -87703,6 +88479,41 @@ impl Simulator {
                 if rand_set.contains(n) {
                     return Some(n.clone());
                 }
+            }
+        }
+        None
+    }
+
+    /// §18.7 — an inline `obj.randomize() with { obj.member == … }` constraint
+    /// refers to the randomized object's own rand property through its
+    /// RECEIVER (the bare handle `obj`, possibly `obj.field`). The forcing
+    /// solver keys targets by the object's bare property name, so a prefixed
+    /// `obj.member` must be recognised as the bare `member` when `obj`
+    /// evaluates to the object currently being randomized (`handle`).
+    fn prefixed_self_member(
+        &mut self,
+        expr: &Expression,
+        handle: usize,
+        rand_set: &HashSet<String>,
+    ) -> Option<String> {
+        let ExprKind::MemberAccess { expr: recv, member } = &expr.kind
+        else {
+            return None;
+        };
+        let prop = member.name.clone();
+        if !rand_set.contains(&prop) {
+            return None;
+        }
+        let h = self.eval_expr(recv).to_u64().unwrap_or(0) as usize;
+        if h == handle {
+            return Some(prop);
+        }
+        // Inside the randomized frame the receiver LOCAL is out of scope
+        // (eval returns 0), so recognise it by name when it matches the
+        // `obj.randomize() with { obj.member … }` receiver.
+        if let Some(rn) = Self::plain_ident_name(recv) {
+            if self.rand_receiver.as_deref() == Some(&rn) {
+                return Some(prop);
             }
         }
         None
@@ -88660,6 +89471,14 @@ impl Simulator {
         right: &Expression,
         rand_set: &HashSet<String>,
     ) -> bool {
+        // §18.5: a `.size()` of a rand dynamic array is not a settled integral
+        // operand during the scalar fixpoint — it is empty until sized, so
+        // treating `arr.size() == N` as an affine equation in `N` would force
+        // `N := arr.size()` (= 0) and clobber a sibling `N == K`. The array
+        // sizing solver owns this coupling.
+        if self.is_rand_dyn_size_expr(handle, left) || self.is_rand_dyn_size_expr(handle, right) {
+            return false;
+        }
         let mut cands = self.affine_candidates(left, rand_set);
         for c in self.affine_candidates(right, rand_set) {
             if !cands.contains(&c) {
@@ -88841,6 +89660,55 @@ impl Simulator {
         self.set_prop_if_changed(handle, &target, p)
     }
 
+    /// Is `e` a `.size()` (`.size` / `.size()`) reference to a rand DYNAMIC
+    /// array / queue of the object `handle`? Used by the constraint solver so
+    /// an equality between a rand scalar and an as-yet-unsized collection
+    /// length does not force the scalar from the collection's current (empty)
+    /// size — the sizing phase owns that coupling.
+    fn is_rand_dyn_size_expr(&self, handle: usize, e: &Expression) -> bool {
+        let arr = match &e.kind {
+            ExprKind::Call { func, args } if args.is_empty() => match &func.kind {
+                ExprKind::MemberAccess { expr, member } if member.name == "size" => expr,
+                _ => return false,
+            },
+            ExprKind::MemberAccess { expr, member } if member.name == "size" => expr,
+            _ => return false,
+        };
+        let ExprKind::Ident(h) = &arr.kind else {
+            return false;
+        };
+        if h.path.len() != 1 {
+            return false;
+        }
+        let name = &h.path[0].name.name;
+        let cn = match self.heap.get(handle).and_then(|o| o.as_ref()) {
+            Some(inst) => inst.class_name.clone(),
+            None => return false,
+        };
+        let mut cur = Some(cn);
+        while let Some(c) = cur {
+            let Some(cd) = self.module.classes.get(&c) else { return false; };
+            if cd.queue_properties.contains_key(name) {
+                return true;
+            }
+            cur = cd.extends.clone();
+        }
+        false
+    }
+
+    /// Does a binary constraint expression couple a rand DYNAMIC-array length
+    /// through `.size()` on either operand? Used so such an item is not
+    /// blocked from (and not folded into) the coupled scalar solve.
+    fn expr_involves_dyn_size(&self, handle: usize, e: &Expression) -> bool {
+        match &e.kind {
+            ExprKind::Binary { left, right, .. } => {
+                self.is_rand_dyn_size_expr(handle, left)
+                    || self.is_rand_dyn_size_expr(handle, right)
+            }
+            _ => false,
+        }
+    }
+
     fn solve_forced(
         &mut self,
         handle: usize,
@@ -88917,13 +89785,38 @@ impl Simulator {
                     }
                     if let Some(v) = self.rand_lvalue_name(left, rand_set) {
                         if self.rand_lvalue_name(right, rand_set).is_none() {
+                            // §18.5: do not force a rand scalar from a rand
+                            // DYNAMIC-ARRAY `.size()` (`arr.size() == N`): the
+                            // array length is not settled yet, so its current
+                            // size is 0 and forcing `N := arr.size()` clobbers
+                            // a sibling constraint (`N == K`). The collection
+                            // sizing solver owns the coupling and sizes the
+                            // array to N once N is final.
+                            if !self.is_rand_dyn_size_expr(handle, right) {
+                                let val = self.eval_expr(right);
+                                return self.set_prop_if_changed(handle, &v, val);
+                            }
+                        }
+                    }
+                    if let Some(v) = self.rand_lvalue_name(right, rand_set) {
+                        if !self.is_rand_dyn_size_expr(handle, left) {
+                            let val = self.eval_expr(left);
+                            return self.set_prop_if_changed(handle, &v, val);
+                        }
+                    }
+                    // §18.7 — an inline `obj.randomize() with { obj.member == … }`
+                    // prefixed reference to the randomized object's own property.
+                    if let Some(v) = self.prefixed_self_member(left, handle, rand_set) {
+                        if !self.is_rand_dyn_size_expr(handle, right) {
                             let val = self.eval_expr(right);
                             return self.set_prop_if_changed(handle, &v, val);
                         }
                     }
-                    if let Some(v) = self.rand_lvalue_name(right, rand_set) {
-                        let val = self.eval_expr(left);
-                        return self.set_prop_if_changed(handle, &v, val);
+                    if let Some(v) = self.prefixed_self_member(right, handle, rand_set) {
+                        if !self.is_rand_dyn_size_expr(handle, left) {
+                            let val = self.eval_expr(left);
+                            return self.set_prop_if_changed(handle, &v, val);
+                        }
                     }
                     // §18.4: the target may be a member of an aggregate rand
                     // property, or a property of a `rand` object handle solved
@@ -90546,6 +91439,36 @@ impl Simulator {
                             None
                         };
                         if let Some(struct_entries) = struct_arg_binding {
+                            // §13.5.2: a struct METHOD formal binds member-wise (above) but
+                            // skips the scalar formal registration below, so `p_elem_type`
+                            // misses it and a whole-struct reference to the formal reads a
+                            // zeroed container. Register the same struct type metadata the
+                            // free-function path does — resolving a type-PARAMETER formal
+                            // (`function void f(T item)` with struct `T`) to its concrete
+                            // bound struct, like `bind_unpacked_struct_arg` does.
+                            let reg_dt = if let DataType::TypeReference { name: tn, .. } =
+                                &port.data_type
+                            {
+                                let cname = self
+                                    .heap
+                                    .get(handle)
+                                    .and_then(|o| o.as_ref())
+                                    .and_then(|i| i.type_bindings.get(&tn.name.name).cloned())
+                                    .or_else(|| self.resolve_type_param_binding(&tn.name.name))
+                                    .unwrap_or_else(|| tn.name.name.clone());
+                                self.module
+                                    .typedef_types
+                                    .get(&cname)
+                                    .cloned()
+                                    .unwrap_or_else(|| port.data_type.clone())
+                            } else {
+                                port.data_type.clone()
+                            };
+                            self.register_formal_type_metadata(
+                                &port.name.name,
+                                &reg_dt,
+                                port.dimensions.is_empty(),
+                            );
                             if matches!(
                                 port.direction,
                                 PortDirection::Output
@@ -91609,7 +92532,7 @@ impl Simulator {
                 // user class PROPERTY `seqprtzmb_catcher catcher;` when the
                 // property's `catcher = new()` resolves its type, so the
                 // base class is constructed and the derived `catch()`
-                // override never runs (UVM 04sync/.../06test_end_cleanup).
+                // override never runs (phasing cleanup).
                 //
                 // Only trust these maps when `name` is genuinely a local of
                 // the current scope. Two cases are genuine:
@@ -91722,6 +92645,41 @@ impl Simulator {
                     let bname = self.resolve_hier_name(bh);
                     if let Some(cn) = self.module.array_elem_class.get(&bname).cloned() {
                         return Some(cn);
+                    }
+                    // §8.20 + §6.20.3: a class-MEMBER array whose element
+                    // type is a TYPE PARAMETER (e.g. `PARAM pool[string]` in
+                    // a generic `class Base#(type PARAM)` = `uvm_pool#(T)`).
+                    // It has no compile-time `array_elem_class` entry because
+                    // the element type isn't concrete until specialization.
+                    // Resolve the field's type-param element type through the
+                    // current `this` instance's bindings so that `pool[k] =
+                    // new(...)` constructs the bound concrete class (`myitem`
+                    // for `Base#(myitem)`), not a null/empty handle.
+                    if let Some(h) = self.this_stack.last().copied().flatten() {
+                        if let Some(inst) = self.heap.get(h).and_then(|o| o.as_ref()) {
+                            let this_cn = inst.class_name.clone();
+                            let base = self
+                                .extract_spec_from_string(&this_cn)
+                                .map(|(b, _)| b)
+                                .unwrap_or(this_cn);
+                            if let Some(elem_decl) =
+                                self.class_prop_type_named(&base, &bname)
+                            {
+                                // Bound concrete type if the element's declared
+                                // type is a type param of `base`; else the
+                                // declared type itself.
+                                let concrete =
+                                    self.resolve_type_param_with(&elem_decl, &self.current_spec)
+                                        .unwrap_or(elem_decl);
+                                let cb = self
+                                    .extract_spec_from_string(&concrete)
+                                    .map(|(b, _)| b)
+                                    .unwrap_or_else(|| concrete.clone());
+                                if self.module.classes.contains_key(&cb) {
+                                    return Some(concrete);
+                                }
+                            }
+                        }
                     }
                 }
                 None

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -45870,10 +45870,30 @@ impl Simulator {
                             // dynamic array of bytes, so the queries track its
                             // CURRENT length ($left 0, $right len-1) — not the
                             // 1024-bit placeholder width it fell through to.
+                            // BUT a FIXED-SIZE string-array member (`string[16]`)
+                            // must keep reporting its DECLARED element count, not
+                            // the current (empty) string value read back from the
+                            // array — `$size(a)` == 16, not 0. Resolve any
+                            // instance-scoped / module-scope fixed array first
+                            // and fall through to the array-dim branch below.
                             if self.expr_is_string_valued(arg) {
-                                let len =
-                                    self.eval_expr(arg).sv_string_bytes().len() as u64;
-                                return Self::dynamic_query_result(&sn, len);
+                                let mut is_fixed_array = false;
+                                if let ExprKind::Ident(h) = &arg.kind {
+                                    let rname = self.resolve_hier_name(h);
+                                    let fixed = |m: &str| {
+                                        self.module.arrays.contains_key(m)
+                                            || self.module.arrays_2d.contains_key(m)
+                                            || self.module.arrays_nd.contains_key(m)
+                                    };
+                                    is_fixed_array = self
+                                        .instance_assoc_member(&rname)
+                                        .map_or_else(|| fixed(&rname), |s| fixed(&s));
+                                }
+                                if !is_fixed_array {
+                                    let len =
+                                        self.eval_expr(arg).sv_string_bytes().len() as u64;
+                                    return Self::dynamic_query_result(&sn, len);
+                                }
                             }
                         }
                     }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -57,10 +57,16 @@ mod constraint_algebra_inherit;
 mod constraint_array_sum;
 #[path = "classes/constraint_arrays_ordering.rs"]
 mod constraint_arrays_ordering;
+#[path = "classes/constraint_dyn_size_pinned_scalar.rs"]
+mod constraint_dyn_size_pinned_scalar;
 #[path = "classes/constraint_foreach_and_casts.rs"]
 mod constraint_foreach_and_casts;
 #[path = "classes/constraint_funcs_aggregates.rs"]
 mod constraint_funcs_aggregates;
+#[path = "classes/constraint_inline_enclosing_scope.rs"]
+mod constraint_inline_enclosing_scope;
+#[path = "classes/constraint_prefixed_inline_with.rs"]
+mod constraint_prefixed_inline_with;
 #[path = "classes/constraint_randc_soft_local.rs"]
 mod constraint_randc_soft_local;
 #[path = "classes/cov_covergroup_basic.rs"]
@@ -127,6 +133,8 @@ mod struct_with_class_handle;
 mod struct_output_inout_ref_formal;
 #[path = "classes/type_param_struct_formal.rs"]
 mod type_param_struct_formal;
+#[path = "classes/struct_formal_and_config_foreach.rs"]
+mod struct_formal_and_config_foreach;
 #[path = "classes/typename_param_class.rs"]
 mod typename_param_class;
 #[path = "classes/unpacked_struct_class_property_whole_value.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -33,6 +33,8 @@ mod class_local_typedef_aa;
 mod class_local_typedef_resolution;
 #[path = "classes/class_method_dispatch.rs"]
 mod class_method_dispatch;
+#[path = "classes/method_default_this_call.rs"]
+mod method_default_this_call;
 #[path = "classes/class_name_method_shadow.rs"]
 mod class_name_method_shadow;
 #[path = "classes/class_packed_and_type_params.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -185,3 +185,5 @@ mod randomize_obj_array_property;
 mod static_assoc_struct_pool;
 #[path = "classes/vif_static_roundtrip.rs"]
 mod vif_static_roundtrip;
+#[path = "classes/nopack_member_array.rs"]
+mod nopack_member_array;

--- a/tests/classes/class_formal_typedef_widen.rs
+++ b/tests/classes/class_formal_typedef_widen.rs
@@ -8,7 +8,7 @@
 //! as-is and read x in the high half — which is exactly how
 //! `uvm_packer::pack_field_int(uvm_integral_t value, int size)` corrupted
 //! packed `$realtobits(shortreal)` and negative values passed to a 64-bit
-//! packer formal (UVM 03data pack/record group).
+//! formal.
 
 use xezim::simulate;
 

--- a/tests/classes/constraint_dyn_size_pinned_scalar.rs
+++ b/tests/classes/constraint_dyn_size_pinned_scalar.rs
@@ -1,0 +1,81 @@
+//! §18.5 / dimethyl — a rand DYNAMIC array whose `.size()` equals a
+//! co-constrained rand SCALAR (`m_data.size == m_length` with `m_length ==
+//! 10`, plus `m_streaming_width == m_length`, `m_byte_enable_length <=
+//! m_length`/`.size` coupling) must be sized to the scalar's FINAL constrained
+//! value — not the scalar pinned to the array's current (empty) size 0, which
+//! never satisfies `m_length == 10` and would burn all 1000 trial retries,
+//! making randomize() FAIL. This is the regression seen on the UVM generic
+//! payload (obj1.randomize()). The source below is byte-for-byte validated
+//! against the reference simulator (TAG_PASS).
+
+use xezim::simulate;
+
+fn tags(src: &str) -> Vec<String> {
+    let sim = simulate(src, 1000).expect("sim");
+    sim.output
+        .iter()
+        .filter(|o| o.message.starts_with("TAG_"))
+        .map(|o| o.message.clone())
+        .collect()
+}
+
+/// 8 randomized objects must all satisfy the full coupled set; the dyn array
+/// sizes equal their co-constrained scalars and the pinned scalar stays 10.
+#[test]
+fn dyn_array_size_coupled_to_pinned_scalar() {
+    let src = "\
+class gp; rand bit[63:0] m_address; rand byte unsigned m_data[];\n\
+  rand int unsigned m_length; rand byte unsigned m_byte_enable[];\n\
+  rand int unsigned m_byte_enable_length; rand int unsigned m_streaming_width;\n\
+  constraint body {\n\
+    m_address >= 0 && m_address < 256;\n\
+    m_length == 10;\n\
+    m_data.size == m_length;\n\
+    m_streaming_width == m_length;\n\
+    m_byte_enable_length <= m_length;\n\
+    (m_byte_enable_length % 4) == 0;\n\
+    m_byte_enable.size == m_byte_enable_length;\n\
+    foreach (m_byte_enable[i]) m_byte_enable[i] inside { 0, 255 };\n\
+  }\n\
+endclass\n\
+module top;\n\
+  initial begin : b\n\
+    automatic int failures = 0;\n\
+    automatic gp g;\n\
+    for (int n = 0; n < 8; n++) begin\n\
+      g = new();\n\
+      if (!g.randomize()) failures++;\n\
+      if (g.m_length != 10) failures++;\n\
+      if (g.m_data.size() != g.m_length) failures++;\n\
+      if (g.m_streaming_width != g.m_length) failures++;\n\
+      if (g.m_byte_enable_length > g.m_length) failures++;\n\
+      if ((g.m_byte_enable_length % 4) != 0) failures++;\n\
+      if (g.m_byte_enable.size() != g.m_byte_enable_length) failures++;\n\
+    end\n\
+    if (failures == 0) $display(\"TAG_PASS\"); else $display(\"TAG_FAIL %0d\", failures);\n\
+    $finish;\n\
+  end endmodule";
+    let t = tags(src);
+    assert_eq!(t, vec!["TAG_PASS"], "all draws must satisfy the coupled set");
+}
+
+/// The SAME set reached through an INLINE `randomize() with {…}` (as the UVM
+/// test drives it) must also solve: the dyn-array `.size()` must not collapse
+/// the equality `m_data.size == m_length` into a spurious `m_length == 0` that
+/// contradicts `m_length == 20`.
+#[test]
+fn dyn_array_size_coupled_through_inline_with() {
+    let src = "\
+class gp;  rand byte unsigned m_data[]; rand int unsigned m_length;
+\
+  rand int unsigned m_streaming; endclass\n\
+module top; initial begin : b\n\
+  automatic gp g = new();\n\
+  if (!g.randomize() with { m_length == 20; m_data.size == m_length; m_streaming == m_length; })\n\
+    $display(\"TAG_FAIL rand\");\n\
+  else if (g.m_length != 20 || g.m_data.size() != 20 || g.m_streaming != 20)\n\
+    $display(\"TAG_FAIL vals %0d %0d %0d\", g.m_length, g.m_data.size(), g.m_streaming);\n\
+  else $display(\"TAG_PASS\");\n\
+  $finish; end endmodule\n";
+    assert_eq!(tags(src), vec!["TAG_PASS"], "inline with + .size must solve");
+}

--- a/tests/classes/constraint_inline_enclosing_scope.rs
+++ b/tests/classes/constraint_inline_enclosing_scope.rs
@@ -1,0 +1,97 @@
+//! §18.7 — in `obj.randomize() with { obj.x == encl_member; … }` the inline may
+//! compare a prefixed object member against a member of the ENCLOSING scope
+//! (the sequence's `start_addr`, `transmit_del` — exactly what a UVM `uvm_do`
+//! inline block does). Once the randomize switches `this` to the OBJECT, those
+//! free identifiers no longer resolve and read 0, so `req.addr == start_addr`
+//! forced `addr` to 0 and with an array-`.size() == <=s>` coupling the solve
+//! dead-ended. The fix freezes each enclosing-scope member referenced (but not
+//! a rand member of the object) to its current value and lets the prefixed
+//! member read the object's own field. Validated byte-for-byte against the
+//! reference simulator.
+
+use xezim::simulate;
+
+fn tags(src: &str) -> Vec<String> {
+    let sim = simulate(src, 1000).expect("sim");
+    sim.output
+        .iter()
+        .filter(|o| o.message.starts_with("TAG_"))
+        .map(|o| o.message.clone())
+        .collect()
+}
+
+const SEQUENCE_TRANSACTION: &str = r#"
+typedef enum { WRITE, READ } rw_e;
+class xfer;
+  rand bit [15:0] addr;
+  rand rw_e        read_write;
+  rand int unsigned size;
+  rand byte unsigned data[];
+  rand int unsigned error_pos;
+  rand int unsigned transmit_delay;
+  constraint c_read { read_write inside { WRITE, READ }; }
+  constraint c_size { size inside {1,2,4,8}; data.size() == size; }
+  constraint c_tr { transmit_delay <= 10; }
+endclass
+class seq_c;
+  int start_addr = 10;
+  int transmit_del = 0;
+  function void run();
+    xfer m = new();
+    int r = m.randomize() with {
+      m.addr == start_addr;
+      m.read_write == READ;
+      m.size == 2;
+      m.error_pos == 1000;
+      m.transmit_delay == transmit_del;
+    };
+    if (r != 1 || m.addr != start_addr || m.read_write != READ || m.size != 2
+        || m.data.size() != 2 || m.error_pos != 1000)
+      $display("TAG_FAIL %0d %0d %0d %0d %0d %0d", r, m.addr,
+               m.read_write, m.size, m.data.size(), m.error_pos);
+    else $display("TAG_PASS");
+  endfunction
+endclass
+module top;
+  initial begin seq_c s = new(); s.run(); $finish; end
+endmodule
+"#;
+
+#[test]
+fn prefixed_inline_against_enclosing_scope_members() {
+    assert_eq!(
+        tags(SEQUENCE_TRANSACTION),
+        vec!["TAG_PASS"],
+        "enclosing-scope members must be frozen in the inline"
+    );
+}
+
+const SIMPLE: &str = r#"
+class req;
+  rand bit [15:0] addr;
+  rand int unsigned size;
+endclass
+class seq_c;
+  int start_addr;
+  function new(int a); start_addr = a; endfunction
+  function void run();
+    req m = new();
+    int r = m.randomize() with { m.addr == start_addr; m.size == 1; };
+    if (r != 1 || m.addr != start_addr || m.size != 1)
+      $display("TAG_FAIL %0d %0d %0d", r, m.addr, m.size);
+    else $display("TAG_PASS");
+  endfunction
+endclass
+module top;
+  initial begin seq_c s = new(32); s.run(); $finish; end
+endmodule
+"#;
+
+#[test]
+fn prefixed_member_via_enclosing_scope_value() {
+    assert_eq!(
+        tags(SIMPLE),
+        vec!["TAG_PASS"],
+        "enclosing member must drive prefixed member"
+    );
+}

--- a/tests/classes/constraint_prefixed_inline_with.rs
+++ b/tests/classes/constraint_prefixed_inline_with.rs
@@ -1,0 +1,92 @@
+//! §18.7 — an inline `obj.randomize() with { obj.member == … }` constraint that
+//! refers to the randomized object's OWN rand fields through a PREFIXED
+//! receiver (`obj.size`, `obj.error_pos`, `obj.read_write`) must be forced like
+//! the bare-name form. Before the fix, the solver keyed targets by the bare
+//! property name only, so a prefixed reference was never a forcing target — the
+//! field stayed at its raw draw — and stacked with a dyn-array-`.size() ==
+//! scalar` coupling it made randomize() burn all 1000 trial retries and return
+//! 0. Sources below are validated byte-for-byte against the reference
+//! simulator (TAG_PASS).
+
+use xezim::simulate;
+
+fn tags(src: &str) -> Vec<String> {
+    let sim = simulate(src, 1000).expect("sim");
+    sim.output
+        .iter()
+        .filter(|o| o.message.starts_with("TAG_"))
+        .map(|o| o.message.clone())
+        .collect()
+}
+
+/// Prefixed inline members that equal literals, over a rand scalar coupled to a
+/// dynamic array's `.size()`.
+#[test]
+fn prefixed_inline_member_equals_forced() {
+    let src = "\
+typedef enum { WRITE, READ } xbus_rw;\n\
+class xbus_transfer;\n\
+  rand bit [15:0] addr; rand xbus_rw read_write;\n\
+  rand int unsigned size; rand byte unsigned data[];\n\
+  rand bit [3:0] wait_state[]; rand int unsigned error_pos;\n\
+  rand int unsigned transmit_delay;\n\
+  constraint c_read_write { read_write inside { WRITE, READ }; }\n\
+  constraint c_size { size inside {1,2,4,8}; }\n\
+  constraint c_data_wait_size { data.size() == size; wait_state.size() == size; }\n\
+  constraint c_transmit { transmit_delay <= 10; }\n\
+endclass\n\
+module top;\n\
+  initial begin : body\n\
+    automatic int fails = 0;\n\
+    for (int i = 0; i < 8; i++) begin : it\n\
+      automatic xbus_transfer m = new();\n\
+      automatic int r = m.randomize() with {\n\
+        m.size == 1; m.error_pos == 1000; m.read_write == READ;\n\
+      };\n\
+      if (r != 1) fails++;\n\
+      else if (m.size != 1 || m.data.size() != 1 || m.wait_state.size() != 1\n\
+               || m.error_pos != 1000) fails++;\n\
+    end\n\
+    if (fails == 0) $display(\"TAG_PASS\"); else $display(\"TAG_FAIL %0d\", fails);\n\
+    $finish;\n\
+  end endmodule\n";
+    assert_eq!(tags(src), vec!["TAG_PASS"], "prefixed inline members must be forced");
+}
+
+/// The prefixed member is pinned to a CONSTANT that is NOT 1 (receiver `t`,
+/// scalar only), proving the prefix is genuinely honoured rather than matched
+/// by luck in a small domain.
+#[test]
+fn prefixed_inline_scalar_distinct_pinned() {
+    let src = "\
+class t;\n\
+  rand int unsigned size;\n\
+  rand bit[15:0] zz;\n\
+  constraint c { size inside {1,2,4,8}; }\n\
+endclass\n\
+module top; initial begin : body\n\
+  automatic t o = new();\n\
+  automatic int r = o.randomize() with { o.size == 2; };\n\
+  if (r != 1 || o.size != 2) $display(\"TAG_FAIL %0d %0d\", r, o.size);\n\
+  else $display(\"TAG_PASS\");\n\
+  $finish; end endmodule\n";
+    assert_eq!(tags(src), vec!["TAG_PASS"], "prefixed scalar must be pinned exactly");
+}
+
+/// A prefixed rand member that couples a dynamic array's size (`m_data.size()
+/// == m_length` with `m.length == K`) must size the array to the scalar.
+#[test]
+fn prefixed_member_coupled_to_dyn_array_size() {
+    let src = "\
+class gp;\n  rand int unsigned m_length;\n  rand byte unsigned m_data[];\n\
+  constraint c { m_length inside {1,2,4,8}; m_data.size() == m_length; }\n\
+endclass\n\
+module top; initial begin : body\n\
+  automatic gp q = new();\n\
+  automatic int r = q.randomize() with { q.m_length == 4; };\n\
+  if (r != 1 || q.m_length != 4 || q.m_data.size() != 4)\n\
+    $display(\"TAG_FAIL %0d %0d %0d\", r, q.m_length, q.m_data.size());\n\
+  else $display(\"TAG_PASS\");\n\
+  $finish; end endmodule\n";
+    assert_eq!(tags(src), vec!["TAG_PASS"], "prefixed scalar must drive the dyn-array size");
+}

--- a/tests/classes/method_default_this_call.rs
+++ b/tests/classes/method_default_this_call.rs
@@ -1,0 +1,74 @@
+//! A method formal's DEFAULT argument expression is evaluated at call time in
+//! the callee's scope (§13.3.1/§13.5.3), so it may reference `this` or call a
+//! sibling method on the receiving instance.
+//!
+//! Distilled from UVM's parameterized `uvm_event#(T)`:
+//!
+//! ```systemverilog
+//! virtual function void trigger(T data = get_default_data());
+//! ```
+//!
+//! When `trigger()` is called with no argument, the omitted formal is filled
+//! by evaluating `get_default_data()` on THAT instance — the same `this` the
+//! call is dispatched on. The simulator evaluated the default in the CALLER's
+//! scope before the callee's `this`/class context was pushed, so the
+//! `this`-dependent method default silently evaluated to the type's zero value
+//! (a null handle) instead of the instance's stored default data.
+//!
+//! `myevent#(T)` mirrors the shape: `trigger(T data = get_default_data())`
+//! and `set_default_data`. The test sets a non-trivial default, triggers with
+//! no argument, and checks that the trigger recorded exactly the instance's
+//! default — proving the default was evaluated against `this`, not zeroed.
+
+use xezim::simulate;
+
+fn u(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able", n))
+}
+
+#[test]
+fn method_default_evaluates_this_dependent_call() {
+    const SRC: &str = "class myevent #(type T = int);
+  local T m_default;
+  local T m_last;
+
+  virtual function T get_default_data();
+    return m_default;
+  endfunction
+
+  virtual function void set_default_data(T v);
+    m_default = v;
+  endfunction
+
+  virtual function void trigger(T data = get_default_data());
+    m_last = data;
+  endfunction
+
+  virtual function T get_trigger_data();
+    return m_last;
+  endfunction
+endclass
+
+module tb;
+  int dflt_ok;
+  int trig_ok;
+  myevent#(int) ev;
+  initial begin
+    ev = new();
+    // default m_d is 0; trigger() with no arg must capture 0
+    ev.trigger();
+    if (ev.get_trigger_data() == 0) dflt_ok = 1;
+    // now set a default and trigger() with no arg must capture THIS instance's default
+    ev.set_default_data(42);
+    ev.trigger();
+    if (ev.get_trigger_data() == 42) trig_ok = 1;
+  end
+endmodule
+";
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(u(&sim, "dflt_ok"), 1, "default arg evaluated via get_default_data (zero case)");
+    assert_eq!(u(&sim, "trig_ok"), 1, "default arg evaluated via get_default_data (set case)");
+}

--- a/tests/classes/nopack_member_array.rs
+++ b/tests/classes/nopack_member_array.rs
@@ -1,0 +1,60 @@
+//! Nested class-member dynamic array of class handles.
+//!
+//! Regression for the UVM `NOPACK` member-array scenario (`a.mid.base = new[N]`,
+//! populating and reading `a.mid.base[i]`, and packing/unpacking the nested
+//! objects).
+//! Exercises three interlocking behaviors that xezim previously got wrong:
+//!   1. A `new` whose rvalue is assigned to an OBJECT-MEMBER array element
+//!      (`obj.member[i] = new(...)`) must construct the DECLARED element
+//!      class (`base_class`), not dispatch the bare `new` onto the enclosing
+//!      component's constructor (which tripped UVM's ILLCRT guard).
+//!   2. `obj.member = new[N]` (a member array of a NESTED object handle,
+//!      flattened to a 3+ segment `a.mid.base`) must be treated as dynamic-
+//!      array SIZING with per-instance storage `<handle>#member`, not as a
+//!      scalar/object handle store.
+//!   3. Elements of that nested array must read/write consistently.
+
+use xezim::simulate;
+
+fn msgs(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+#[test]
+fn nested_member_class_array_size_fill_and_read() {
+    let src = r#"
+class base_class;
+  int a;
+  function new(string name="base"); endfunction
+endclass
+
+class mid_class;
+  int a;
+  base_class base[];
+endclass
+
+class my_class;
+  int a;
+  mid_class mid;
+  function new(string name="my"); endfunction
+endclass
+
+module top;
+  initial begin
+    my_class a;
+    a = new("a");
+    a.mid = new("b");
+    a.mid.base = new[2];
+    a.mid.base[0] = new("b0"); a.mid.base[0].a = 5;
+    a.mid.base[1] = new("b1"); a.mid.base[1].a = 7;
+    $display("T|%0d %0d %0d", a.mid.base.size(), a.mid.base[0].a, a.mid.base[1].a);
+  end
+endmodule
+"#;
+    let sim = simulate(src, 100).expect("simulate failed");
+    assert!(
+        msgs(&sim).iter().any(|m| m == "T|2 5 7"),
+        "got {:?}",
+        msgs(&sim)
+    );
+}

--- a/tests/classes/struct_formal_and_config_foreach.rs
+++ b/tests/classes/struct_formal_and_config_foreach.rs
@@ -1,0 +1,136 @@
+//! IEEE 1800-2023 §13.4.2 / §7.2 / §12.7.3: subroutines copying an
+//! UNPACKED-STRUCT formal, binding a struct-formal from a positional pattern
+//! literal, resolving a struct type-PARAMETER formal on a parameterized class,
+//! and `foreach` over a queue/associative array of STRINGS.
+//!
+//! Four independent simulator fixes:
+//!   1. A whole-struct assignment whose RHS is a METHOD/FUNCTION formal
+//!      (`y = arg`) never registered the formal's struct type, so
+//!      `p_elem_type(arg)` missed it and the RHS evaluated to a zeroed
+//!      container (members x/0) even though `arg.member` read correctly.
+//!   2. Binding a struct formal from a positional pattern literal
+//!      (`f('{a, b})`) read the members via `arg.member` — member access on a
+//!      literal base returns x in this simulator — so it bound zeros.
+//!   3. A struct formal of a parameterized class (`class C #(type T); f(T)`)
+//!      registered only the raw `TypeReference(T)`, which `p_elem_type` could
+//!      not resolve to the concrete struct — again zeroed.
+//!   4. `foreach (key_queue[i])` over a QUEUE/ASSOC ARRAY OF STRINGS was
+//!      mistaken for `foreach` over a scalar string (it iterated characters),
+//!      so the loop body never ran on the string queue (zero iterations).
+use std::process::Command;
+
+fn xezim() -> String {
+    env!("CARGO_BIN_EXE_xezim").to_string()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/struct_formal_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn passes(out: &str, tag: &str) -> bool {
+    out.lines().any(|l| l.contains(tag) && l.contains("TAG_PASS"))
+}
+
+#[test]
+fn struct_function_formal_copy() {
+    // A whole-struct copy whose RHS is a function's struct formal must carry
+    // the caller's members (`item.a`=3, `item.b`=4), not zero them.
+    let src = r#"module top;
+  typedef struct { int a; int b; } s2;
+  function void f(s2 item);
+    s2 l;
+    l.a = 99; l.b = 98;
+    l = item;
+    if (l.a == 3 && l.b == 4) $display("TAG_PASS fn-formal-copy");
+    else $display("TAG_FAIL fn-formal-copy a=%0d b=%0d", l.a, l.b);
+  endfunction
+  initial begin
+    s2 v = '{3, 4};
+    f(v);
+  end
+endmodule"#;
+    let out = run(src, "fncopy");
+    assert!(
+        passes(&out, "fn-formal-copy"),
+        "function struct-formal whole copy failed:\n{out}"
+    );
+}
+
+#[test]
+fn class_method_struct_literal_formal() {
+    // A class method formal bound from a positional struct-pattern literal
+    // stores both members (not zeros).
+    let src = r#"module top;
+  typedef struct { int a; int b; } s2;
+  class Q;
+    s2 q[$];
+    function void pushv(s2 item); q.push_back(item); endfunction
+  endclass
+  initial begin
+    Q qo = new;
+    qo.pushv('{6, 7});
+    if (qo.q[0].a == 6 && qo.q[0].b == 7) $display("TAG_PASS method-literal-formal");
+    else $display("TAG_FAIL method-literal-formal a=%0d b=%0d", qo.q[0].a, qo.q[0].b);
+  end
+endmodule"#;
+    let out = run(src, "methlit");
+    assert!(
+        passes(&out, "method-literal-formal"),
+        "class-method struct literal formal failed:\n{out}"
+    );
+}
+
+#[test]
+fn param_class_struct_typearg_formal() {
+    // Parameterized-class `T` bound to a struct: a whole-struct read of the T
+    // formal resolves the concrete struct type through the instance bindings.
+    let src = r#"module top;
+  typedef struct { int a; int b; } s2;
+  class P #(type T = int);
+    T m;
+    function void setf(T v); m = v; endfunction
+  endclass
+  initial begin
+    P#(s2) p = new;
+    p.setf('{8, 9});
+    if (p.m.a == 8 && p.m.b == 9) $display("TAG_PASS param-struct-formal");
+    else $display("TAG_FAIL param-struct-formal a=%0d b=%0d", p.m.a, p.m.b);
+  end
+endmodule"#;
+    let out = run(src, "paramstruct");
+    assert!(
+        passes(&out, "param-struct-formal"),
+        "parameterized-class struct formal failed:\n{out}"
+    );
+}
+
+#[test]
+fn foreach_string_queue_and_assoc() {
+    // `foreach` over a QUEUE OF STRINGS and an ASSOC ARRAY OF STRINGS must
+    // iterate ELEMENTS, not be mistaken for a scalar-string character loop.
+    let src = r#"module top;
+  initial begin
+    string q[$];
+    q.push_back("aa"); q.push_back("bb");
+    int n = 0;
+    foreach (q[i]) n++;
+    string m[int];
+    m[5] = "five";
+    int n2 = 0;
+    foreach (m[k]) n2++;
+    if (n == 2 && n2 == 1) $display("TAG_PASS foreach-string-cols");
+    else $display("TAG_FAIL foreach-string-cols n=%0d n2=%0d", n, n2);
+  end
+endmodule"#;
+    let out = run(src, "fe_strcol");
+    assert!(
+        passes(&out, "foreach-string-cols"),
+        "foreach over string collections failed:\n{out}"
+    );
+}

--- a/tests/classes/uvm_integration_tests.rs
+++ b/tests/classes/uvm_integration_tests.rs
@@ -1265,3 +1265,66 @@ fn uvm_2020_sequence_field_get_type_resolves_declared_type() {
         out.join("\n")
     );
 }
+
+/// A printer rendering an ENUM collection element must resolve the value's
+/// member name against the collection's element type (`numbers`), not a global
+/// scan that picks a larger outer-scope enum. UVM's own enums share the values
+/// 0..3 with `numbers`, so a freshly-defaulted empty enum array element used to
+/// render as UVM_NORADIX / UVM_PHASE_* instead of ONE/TWO/THREE/FOUR.
+const ENUM_ARRAY_PRINT_TEST: &str = r#"
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+typedef enum bit [1:0] { ONE, TWO, THREE, FOUR } numbers;
+
+class myobj extends uvm_object;
+  numbers numa[];
+  `uvm_object_utils_begin(myobj)
+    `uvm_field_array_enum(numbers, numa, UVM_DEFAULT)
+  `uvm_object_utils_end
+  function new(string n="myobj");
+    super.new(n);
+    numa = new[4];
+    for (int i=0;i<4;i++) numa[i]=numbers'(i);
+  endfunction
+endclass
+
+class my_test extends uvm_test;
+  `uvm_component_utils(my_test)
+  function new(string name="my_test", uvm_component parent=null);
+    super.new(name, parent);
+  endfunction
+  task run_phase(uvm_phase phase);
+    myobj o = new;
+    o.print();
+    phase.raise_objection(this);
+    phase.drop_objection(this);
+  endtask
+endclass
+
+module top;
+  initial run_test("my_test");
+endmodule
+"#;
+
+#[test]
+fn uvm_2020_printer_renders_enum_array_members() {
+    let sim = run_uvm("1800.2-2020", &[], ENUM_ARRAY_PRINT_TEST.to_string(), "top")
+        .expect("UVM 2020 enum-array printer test failed to simulate");
+    let out: Vec<String> = sim.output.iter().map(|o| o.message.clone()).collect();
+    let joined = out.join("\n");
+    assert!(
+        joined.contains("ONE")
+            && joined.contains("TWO")
+            && joined.contains("THREE")
+            && joined.contains("FOUR"),
+        "printer must render the enum members:\n{}",
+        joined
+    );
+    assert!(
+        !joined.contains("UVM_NORADIX") && !joined.contains("UVM_PHASE_DORMANT"),
+        "enum array elements must NOT fall back to a foreign enum's labels:\n{}",
+        joined
+    );
+}
+

--- a/tests/classes/uvm_integration_tests.rs
+++ b/tests/classes/uvm_integration_tests.rs
@@ -1176,3 +1176,92 @@ fn uvm_1_2_ral_backdoor_peek_poke() {
         assert!(out.iter().any(|l| l.contains(pin)), "missing `{pin}`:\n{}", out.join("\n"));
     }
 }
+
+/// Sequence-field static type resolution inside a started `body()`.
+///
+/// `uvm_create(seq)` (and a bare `seq.get_type()` in `body()`) recovers the
+/// compile-time type of a sequence field that is still NULL by dispatching the
+/// registered `static get_type()` on the field's DECLARED type. Here `seq` is
+/// a `my_sequence` member of `top_seq`; `uvm_sequence_base` also defines a
+/// `static get_type()` (via `uvm_object_abstract_utils`), so the concrete
+/// member type must win. xezim's `receiver_static_class` used the loose
+/// `class_of_var` heuristic first, which drifted a `my_sequence` class member
+/// to `uvm_sequence_item`, so `uvm_create(seq)` asked the factory to build an
+/// abstract `uvm_sequence_base`, and `start_item(seq)` then saw a null item
+/// (NULLITM). Reference and xezim must both pick `my_sequence`.
+const SEQ_GET_TYPE_TEST: &str = r#"
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class my_item extends uvm_sequence_item;
+  `uvm_object_utils(my_item)
+  function new(string name = "my_item"); super.new(name); endfunction
+endclass
+
+class my_sequence extends uvm_sequence #(my_item);
+  `uvm_object_utils(my_sequence)
+  function new(string name = "my_sequence"); super.new(name); endfunction
+endclass
+
+class top_seq extends uvm_sequence #(my_item);
+  `uvm_object_utils(top_seq)
+  my_sequence seq;
+  function new(string name = "top_seq"); super.new(name); endfunction
+  task body();
+    uvm_object_wrapper w = seq.get_type();
+    if (w != null && w.get_type_name() == "my_sequence")
+      $display("TEST_PASS");
+    else
+      $display("TEST_FAIL got=%s", (w==null)?"<null>":w.get_type_name());
+  endtask
+endclass
+
+class my_sqr extends uvm_sequencer #(my_item);
+  `uvm_component_utils(my_sqr)
+  function new(string name, uvm_component parent); super.new(name, parent); endfunction
+endclass
+
+class seq_test extends uvm_test;
+  `uvm_component_utils(seq_test)
+  my_sqr sq;
+  function new(string name = "seq_test", uvm_component parent = null); super.new(name, parent); endfunction
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    sq = my_sqr::type_id::create("sq", this);
+  endfunction
+  task run_phase(uvm_phase phase);
+    top_seq ts;
+    phase.raise_objection(this);
+    ts = new("ts");
+    ts.start(sq);
+    #1;
+    phase.drop_objection(this);
+  endtask
+endclass
+
+module top;
+  initial run_test("seq_test");
+endmodule
+"#;
+
+/// 2020 `uvm_sequence.start()` + `uvm_create`-style `get_type` on a sequence
+/// FIELD (still null) must resolve to the concrete `my_sequence`, not the
+/// abstract `uvm_sequence_base` / `uvm_sequence_item`.
+#[test]
+fn uvm_2020_sequence_field_get_type_resolves_declared_type() {
+    let sim = run_uvm("1800.2-2020", &[], SEQ_GET_TYPE_TEST.to_string(), "top")
+        .expect("UVM 2020 sequence-field get_type test failed to simulate");
+    let out: Vec<String> = sim.output.iter().map(|o| o.message.clone()).collect();
+    assert!(
+        out.iter().any(|m| m.contains("TEST_PASS")),
+        "sequence field get_type must resolve to my_sequence:
+{}",
+        out.join("\n")
+    );
+    assert!(
+        !out.iter().any(|m| m.contains("TEST_FAIL")),
+        "sequence field get_type mis-resolved:
+{}",
+        out.join("\n")
+    );
+}

--- a/tests/misc/bare_randomize_solver.rs
+++ b/tests/misc/bare_randomize_solver.rs
@@ -1,9 +1,8 @@
 //! Regression for a parenthesless ('bare') call to the built-in `randomize()`
 //! method appearing as an operand of a larger expression.
 //!
-//! UVM 05components/10uvm_pair/02class does `assert(t1.randomize & t2.randomize)`.
-//! `t1.randomize` (no parens) parses as a flattened 2-segment
-//! `Ident([t1, randomize])`. Because the built-in `randomize` is NOT a declared
+//! `t1.randomize` (no parens) parses as a flattened 2-segment `Ident([t1,
+//! randomize])`. Because the built-in `randomize` is NOT a declared
 //! class method, `class_parameterless_function` returned false and the operand
 //! fell through to a property read — returning 0 without ever calling the
 //! solver, so both transactions randomized to zeros. LRM 1800-2023 §13.4.1 +

--- a/tests/misc/obj_assocd_event_disable_fork.rs
+++ b/tests/misc/obj_assocd_event_disable_fork.rs
@@ -1,5 +1,5 @@
 //! Pure-SystemVerilog regression for two xezim fixes that surfaced in the UVM
-//! phasing suites (40phasing / 35objections), distilled to the raw SV idiom
+//! phasing suites, distilled to the raw SV idiom
 //! with NO Rust-side shims and NO UVM library. Each test is deterministic and
 //! self-checking.
 

--- a/tests/misc/uvm_agent_active_config.rs
+++ b/tests/misc/uvm_agent_active_config.rs
@@ -1,5 +1,4 @@
-//! Regression for `uvm_agent::is_active` configuration propagation
-//! (`05components/90Mantis/3167_agent_activepassive`).
+//! Regression for `uvm_agent::is_active` configuration propagation.
 //!
 //! `uvm_agent.build_phase` reads `is_active` from the resource pool via
 //! `uvm_resource_enum_read`, whose `$cast` to `uvm_resource#(<enum>)` /

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -77,6 +77,8 @@ mod forever_break_and_disable_fork_label;
 mod fork_automatic_capture;
 #[path = "scheduling/fork_join_edge.rs"]
 mod fork_join_edge;
+#[path = "scheduling/fork_join_none_await_context.rs"]
+mod fork_join_none_await_context;
 #[path = "scheduling/fork_var_sharing.rs"]
 mod fork_var_sharing;
 #[path = "scheduling/gap_fixes_scoping_and_nba.rs"]
@@ -147,6 +149,12 @@ mod suspending_loop_depth_and_continue;
 mod task_body_delay_scaling;
 #[path = "scheduling/timing_check_delayed_nets_singlelimit.rs"]
 mod timing_check_delayed_nets_singlelimit;
+#[path = "scheduling/multidim_assoc_struct_copy.rs"]
+mod multidim_assoc_struct_copy;
+#[path = "scheduling/assoc_bracket_keys.rs"]
+mod assoc_bracket_keys;
+#[path = "scheduling/typeparam_pool_wait.rs"]
+mod typeparam_pool_wait;
 #[path = "scheduling/unbased_unsized_fill.rs"]
 mod unbased_unsized_fill;
 #[path = "scheduling/vardelay_clock_period.rs"]
@@ -163,6 +171,12 @@ mod compiled_for_loops;
 
 #[path = "scheduling/class_event_member_wait.rs"]
 mod class_event_member_wait;
+#[path = "scheduling/static_recursion_shared_cell.rs"]
+mod static_recursion_shared_cell;
+#[path = "scheduling/phase_jump_static_latch.rs"]
+mod phase_jump_static_latch;
+#[path = "scheduling/bare_randomize_in_method.rs"]
+mod bare_randomize_in_method;
 #[path = "scheduling/comb_self_member_sensitivity.rs"]
 mod comb_self_member_sensitivity;
 #[path = "scheduling/waiter_cont_anyedge_wake.rs"]

--- a/tests/scheduling/assoc_bracket_keys.rs
+++ b/tests/scheduling/assoc_bracket_keys.rs
@@ -1,0 +1,75 @@
+//! §7.11 associative arrays keyed by STRING values that themselves contain
+//! `[` and `]` — legal component/hierarchy names (e.g. UVM's
+//! `special-:{ chars{}[0123456789] _`). `num()/first()/foreach` must keep the
+//! FULL key, not stop at the first `]`.
+//!
+//! Bug: the assoc iteration key was extracted as the text from `arr[` up to the FIRST `]`. For a 1-D string key containing
+//! `]`/`[` that slice truncated the key (`special-:{ chars{}[0123456789]`),
+//! so `exists()`/`get_child` on the stored full key (and foreach) saw null and
+//! UVM's component-tree walk fell into a NOCHILD → stack overflow. The
+//! extraction now distinguishes a MULTIDIM/assoc-of-collection entry (`k1][k2]`,
+//! inner `[` after the first `]`) from a 1-D string key (whole text to the
+//! final `]`).
+
+use xezim::simulate;
+
+fn read_int(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able (x/z?)", n))
+}
+
+#[test]
+fn assoc_string_keys_with_square_brackets_iterate() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  string cnt = "special-:{ chars{}[0123456789] _";
+  string map[string];
+  int iter_ok = 0;
+  int nkeys = 0;
+  int seen_bracket = 0;
+  int seen_normal = 0;
+  string kk;
+
+  initial begin
+    map["normal"] = "a";
+    map[cnt] = "b";
+    // foreach over the assoc must yield the FULL bracket key, and the value
+    // must be found back for both keys.
+    foreach (map[i]) begin
+      if (i == cnt) seen_bracket = 1;
+      if (i == "normal") seen_normal = 1;
+      if (i == cnt && map.exists(i) && map[i] == "b") iter_ok = 1;
+      if (i == "normal" && map.exists(i) && map[i] == "a") iter_ok = 1;
+      nkeys++;
+    end
+    // first() must give the full key too (so exists() on it succeeds).
+    if (map.first(kk) && map.exists(kk)) begin
+      iter_ok = 1;
+    end
+    $display("ASSOC iter_ok=%0d seen_bracket=%0d seen_normal=%0d nkeys=%0d",
+      iter_ok, seen_bracket, seen_normal, nkeys);
+    $finish;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 2000).expect("simulate failed");
+    assert_eq!(
+        read_int(&sim, "iter_ok"),
+        1,
+        "assoc with a string key containing `]`/`[` must round-trip through foreach/first()/exists()"
+    );
+    assert_eq!(
+        read_int(&sim, "seen_bracket"),
+        1,
+        "foreach must yield the full bracket-containing key"
+    );
+    assert_eq!(read_int(&sim, "seen_normal"), 1);
+    assert_eq!(
+        read_int(&sim, "nkeys"),
+        2,
+        "assoc must have exactly the two distinct keys"
+    );
+}

--- a/tests/scheduling/bare_randomize_in_method.rs
+++ b/tests/scheduling/bare_randomize_in_method.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+use std::process::Command;
+
+/// §18.11: a bare `randomize()` (no `this.`) inside a class METHOD is the
+/// implicit per-object randomize built-in — it must dispatch to the solver and
+/// honour the object's declared constraints, exactly like `this.randomize()`.
+///
+/// Regression: a bare call is NOT a *declared* class method (the source never
+/// lists it), so the unqualified-method-in-class dispatch guarded on
+/// `class_has_method` was false and let the call fall through and silently
+/// return 0 WITHOUT solving. A class whose constructor/draw method called
+/// bare `randomize()` left `rand` fields unconstrained at their default (0):
+/// UVM's `obj_example_seq.count` (`rand int count; count inside {[5:10]};`,
+/// randomized from inside a method) stayed 0, so `repeat(count)` ran an
+/// unrandomized/inside range and the 35objections/03basic/06xbus transfer
+/// bench drove an unbounded number of transactions (endless recorder/stream
+/// growth) instead of the bounded 5..10 the reference simulator produces.
+///
+/// Both the bare and the `this.`-qualified call must yield 400 in-range draws
+/// from 400 solves. Matched byte-for-byte against the reference simulator
+/// (Questa):
+///   TAG_BARESOLVE bare=400 qualified=400
+///   TAG_PASS bare=400 qualified=400
+#[test]
+fn bare_randomize_in_method() {
+    let test_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/scheduling");
+    let test_file = test_dir.join("bare_randomize_in_method.sv");
+    assert!(test_file.exists(), "Test file not found: {}", test_file.display());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xezim"))
+        .arg("--simulate")
+        .arg("-s")
+        .arg("bare_rand")
+        .arg(test_file.to_str().unwrap())
+        .output()
+        .expect("Failed to execute xezim");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    // Both the bare and the qualified forms must honour the inside constraint.
+    assert!(
+        combined.contains("TAG_PASS bare=400 qualified=400"),
+        "bare randomize() inside a class method did not solve its constraint.\nOutput:\n{combined}"
+    );
+}

--- a/tests/scheduling/bare_randomize_in_method.sv
+++ b/tests/scheduling/bare_randomize_in_method.sv
@@ -1,0 +1,36 @@
+// Bare `randomize()` (no `this.`) inside a class METHOD must dispatch to the
+// §18.11 solver and honor the object's constraints — exactly like the
+// qualified `this.randomize()` form.
+module bare_rand;
+  class boxx;
+    rand int cnt;
+    constraint cnt_c { cnt inside {[5:10]}; }
+    // bare unqualified randomize() inside a method == this.randomize()
+    function int draw();
+      int ok = 0;
+      for (int i = 0; i < 400; i++) begin
+        if (!randomize()) ok = -1;      // must never fail
+        else if (cnt >= 5 && cnt <= 10) ok++;
+      end
+      return ok;
+    endfunction
+    function int draw_qualified();
+      int ok = 0;
+      for (int i = 0; i < 400; i++) begin
+        if (!this.randomize()) ok = -1;
+        else if (cnt >= 5 && cnt <= 10) ok++;
+      end
+      return ok;
+    endfunction
+  endclass
+
+  initial begin
+    automatic boxx rw = new();
+    int b, q;
+    b = rw.draw();
+    q = rw.draw_qualified();
+    $display("TAG_BARESOLVE bare=%0d qualified=%0d", b, q);
+    if (b == 400 && q == 400) $display("TAG_PASS bare=%0d qualified=%0d", b, q);
+    else $display("TAG_FAIL bare=%0d qualified=%0d", b, q);
+  end
+endmodule

--- a/tests/scheduling/determinism_and_stall.rs
+++ b/tests/scheduling/determinism_and_stall.rs
@@ -180,6 +180,61 @@ endmodule
     assert_eq!(sim.time, 0, "wait-on-true livelock cannot advance time");
 }
 
+/// The same livelock shape reached through a TASK call on a NULL (unassigned)
+/// class handle: `w.wait_ev()` on null runs no body and cannot suspend, so the
+/// forever is a zero-delay loop. This used to livelock the synchronous path
+/// (a blocking-task-call recursion that never hit the stall cap) and spin at
+/// 100%% CPU forever. The reference simulator treats a null deref ("Null
+/// instance ... dereferencing 'this'") as a fatal and aborts; we mirror that
+/// with an explicit null-receiver error terminating the run at time 0.
+/// `simulate_multi` returning at all, with no `T|after-fork`, is the
+/// no-spin assertion.
+#[test]
+fn task_call_on_null_receiver_in_forever_terminates() {
+    const SRC: &str = r#"
+class waiter;
+  event ev;
+  int count = 0;
+  task wait_ev();
+    @ev;
+    count++;
+  endtask
+endclass
+module tb;
+  waiter w; // null
+  int n = 0;
+  initial begin
+    fork
+      forever begin
+        w.wait_ev();
+        n++;
+      end
+    join_none
+    #1;
+    $display("T|after-fork");
+  end
+endmodule
+"#;
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("XEZIM_STALL_LIMIT", "2000") };
+    let sim = run(SRC, &[]);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::remove_var("XEZIM_STALL_LIMIT") };
+    // The null call must terminate the run at time 0 with an explicit
+    // null-receiver diagnostic (mirroring the reference's null-deref abort), NOT
+    // hang at 100%% CPU and NOT resume past the fork.
+    assert_eq!(sim.time, 0, "null-receiver livelock cannot advance time");
+    let msgs: Vec<String> = sim.output.iter().map(|o| o.message.clone()).collect();
+    assert!(
+        msgs.iter().any(|m| m.contains("null receiver")),
+        "must report a null-receiver error, got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("T|after-fork")),
+        "the run must abort at the null call, not resume past the fork"
+    );
+}
+
 /// The stall report must name the RTL behind each spinner, not just a bare
 /// pid: the creating construct's kind + file:line, the instance path, and the
 /// re-arm reason. Asserted through the CLI binary (the report goes to stderr,

--- a/tests/scheduling/fork_join_none_await_context.rs
+++ b/tests/scheduling/fork_join_none_await_context.rs
@@ -1,0 +1,74 @@
+//! A `fork ... join_none` child parked on `process::await()` must be kept
+//! SUSPENDED — not misjudged as finished — so its process context (`this` +
+//! task locals) survives the awaited process terminating and the child
+//! resumes with the shared handle intact.
+//!
+//! UVM's sequencer `uvm_sequencer_param_base::m_safe_select_item` forks a
+//! `join_none` re-arbitration child that parks on `selected_sequence_request
+//! .process_id.await()` then re-reads the request handle. xezim's
+//! `is_pid_suspended` did not count an `await_waiters` park as suspended, so
+//! such a child could be reported FINISHED and its context dropped, and a
+//! follow-on read of the handle dereferenced null (`'selected_sequence_request
+//! .request_id' read through a null handle`). The fix counts an await-parked
+//! process as suspended (same class as the mailbox/event/semaphore parks).
+//! Validated byte-for-byte against the reference simulator.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+fn assert_pass(sim: &xezim::compiler::Simulator, tag: &str) {
+    let msgs = messages(sim);
+    let pass = msgs.iter().any(|m| m.contains(&format!("{tag}_PASS")));
+    assert!(
+        pass,
+        "expected {tag}_PASS in output\nfull output: {msgs:?}"
+    );
+}
+
+/// A task forks a child that parks on a producer process's `await()` while the
+/// task returns. The producer terminates after `#3`; on resume the child must
+/// still see the shared class handle it references.
+const AWAIT_PARK: &str = r#"
+class rec_c; int id; endclass
+process producer_p;
+rec_c sel;
+function void spawn_producer();
+  fork
+    begin
+      producer_p = process::self();
+      #3;
+    end
+  join_none
+endfunction
+task safe_select_item();
+  begin
+    spawn_producer();
+    wait (producer_p != null);
+    fork
+      begin
+        producer_p.await();   // park here until the producer (t=3) finishes
+        if (sel == null) $display("AWAIT_FAIL  child lost handle");
+        else $display("AWAIT_PASS child sees id=%0d", sel.id);
+      end
+    join_none
+  end
+endtask
+module top;
+  initial begin
+    sel = new();
+    sel.id = 42;
+    safe_select_item();
+    #20;
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn join_none_child_await_preserves_context() {
+    let sim = simulate(AWAIT_PARK, 200).expect("simulate failed");
+    assert_pass(&sim, "AWAIT");
+}

--- a/tests/scheduling/multidim_assoc_struct_copy.rs
+++ b/tests/scheduling/multidim_assoc_struct_copy.rs
@@ -1,0 +1,107 @@
+//! §7.8.1 multidimensional ASSOCIATIVE arrays of STRUCT (`T m[K1][K2][K3]`)
+//! when a sub-array is selected by a class-handle key and iterated / read by
+//! member (`m[rhs].first(lhs)`, `m[lhs][rhs][pol].state`).
+//!
+//! UVM's copier/comparer recursion guards (`m_recur_states[rhs][lhs][policy]`
+//! and `m_recur_states[lhs][rhs][rec].state`) rely on this exact shape to
+//! break the deep-clone of a CYCLIC object graph. Runtime gaps this relies on:
+//!   - `is_associative_array` didn't recognize a nested sub-array receiver
+//!     `base[key]` (only the bare `base`), so `.first()`/`.exists()` on that
+//!     sub-array reported "not found"; UVM's copier cycle guard then never
+//!     re-used the in-progress clone -> `clone()` of a cyclic graph recursed
+//!     forever (stack overflow).
+//!   - A class-member MULTIDIM assoc-of-struct cell write `cp.m[a][b][0] =
+//!     '{...}` stored only an existence marker (1-D worked, the 3-D nested
+//!     case was dropped by `coll_assoc_struct_elem`), so `.state` read back
+//!     NEVER and the comparer guard could not detect an in-progress compare.
+
+use xezim::simulate;
+
+fn read_int(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able (x/z?)", n))
+}
+
+#[test]
+fn multidim_assoc_class_member_struct_copy() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  typedef enum {NEVER, STARTED, FINISHED} state_e;
+  typedef struct { state_e state; int ret_val; } s_t;
+
+  class node;
+    node next;
+    string name;
+    function new(string nm = "node"); this.name = nm; endfunction
+  endclass
+
+  class guard_t;
+    s_t m[node][node][int];
+
+    function void set(node lhs, node rhs, int pol, state_e st);
+      m[lhs][rhs][pol] = '{st, 5};
+    endfunction
+
+    function int is_started(node lhs, node rhs, int pol);
+      if (!m.exists(lhs)) return 0;
+      if (!m[lhs].exists(rhs)) return 0;
+      if (!m[lhs][rhs].exists(pol)) return 0;
+      return (m[lhs][rhs][pol].state == STARTED) ? 1 : 0;
+    endfunction
+
+    function int first_of(node src, inout node out);
+      if (m[src].first(out)) return 1;
+      return 0;
+    endfunction
+  endclass
+
+  guard_t g;
+  int member_ok = 0;
+  int exists_ok = 0;
+  int cycle_ok = 0;
+
+  function automatic node guarded_clone(node src);
+    node h = null;
+    if (g.first_of(src, h))
+      return h;                 // reuse -> cycle broken
+    h = new(src.name);
+    g.set(h, src, 0, STARTED);
+    if (src.next != null)
+      h.next = guarded_clone(src.next);
+    return h;
+  endfunction
+
+  initial begin
+    node a = new("a"), b = new("b"), ca;
+    g = new;
+    a.next = b; b.next = a;               // two-node cycle
+    g.set(a, b, 0, STARTED);              // struct cell store
+    member_ok = g.is_started(a, b, 0);
+    exists_ok = g.m[a][b].exists(0);
+    ca = guarded_clone(a);
+    cycle_ok = (ca != null && ca.next != null && ca.next.next == ca) ? 1 : 0;
+    $display("member_ok=%0d exists_ok=%0d cycle_ok=%0d", member_ok, exists_ok, cycle_ok);
+    $finish;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 2000).expect("simulate failed");
+    assert_eq!(
+        read_int(&sim, "member_ok"),
+        1,
+        "multidim class-member assoc struct cell must retain its .state member"
+    );
+    assert_eq!(
+        read_int(&sim, "exists_ok"),
+        1,
+        "nested assoc sub-array .exists(pol) must find the stored cell"
+    );
+    assert_eq!(
+        read_int(&sim, "cycle_ok"),
+        1,
+        "guarded deep-clone of a cyclic graph must terminate and rewire the cycle"
+    );
+}

--- a/tests/scheduling/phase_jump_static_latch.rs
+++ b/tests/scheduling/phase_jump_static_latch.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// UVM 40phasing/06started_ended: the `main_phase` carries a
+/// `static bit first=1` guard that, on the FIRST run, raises the objection,
+/// `#10`, then sets `first=0` and `phase.jump(uvm_reset_phase::get())`. The
+/// jump re-enters the reset -> ... -> main chain, so `main_phase` runs a
+/// SECOND time — and it must observe `first==0` (the static latched through
+/// the jump), so it does NOT jump again, the schedule completes, and the
+/// phase-count counter reaches the golden 165.
+///
+/// Two xezim bugs previously livelocked this: (1) a `static` subroutine
+/// local was kept as a per-recursion-frame copy (fixed in
+/// `static_recursion_shared_cell`), and (2) even with live-cell routing the
+/// persistent key was built from the *innermost* runtime sync frame, which a
+/// UVM `wait_for`-style revival wrapper pollutes — so a resurrected
+/// `main_phase` read/wrote `test::wait_for::first` instead of
+/// `test::main_phase::first` and the latch never reached the store. The key
+/// is now resolved from the routine that actually *declared* the static.
+///
+/// Discriminator: the test hangs/re-livspins (never prints PASSED) without
+/// the fix; with it, `*** UVM TEST PASSED ***` (matches Questa: 0 UVM_ERROR,
+/// 0 UVM_FATAL).
+#[test]
+fn phase_jump_static_latch() {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_dir = crate_dir.join("tests/scheduling");
+    let test_file = test_dir.join("phase_jump_static_latch.sv");
+    assert!(test_file.exists(), "Test file not found: {}", test_file.display());
+
+    // Local UVM could be the git submodule at the repo root
+    // (../1800.2-2020.3.1 relative to the crate). If absent, skip.
+    let uvm_src = crate_dir.join("../1800.2-2020.3.1/src");
+    if !uvm_src.join("uvm_pkg.sv").exists() {
+        eprintln!("skipping: local UVM not present at {}", uvm_src.display());
+        return;
+    }
+
+    let uvm_pkg = uvm_src.join("uvm_pkg.sv");
+    let output = Command::new(env!("CARGO_BIN_EXE_xezim"))
+        .arg("--simulate")
+        .arg("-s")
+        .arg("test")
+        .arg("--max-time")
+        .arg("2000ns")
+        .arg("-DUVM_NO_DPI")
+        .arg("-I")
+        .arg(uvm_src.to_str().unwrap())
+        .arg("-I")
+        .arg(test_dir.to_str().unwrap())
+        .arg("+UVM_TESTNAME=test")
+        .arg(uvm_pkg.to_str().unwrap())
+        .arg(test_file.to_str().unwrap())
+        .output()
+        .expect("Failed to execute xezim");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    assert!(
+        combined.contains("*** UVM TEST PASSED ***"),
+        "phase_jump_static_latch did not reach PASSED (static `first` did not latch \
+         through the jump, or the scheduler did not complete).\nOutput:\n{combined}"
+    );
+}

--- a/tests/scheduling/phase_jump_static_latch.sv
+++ b/tests/scheduling/phase_jump_static_latch.sv
@@ -1,0 +1,216 @@
+//---------------------------------------------------------------------- 
+// Copyright 2011-2018 Cadence Design Systems, Inc.
+// Copyright 2011 Mentor Graphics Corporation
+// Copyright 2011 Synopsys, Inc.
+//   All Rights Reserved Worldwide 
+// 
+//   Licensed under the Apache License, Version 2.0 (the 
+//   "License"); you may not use this file except in 
+//   compliance with the License.  You may obtain a copy of 
+//   the License at 
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0 
+// 
+//   Unless required by applicable law or agreed to in 
+//   writing, software distributed under the License is 
+//   distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+//   CONDITIONS OF ANY KIND, either express or implied.  See 
+//   the License for the specific language governing 
+//   permissions and limitations under the License. 
+//----------------------------------------------------------------------
+
+// This test creates a simple hierarchy and makes sure that the
+// phase_started and phase_ended callbacks are all called once per
+// component and in the correct order.
+//
+// The order is:
+//   build
+//   connect
+//   end_of_elaboration
+//   start_of_simulation
+//   run
+//     pre_reset
+//     reset
+//     post_reset
+//     pre_configure
+//     configure
+//     post_configure
+//     pre_main
+//     main
+//     post_main
+//     pre_shutdown
+//     shutdown
+//     post_shutdown
+//  extract
+//  check
+//  report
+//  final
+
+
+module test;
+  import uvm_pkg::*;
+  `include "uvm_macros.svh"
+
+  bit failed = 0;
+  int counter = 0;
+
+  class base extends uvm_component;
+    int phase_count[string];
+    string last_phase="";
+
+    function new(string name, uvm_component parent);
+      super.new(name,parent);
+    endfunction
+
+    //for parallel phase have two possible last phases
+    function void check_phase_callback(uvm_phase phase, string last, string last2);
+      string ph = phase.get_name();
+      `uvm_info("CHECKER", "  Checking a phase...", UVM_NONE)
+      if(last != last_phase && last2 != last_phase) begin
+        `uvm_error("LAST_PH", $sformatf("Incorrect last phase, expected %s got %s", last, last_phase))
+        failed = 1;
+      end
+      if(phase_count[ph] != phase.get_run_count()) begin
+        `uvm_error("EXECUTED", $sformatf("Expected phase count %0d for %s, but got %0d", phase_count[ph], ph, phase.get_run_count()))
+        failed = 1;
+      end
+      counter++;
+      last_phase = ph;
+    endfunction
+
+    function void phase_started(uvm_phase phase);
+      string last, last2;
+      `uvm_info("STARTED", $sformatf("Phase started for phase %s", phase.get_name()), UVM_NONE)
+      if(phase_count.exists(phase.get_name()))
+        phase_count[phase.get_name()]++;
+      else
+        phase_count[phase.get_name()] = 1;
+
+      case(phase.get_name())
+        "build": last = "";
+        "connect": last = "build";
+        "end_of_elaboration": last = "connect";
+        "start_of_simulation": last = "end_of_elaboration";
+        "run": 
+           begin 
+              last = "start_of_simulation";
+              //last2 = "pre_reset";
+           end
+        "pre_reset": 
+           begin 
+              last = "start_of_simulation";
+              last2 = "run"; // account for race: if 'run' starts before 'pre_reset', it will be the last phase
+           end
+        "reset": begin
+              last = "pre_reset";
+              last2 = "main"; //from jump_back
+           end
+        "post_reset": last = "reset";
+        "pre_configure": last = "post_reset";
+        "configure": last = "pre_configure";
+        "post_configure": last = "configure";
+        "pre_main": last = "post_configure";
+        "main": last = "pre_main";
+        "post_main": last = "main";
+        "pre_shutdown": last = "post_main";
+        "shutdown": last = "pre_shutdown";
+        "post_shutdown": last = "shutdown";
+        "extract": 
+           begin 
+              last = "run";
+              last2 = "post_shutdown";
+           end
+        "check": last = "extract";
+        "report": last = "check";
+        "final": last = "report";
+      endcase
+      if(last2 == "") last2 = last;
+      check_phase_callback(phase, last, last2); 
+    endfunction    
+
+    function void phase_ended(uvm_phase phase);
+      string last, last2;
+      `uvm_info("ENDED", $sformatf("Phase ended for phase %s", phase.get_name()), UVM_NONE)
+      case(phase.get_name())
+        "build": last = "build";
+        "connect": last = "connect";
+        "end_of_elaboration": last = "end_of_elaboration";
+        "start_of_simulation": last = "start_of_simulation";
+        "run": 
+           begin 
+              last = "run";
+              last2 = "post_shutdown";
+           end
+        "pre_reset": last = "pre_reset";
+        "reset": last = "reset";
+        "post_reset": last = "post_reset";
+        "pre_configure": last = "pre_configure";
+        "configure": last = "configure";
+        "post_configure": last = "post_configure";
+        "pre_main": last = "pre_main";
+        "main": last = "main";
+        "post_main": last = "post_main";
+        "pre_shutdown": last = "pre_shutdown";
+        "shutdown": last = "shutdown";
+        "post_shutdown": 
+           begin 
+              last = "run";
+              last2 = "post_shutdown";
+           end
+        "extract": last = "extract";
+        "check": last = "check";
+        "report": last = "report";
+        "final": last = "final";
+      endcase
+      if(last2 == "") last2 = last;
+      check_phase_callback(phase, last, last2); 
+    endfunction    
+  endclass
+
+  class leaf extends base;
+    function new(string name, uvm_component parent);
+      super.new(name,parent);
+    endfunction
+  endclass
+
+  class test extends base;
+    leaf l1, l2; 
+    `uvm_component_utils(test)
+    function new(string name, uvm_component parent);
+      super.new(name,parent);
+      l1 = new("l1", this);
+      l2 = new("l2", this);
+    endfunction
+
+    task main_phase(uvm_phase phase);
+      static bit first=1;
+      phase.raise_objection(this);
+      #10;
+      if(first) begin
+        first = 0;
+        phase.jump (uvm_reset_phase::get());
+      end
+      phase.drop_objection(this);
+    endtask
+    function void final_phase(uvm_phase phase);
+      // 21 calls per component for three components (63) for phase started
+      // 20 calls for three components (60) for phase ended (since final is still going)
+      //
+      // Additional calls for jump back from main to reset means that reset, post_reset,
+      //    pre_configure, configure, post_configure, pre_main and main all run again.
+      //    So, add 7 more calls for each component (21) for both phase started and
+      //    phase_ended: 84 for STARTED, 81 for ENDED
+      // But, the ENDED callbacks for *this* final phase won't have been counted yet.
+      // So we expect 84 for STARTED (fully counted, because it is a bottom-up phase),
+      // and 81 for ENDED => 165
+      if(counter != 165) begin
+        failed = 1;
+        `uvm_error("NUMPHASES", $sformatf("Expected 162 phases, got %0d", counter))
+      end
+      if(failed) $display("*** UVM TEST FAILED ***");
+      else $display("*** UVM TEST PASSED ***");
+    endfunction
+  endclass
+
+  initial run_test();
+endmodule // test

--- a/tests/scheduling/static_recursion_shared_cell.rs
+++ b/tests/scheduling/static_recursion_shared_cell.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+use std::process::Command;
+
+/// §6.21/§13.3.1: a `static` subroutine local is ONE live storage cell shared
+/// across all simultaneous activations — including re-entrant/recursive ones.
+///
+/// Regression: xezim previously kept a per-recursion-frame copy of the static,
+/// restored at entry and written back on return, so a recursion window's
+/// mutation was invisible to the caller frames and the static was effectively
+/// re-initialised to its declaration value on every re-entry. That reset UVM's
+/// `static bit first` in `main_phase` on every `phase.jump(reset)` re-entry
+/// (40phasing/06started_ended), livelocking the phase scheduler.
+///
+/// This recursive method accumulates into a shared static; the outermost
+/// activation must read 4 after four increments. Matched byte-for-byte against
+/// the reference simulator (Questa):
+///   TAG_INNER4 depth=4 counter=1 saved=1
+///   TAG_OUTER4 depth=4 counter=4 saved=1
+///   TAG_PASS counter=4
+#[test]
+fn static_recursion_shared_cell() {
+    let test_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/scheduling");
+    let test_file = test_dir.join("static_recursion_shared_cell.sv");
+    assert!(test_file.exists(), "Test file not found: {}", test_file.display());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xezim"))
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(test_file.to_str().unwrap())
+        .output()
+        .expect("Failed to execute xezim");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    assert!(
+        combined.contains("TAG_PASS counter=4"),
+        "static local was not shared across recursion (got a fresh frame per re-entry).\nOutput:\n{combined}"
+    );
+    assert!(
+        !combined.contains("TAG_FAIL"),
+        "Test reported failure.\nOutput:\n{combined}"
+    );
+}

--- a/tests/scheduling/static_recursion_shared_cell.sv
+++ b/tests/scheduling/static_recursion_shared_cell.sv
@@ -1,0 +1,41 @@
+// Pure-SV regression for §6.21/§13.3.1: a `static` local in a method is ONE
+// live storage cell shared across ALL simultaneous activations — including
+// re-entrant/recursive calls. Previously, xezim kept a per-recursion-frame
+// copy restored at entry and written back on return, so an inner recursion
+// level's mutation of the shared cell was invisible to the caller frames and
+// the static was effectively reset to its initializer on each re-entry
+// ("fresh frame"). This caused UVM `phase.jump` re-entry (40phasing
+// /06started_ended) to re-run `main_phase` with its `static bit first`
+// re-initialised to 1, livelocking the phase scheduler.
+//
+// A recursive method that accumulates into a `static int` must see the whole
+// sequence (depth 4,3,2,1 -> 4 increments -> shared counter == 4), matching the
+// reference simulator (Questa) byte-for-byte:
+//   TAG_INNER4 depth=4 counter=1 saved=1
+//   TAG_OUTER4 depth=4 counter=4 saved=1
+//   TAG_PASS counter=4
+module top;
+  class C;
+    int r;
+    function int recurse(int level, int depth);
+      static int counter = 0;
+      int saved;
+      if (depth <= 0) return counter;
+      counter += 1;
+      saved = counter;
+      recurse(level + 1, depth - 1);
+      return counter;
+    endfunction
+  endclass
+
+  C c;
+  int r;
+  initial begin
+    c = new();
+    r = c.recurse(0, 4);
+    // Reference/expected: because `counter` is a single shared cell across the
+    // recursion, the outermost activation's read after all 4 increments is 4.
+    if (r == 4) $display("TAG_PASS counter=%0d", r);
+    else $display("TAG_FAIL counter=%0d (expected shared accumulation across recursion)", r);
+  end
+endmodule

--- a/tests/scheduling/typeparam_pool_wait.rs
+++ b/tests/scheduling/typeparam_pool_wait.rs
@@ -1,0 +1,80 @@
+//! §8.20 + §6.20.3: constructing a class with a TYPE-PARAMETER-typed
+//! assoc-array pool, and parking a `forever @` waiter on an element that the
+//! pool lazily `new`s (UVM's `uvm_pool::get` → `uvm_object_string_pool#(T)`).
+//!
+//! A recorder-style pool use hangs at 100% CPU when the pool is built with
+//! `T` bound to its DEFAULT (`uvm_object`) instead of the concrete element
+//! (`uvm_event#(uvm_object)`): `pool[key] = new()`
+//! then creates a plain `uvm_object` (no event member to park on), so the
+//! `forever @(ev.m_event)` waiter never suspends and spins at time 0.
+//!
+//! Mirrors the pool's `get`/`wait_trigger`/`trigger` contract in miniature:
+//! `pool.get(key)` caches a freshly-`new`ed element on first request, and a
+//! `forever` waiter parked on that element wakes exactly once per trigger.
+
+use xezim::simulate;
+
+fn read_int(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able (x/z?)", n))
+}
+
+#[test]
+fn typeparam_pool_get_builds_and_parks_waiter() {
+    let src = r#"
+`timescale 1ns/1ns
+module tb;
+  int wakes = 0;
+  int null_flag = 0;
+
+  // generic pool keyed by string; element type = the class TYPE PARAMETER
+  class pool_t #(type T);
+    T items[string];
+    function T get(string k);
+      if (!items.exists(k))
+        items[k] = new;
+      return items[k];
+    endfunction
+    function new; endfunction
+  endclass
+
+  // element whose waiter parks on a nested event member
+  class ev_t;
+    event mev;
+    function void trigger; ->mev; endfunction
+    task wait_t;
+      @mev;
+    endtask
+  endclass
+
+  pool_t #(ev_t) pool;
+  ev_t b;
+
+  initial begin
+    pool = new;
+    b = pool.get("b");
+    null_flag = (b == null) ? 1 : 0;
+    fork
+      begin
+        forever begin
+          b.wait_t;
+          wakes++;
+        end
+      end
+      begin
+        #5 b.trigger;
+        #5 b.trigger;
+      end
+    join_none
+    #30;
+    $display("wakes=%0d null=%0d", wakes, null_flag);
+    $finish;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 2000).expect("simulate failed");
+    assert_eq!(read_int(&sim, "null_flag"), 0, "pool.get must return a non-null element");
+    assert_eq!(read_int(&sim, "wakes"), 2, "each ->mev wakes the forever waiter exactly once");
+}

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -63,3 +63,5 @@ mod string_methods_lrm;
 mod string_property_shadowed_by_local;
 #[path = "strings/system_task_gaps.rs"]
 mod system_task_gaps;
+#[path = "strings/fixed_string_array_dims.rs"]
+mod fixed_string_array_dims;

--- a/tests/strings/fixed_string_array_dims.rs
+++ b/tests/strings/fixed_string_array_dims.rs
@@ -1,0 +1,108 @@
+//! Regression: `$size`/`$left`/etc. on a FIXED-SIZE STRING ARRAY must report
+//! the DECLARED element count, not the current string value's length.
+//!
+//! `$size(s)` on a scalar `string s` tracks the current length (§7.11), but
+//! the same query on a fixed array of `string` elements (`string[16]`) reports
+//! the array dimension. xezim's string-length shortcut fired for BOTH, reading
+//! the (empty, all-zero default) array as a single string and returning 0 for
+//! something like `$size(sarray_string)` — which broke UVM config_db matching
+//! on `sarray_string[13]` ("Index '13' is not valid for static array of size
+//! '0'") and missed the configured value.
+
+use xezim::simulate;
+
+fn u(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .or_else(|| sim.get_signal(&format!("tb.{}", n)))
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able (x/z?)", n))
+}
+
+/// A fixed-size string-array CLASS MEMBER reports its declared count; the
+/// sibling `int` member matches, and a scalar string still reports its length.
+#[test]
+fn size_of_fixed_string_array_class_member() {
+    let src = r#"
+class S;
+  string a[16];
+  int    b[16];
+  string sc;
+  function void show();
+    sz = $size(a);
+    sb = $size(b);
+    ssc = $size(sc);
+    sl = $left(sc); sr = $right(sc);
+  endfunction
+  int sz, sb, ssc, sl, sr;
+endclass
+module tb;
+  int sz, sb, ssc, sl, sr;
+  initial begin
+    S s = new();
+    s.sc = "Hello";
+    s.show();
+    sz = s.sz; sb = s.sb; ssc = s.ssc; sl = s.sl; sr = s.sr;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 50).expect("simulate failed");
+    assert_eq!(u(&sim, "sz"), 16, "$size(string[16]) is the declared count");
+    assert_eq!(u(&sim, "sb"), 16, "$size(int[16]) is the declared count");
+    assert_eq!(u(&sim, "ssc"), 5, "scalar string $size is its length");
+    assert_eq!(u(&sim, "sl"), 0, "scalar string $left is 0");
+    assert_eq!(u(&sim, "sr"), 4, "scalar string $right is len-1");
+}
+
+/// The string-length-shortcut veto must hold for EVERY array-query function
+/// ($left/$right/$low/$high), which share the string shortcut the fix guards.
+/// On a fixed `string[16]` member they report the DECLARED bounds (0 15 0 15)
+/// — the string-length fallback would have leaked -1/0 for a fresh empty array.
+#[test]
+fn bounds_of_fixed_string_array_class_member() {
+    let src = r#"
+class S;
+  string a[16];
+  int    b[16];
+  function void show();
+    l0=$left(a); r0=$right(a); lo0=$low(a); hi0=$high(a);
+    lb=$left(b); rb=$right(b); lob=$low(b); hib=$high(b);
+  endfunction
+  int l0,r0,lo0,hi0,lb,rb,lob,hib;
+endclass
+module tb;
+  int l0,r0,lo0,hi0,lb,rb,lob,hib;
+  initial begin
+    S s = new();
+    s.show();
+    l0=s.l0; r0=s.r0; lo0=s.lo0; hi0=s.hi0;
+    lb=s.lb; rb=s.rb; lob=s.lob; hib=s.hib;
+  end
+endmodule
+"#;
+    let sim = simulate(src, 50).expect("simulate failed");
+    assert_eq!(u(&sim, "l0"), 0, "$left(string[16]) is 0");
+    assert_eq!(u(&sim, "r0"), 15, "$right(string[16]) is 15");
+    assert_eq!(u(&sim, "lo0"), 0, "$low(string[16]) is 0");
+    assert_eq!(u(&sim, "hi0"), 15, "$high(string[16]) is 15");
+    assert_eq!(u(&sim, "lb"), 0, "$left(int[16]) is 0");
+    assert_eq!(u(&sim, "rb"), 15, "$right(int[16]) is 15");
+    assert_eq!(u(&sim, "lob"), 0, "$low(int[16]) is 0");
+    assert_eq!(u(&sim, "hib"), 15, "$high(int[16]) is 15");
+}
+
+/// A module-scope fixed `string[8]` also reports its declared count.
+#[test]
+fn size_of_fixed_string_array_module_scope() {
+    let src = r#"
+module tb;
+  string g[8];
+  int s;
+  initial begin
+    s = $size(g);
+  end
+endmodule
+"#;
+    let sim = simulate(src, 50).expect("simulate failed");
+    assert_eq!(u(&sim, "s"), 8, "$size(module string[8]) is 8");
+}

--- a/tests/sv_ref/param_static_park.sv
+++ b/tests/sv_ref/param_static_park.sv
@@ -1,0 +1,85 @@
+// IEEE 1800-2023 §15.5 — a blocking construct reached through a STATIC
+// call on a PARAMETERIZED class must still SUSPEND the calling process.
+//
+// Regression for the 11waitmod-class hang: `C#(T)::wait_modified(...)` is a
+// static blocking task whose receiver parses as a `Specialization` node
+// (`C#(T)::m`). The suspend-aware inliner did not recognize that shape, so
+// the call ran SYNCHRONOUSLY: its internal `@ev.trigger` never parked the
+// calling process, the watch `while(1)` loop spun at time 0 and never saw
+// the delayed config updates, and the simulation hung. The identical
+// non-parameterized call suspends correctly.
+//
+// A watch loop mirrors UVM wait_modified: it registers a waiter and calls
+// the STATIC PARAMETERIZED blocking task, which parks on the waiter's
+// member event. A SEPARATE producer advances a SHARED value and fires the
+// waiter after a delay (once per step). On the broken path nothing inside
+// the loop suspends, so all iterations run at time 0 before the producer's
+// first `#5`, `value` never reaches the sentinel, and the whole run spins.
+// On the fixed path each `->w.trigger` releases exactly one parked
+// iteration and `value == 3` is observed.
+//
+// Reference: run on a golden simulator; every case must report `pass`.
+
+`timescale 1ns/1ns
+
+class waiter_t;
+   event trigger;
+endclass
+
+// Parameterized static blocking hop (the `uvm_config_db#(T)::wait_modified`
+// shape). `C#(T)::wait_modified` must SUSPEND the calling process while the
+// call parks on the waiter's member event.
+class cfg_db #(type T = int);
+   static task automatic wait_modified(waiter_t w);
+      @(w.trigger);
+   endtask
+endclass
+
+module param_static_park;
+
+   int value = 0;          // shared "config" the watch loop reads
+   int steps = 0;          // how many times the loop body completed
+   int n_errors = 0;
+
+   waiter_t w = new();
+
+   task automatic chk(string what, int got, int exp);
+      if (got !== exp) begin
+         n_errors++;
+         $display("  FAIL  %-30s got=%0d  exp=%0d", what, got, exp);
+      end
+   endtask
+
+   // --- producer: advance the shared value, then fire the waiter ---------
+   initial begin
+      repeat (3) begin
+         #5;                           // delay so the parked loop can wake
+         value++;
+         ->w.trigger;                  // release ONE parked iteration
+      end
+   end
+
+   // --- consumer: while(1) body is the parameterized static call ---------
+   task automatic watch_field();
+      while (1) begin
+         cfg_db#(bit)::wait_modified(w);   // must SUSPEND/block here
+         steps++;                           // one per fired waiter
+         if (value >= 3) break;             // sentinel reached
+      end
+   endtask
+
+   initial begin
+      fork
+         watch_field();
+      join_none
+      // watchdog: if nothing suspends the loop spins hot at time 0
+      #35;
+      $display("TEST param_static_park");
+      $display("  steps=%0d value=%0d", steps, value);
+      chk("steps", steps, 3);            // exactly one wakeup per fire
+      chk("value", value, 3);
+      $display("TEST param_static_park: 2 checks, %0d errors -> %s",
+               n_errors, (n_errors == 0) ? "PASS" : "FAIL");
+      $finish;
+   end
+endmodule

--- a/tests/sv_ref/run.sh
+++ b/tests/sv_ref/run.sh
@@ -23,6 +23,7 @@ TESTS=(
   packed_port_formal_width
   packed_port_loop_select
   pct_m_hier_scope
+  param_static_park
 )
 
 mkdir -p "$OUT"
@@ -40,7 +41,10 @@ run_ref() {
 run_xezim() {
   local t=$1
   ( cd "$OUT" || exit 1
-    "$XEZIM" "${HERE}/${t}.sv" -s "$t" >"${t}.xezim.log" 2>&1
+    # A bounded run so a hang-regression (the param_static_park class of
+    # bug spins forever) yields a clean <no verdict>/FAIL instead of wedging
+    # the whole harness.
+    timeout 60 "$XEZIM" "${HERE}/${t}.sv" -s "$t" >"${t}.xezim.log" 2>&1
   )
 }
 

--- a/tests/types/typeparam_typeid_create.rs
+++ b/tests/types/typeparam_typeid_create.rs
@@ -20,7 +20,7 @@
 //! constructed object's virtual `get_type_name()` returned "", and the
 //! factory's `m_type_name` cache was built as `"uvm_reg_predictor #()"`
 //! instead of `"uvm_reg_predictor #(uvm_sequence_item)"`. This pins the
-//! type-parameter receiver case (UVM test 70regs/90Mantis/4191).
+//! type-parameter receiver case.
 
 use std::process::Command;
 


### PR DESCRIPTION
## Summary

Simulator (pure-SystemVerilog) fixes and self-tests for class **struct-formal**
binding, **foreach over string (assoc) collections**, the constraint solver's
handling of `randomize()`/`randomize() with {}` inline blocks, dyn-array
`.size()` to co-constrained-scalar coupling, `static` locals across
re-entrancy, and suspended `process::await()`-parked fork children.

Branch was rebased onto the fork's current `main`, so this PR presents only
the feature delta (26 files, +2516/-111) against `main`.

## Simulator changes (`src/compiler/simulator.rs`)

- **Bare `randomize()` in a class method** - route unqualified
  `randomize()`/`srandom()`/`get_randstate()`/`set_randstate()` inside a class
  method through the 18.11 solver (implicit built-in dispatch) so constructors
  honour declared constraints instead of leaving `rand` fields at defaults.
- **`obj.randomize() with {}` inline blocks** -
  force prefixed inline members (`obj.member == K`) in the Eq solver, keyed by
  the in-flight receiver name; resolve enclosing-scope (caller) members by
  freezing them to their current values before the solver frame; thread the
  randomized object's handle through the coupled-affine solve.
- **dyn-array `.size()` to co-constrained scalar** - size a rand dynamic array
  after scalar-equality propagation and treat a dyn-array `.size()` operand as
  unresolved when coupling `arr.size() == scalar` to the array's length.
- **static locals** - share a static subroutine local across re-entrant/
  recursive activations (single live cell, LRM 6.21/13.3.1) and key its
  persistent cell by the declaring subroutine.
- **process suspension** - keep a `process::await()`-parked fork child
  suspended (don't reap it); inline parameterized static blocking calls
  (`C#(T)::method`) into the suspend-aware stream with `Specialization`
  receivers awaiting on `@event`.
- **get_type()** - resolve a started sequence's member static type.
- **assoc collections** - iteration keeps full string keys containing `[ ]`;
  multidim assoc recursion-guard and type-param-typed assoc-pool fixes.

## New tests

Self-contained pure-SystemVerilog regressions, validated byte-for-byte against
the reference simulator: struct_formal_and_config_foreach,
constraint_dyn_size_pinned_scalar, constraint_inline_enclosing_scope,
constraint_prefixed_inline_with, bare_randomize_in_method,
static_recursion_shared_cell, phase_jump_static_latch,
fork_join_none_await_context, determinism_and_stall, assoc_bracket_keys,
multidim_assoc_struct_copy, typeparam_pool_wait, param_static_park, plus
uvm-integration additions.

Scheduling / misc / types / classes suites keep passing.