### PR TITLE
Enable the §6.6.7 resolution tests; add an EEnet RNM regression

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -51293,8 +51293,32 @@ impl Simulator {
                                     .find(|(m, _, _)| m == &member.name)
                                     .cloned()
                                 {
-                                    return base_val
+                                    let mut v = base_val
                                         .range_select((off + w - 1) as usize, off as usize);
+                                    // §6.6.7 / §7.2.1: `packed_agg_layout` is a
+                                    // 3-tuple with no is_real, so a `real`
+                                    // member projected out of a struct VALUE
+                                    // (a call result — notably a nettype
+                                    // resolution function's return) came back
+                                    // as the raw f64 BIT PATTERN: 1.5 read as
+                                    // 4609434218613702656. Restore is_real
+                                    // from the member's declared type.
+                                    let mreal = su.members.iter().any(|m| {
+                                        m.declarators
+                                            .iter()
+                                            .any(|d| d.name.name == member.name)
+                                            && matches!(
+                                                Self::resolve_type_ref(
+                                                    &m.data_type,
+                                                    &self.module.typedef_types
+                                                ),
+                                                DataType::Real { .. }
+                                            )
+                                    });
+                                    if mreal {
+                                        v.is_real = true;
+                                    }
+                                    return v;
                                 }
                             }
                         }
@@ -76165,12 +76189,21 @@ impl Simulator {
         let su = self.unpacked_struct_of(&ret)?;
         suffix.reverse();
         let want = format!("X{}", suffix.concat());
-        let (_, off, w, _) = self
+        let (_, off, w, leaf_is_real) = self
             .struct_leaf_layout("X", &su)
             .into_iter()
             .find(|(k, ..)| *k == want)?;
         let v = self.eval_expr(cur);
-        Some(v.range_select((off + w - 1) as usize, off as usize))
+        let mut out = v.range_select((off + w - 1) as usize, off as usize);
+        // `struct_leaf_layout` already knows which leaves are `real`; that flag
+        // was dropped here, so a real member projected out of a call result
+        // came back as the raw f64 BIT PATTERN (1.5 read as
+        // 4609434218613702656). This is the read path a §6.6.7 resolution
+        // function's struct return goes through — `Tsum('{...}).field1`.
+        if leaf_is_real {
+            out.is_real = true;
+        }
+        Some(out)
     }
 
     fn chain_base_packed_struct(

--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -260,25 +260,25 @@ fn test_sv_35_disable_fork() {
 fn test_sv_36_tagged_union_patterns() {
     run_positive_compliance_test("tests_advanced", "36_tagged_union_patterns.sv");
 }
-#[ignore = "unimplemented feature (was dormant/unregistered before PR #48); un-ignore when implemented"]
 #[test]
 fn test_sv_37_z_skip_resolution() {
     run_positive_compliance_test("tests_advanced", "37_z_skip_resolution.sv");
 }
-#[ignore = "unimplemented feature (was dormant/unregistered before PR #48); un-ignore when implemented"]
 #[test]
 fn test_sv_38_resolver_dispatch() {
     run_positive_compliance_test("tests_advanced", "38_resolver_dispatch.sv");
 }
-#[ignore = "unimplemented feature (was dormant/unregistered before PR #48); un-ignore when implemented"]
 #[test]
 fn test_sv_39_builtin_nettype_resolution() {
     run_positive_compliance_test("tests_advanced", "39_builtin_nettype_resolution.sv");
 }
-#[ignore = "unimplemented feature (was dormant/unregistered before PR #48); un-ignore when implemented"]
 #[test]
 fn test_sv_40_struct_nettype_resolution() {
     run_positive_compliance_test("tests_advanced", "40_struct_nettype_resolution.sv");
+}
+#[test]
+fn test_sv_44_eenet_rnm() {
+    run_positive_compliance_test("tests_advanced", "44_eenet_rnm.sv");
 }
 #[test]
 fn test_sv_41_genfor_localparam_idx() {

--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -44,3 +44,4 @@ file,topic,description
 43_typedef_type_id_create.sv,typedef factory alias,typedef alias of parameterised class resolved via type_id::create factory path
 43_vif_writes.sv,virtual interface writes,blocking/NBA scalar+bit-select+vector writes through a virtual interface propagate to the bound instance
 43_packed_struct_assign.sv,packed struct assignment patterns,named/ordered patterns into packed struct packed by member offset; packed-2D element continuous assign emits full-width gate
+44_eenet_rnm.sv,user-defined nettypes for RNM,EEnet struct-of-real UDN with Millman/KCL resolution over 2-4 simultaneous drivers (DVCon EU 2019 TI/Cadence pattern)

--- a/tests/sv_compliance/tests_advanced/37_z_skip_resolution.sv
+++ b/tests/sv_compliance/tests_advanced/37_z_skip_resolution.sv
@@ -27,7 +27,7 @@
 // So Tier 0 is more of a documentation/regression baseline than a bug
 // catch; the bug-catching tier is Tier 1 (per-NetType fold).
 
-`include "svtest_defs.svh"
+`include "../common/svtest_defs.svh"
 
 module test_37_tier0_z_skip_resolution;
   `SVTEST_INIT

--- a/tests/sv_compliance/tests_advanced/38_resolver_dispatch.sv
+++ b/tests/sv_compliance/tests_advanced/38_resolver_dispatch.sv
@@ -19,7 +19,7 @@
 // rather than a real function-call result, because `cnt_mix` returns 3
 // which is not reachable by any static fold of [1,0,1,1,0].
 
-`include "svtest_defs.svh"
+`include "../common/svtest_defs.svh"
 
 // ----------------------------------------------------------------------------
 // Resolver functions. Each must be `automatic`, take a single unpacked-queue

--- a/tests/sv_compliance/tests_advanced/39_builtin_nettype_resolution.sv
+++ b/tests/sv_compliance/tests_advanced/39_builtin_nettype_resolution.sv
@@ -36,7 +36,7 @@
 // So this test will fail on xezim at every NetType that is NOT OR-fold and
 // will pass only after Tier 1 is implemented.
 
-`include "svtest_defs.svh"
+`include "../common/svtest_defs.svh"
 
 module test_39_tier1_builtin_nettype_resolution;
   `SVTEST_INIT

--- a/tests/sv_compliance/tests_advanced/40_struct_nettype_resolution.sv
+++ b/tests/sv_compliance/tests_advanced/40_struct_nettype_resolution.sv
@@ -22,7 +22,7 @@
 // non-primitive element type at all, or where struct field access is not
 // resolved through the driver-queue element.
 
-`include "svtest_defs.svh"
+`include "../common/svtest_defs.svh"
 
 // ---------------------------------------------------------------------------
 // User-defined struct type with a `real` field and a `bit` field.

--- a/tests/sv_compliance/tests_advanced/44_eenet_rnm.sv
+++ b/tests/sv_compliance/tests_advanced/44_eenet_rnm.sv
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+//
+// 44_eenet_rnm.sv — §6.6.7 user-defined nettypes used for REAL NUMBER
+// MODELLING: the "EEnet" pattern from the DVCon Europe 2019 TI/Cadence paper
+// "Enabling Digital Mixed-Signal Verification of Loading Effects in Power
+// Regulation using SystemVerilog User-Defined Nettype" (Caicedo / Fritz).
+//
+// A UDT struct carries voltage / current / series resistance; a UDN declares
+// nets of it; a UDR combines every driver at a shared node the way an analog
+// solver would. Unlike 38 (scalar resolvers) and 40 (the LRM's `Tsum`), this
+// exercises the combination that motivates UDNs in practice:
+//
+//   - a struct of THREE reals resolved field-by-field,
+//   - arithmetic over the driver set that no fold can express (Millman's
+//     theorem: V = (sum Vk/Rk + sum Ik) / (sum 1/Rk)),
+//   - drivers that differ in NATURE — voltage sources, current sinks, and
+//     passive loads sharing one node,
+//   - 2, 3 and 4 simultaneous drivers.
+//
+// Reference values are hand-derived circuit results, so a resolver that is
+// silently skipped, folded, or called with a truncated driver set cannot pass.
+
+`include "../common/svtest_defs.svh"
+
+package EE_pkg;
+  typedef struct {
+    real V;   // Thevenin source voltage
+    real I;   // current injected into the node
+    real R;   // series resistance (0.0 => ideal current source, no conductance)
+  } EEstruct;
+endpackage
+
+import EE_pkg::*;
+
+// Millman / Thevenin combination at a shared node.
+function automatic EEstruct res_EE (input EEstruct driver []);
+  real g_sum, i_sum, vg_sum;
+  g_sum = 0.0; i_sum = 0.0; vg_sum = 0.0;
+  foreach (driver[k]) begin
+    i_sum += driver[k].I;
+    if (driver[k].R != 0.0) begin
+      g_sum  += 1.0 / driver[k].R;
+      vg_sum += driver[k].V / driver[k].R;
+    end
+  end
+  if (g_sum == 0.0) begin
+    res_EE.V = 0.0;
+    res_EE.R = 0.0;
+  end else begin
+    res_EE.V = (vg_sum + i_sum) / g_sum;
+    res_EE.R = 1.0 / g_sum;
+  end
+  res_EE.I = i_sum;
+endfunction
+
+nettype EEstruct EEnet with res_EE;
+
+// Power rail: the regulator sets the voltage, loads add current (KCL).
+function automatic EEstruct res_rail (input EEstruct driver []);
+  real i_sum, v;
+  i_sum = 0.0; v = 0.0;
+  foreach (driver[k]) begin
+    i_sum += driver[k].I;
+    if (driver[k].V != 0.0) v = driver[k].V;
+  end
+  res_rail.V = v;
+  res_rail.I = i_sum;
+  res_rail.R = 0.0;
+endfunction
+
+nettype EEstruct RailNet with res_rail;
+
+module test_44_eenet_rnm;
+  `SVTEST_INIT
+
+  // Two Thevenin sources sharing a node: 5V/100R against 0V/100R.
+  //   V = (5/100) / (2/100) = 2.5,  R = 1/(2/100) = 50
+  EEnet nA;
+  assign nA = '{5.0, 0.0, 100.0};
+  assign nA = '{0.0, 0.0, 100.0};
+
+  // Voltage source loaded by a current sink — the loading effect EEnet exists
+  // to model.  V = (5/10 - 0.1) / (1/10) = 4.0,  R = 10,  I = -0.1
+  EEnet nB;
+  assign nB = '{5.0,  0.0, 10.0};
+  assign nB = '{0.0, -0.1,  0.0};
+
+  // Three-way divider: 12V/100R against two grounded 100R legs.
+  //   V = (12/100) / (3/100) = 4.0,  R = 100/3
+  EEnet nC;
+  assign nC = '{12.0, 0.0, 100.0};
+  assign nC = '{ 0.0, 0.0, 100.0};
+  assign nC = '{ 0.0, 0.0, 100.0};
+
+  // 1.8V rail with three loads — 4 simultaneous drivers, KCL current sum.
+  RailNet rail;
+  assign rail = '{1.8,  0.0,   0.0};
+  assign rail = '{0.0, -0.010, 0.0};
+  assign rail = '{0.0, -0.025, 0.0};
+  assign rail = '{0.0, -0.005, 0.0};
+
+  initial begin
+    #1;
+    `SVTEST_CHECK(nA.V > 2.4999 && nA.V < 2.5001,
+                  "A: two 100R Thevenin sources -> node V = 2.5")
+    `SVTEST_CHECK(nA.R > 49.999 && nA.R < 50.001,
+                  "A: two 100R in parallel -> Thevenin R = 50")
+    `SVTEST_CHECK(nB.V > 3.9999 && nB.V < 4.0001,
+                  "B: 5V/10R loaded by 100mA sink -> V = 4.0 (loading effect)")
+    `SVTEST_CHECK(nB.I > -0.1001 && nB.I < -0.0999,
+                  "B: node current = -0.1")
+    `SVTEST_CHECK(nC.V > 3.9999 && nC.V < 4.0001,
+                  "C: 12V through 3-way 100R divider -> V = 4.0")
+    `SVTEST_CHECK(nC.R > 33.3332 && nC.R < 33.3334,
+                  "C: three 100R in parallel -> R = 33.3333")
+    `SVTEST_CHECK(rail.V > 1.7999 && rail.V < 1.8001,
+                  "D: rail voltage passes through 4 drivers -> 1.8")
+    `SVTEST_CHECK(rail.I > -0.0401 && rail.I < -0.0399,
+                  "D: KCL over 3 loads -> total current = -40mA")
+
+    `SVTEST_PASSFAIL
+  end
+endmodule


### PR DESCRIPTION
# Enable the §6.6.7 resolution tests; add an EEnet RNM regression

**Draft until the companion core PR merges.** Depends on: https://github.com/aionhw/xezim-core/pull/27
Issue: https://github.com/aionhw/xezim/issues/119

The elaborator changes live in `xezim-core`. Once that PR merges I'll bump both
`rev = ...` fields in `Cargo.toml` to the merged SHA and mark this ready — until
then this branch does not build against the pinned core.

Two commits, +168 / −11.

## Commit 1 — `Restore is_real on a real member projected from a call result`

`eval_unpacked_call_member` sliced the member out of the packed return value but
dropped the per-leaf `is_real` flag that `struct_leaf_layout` had **already
computed** (it was bound to `_`). A `real` member read out of any struct-returning
function came back as its raw f64 bit pattern:

```systemverilog
typedef struct { real f1; bit f2; } T;
function automatic T mk(); ... endfunction
$display("%f", mk().f1);   // 4609434218613702656.0, want 1.5
```

Not nettype-specific — it affects any struct-returning function — but it is the
read path a resolution function's struct return goes through, so it also blocked
struct-of-real nettypes. Separated into its own commit; it stands alone and is
verified green against released core (2241 passed, 0 failed).

## Commit 2 — `Enable the §6.6.7 resolution tests; add an EEnet RNM regression`

The four resolution-tier tests added alongside 31 were **never runnable**: each
includes `"svtest_defs.svh"` while the harness lives at
`"../common/svtest_defs.svh"` (31 has the correct path), so all four failed in
the preprocessor before reaching simulation. Being `#[ignore]`d meant nothing
surfaced it.

- Fix the include path in 36–40; un-ignore 37–40.
- **36 stays ignored** — tagged union patterns are still genuinely unimplemented.
- Worth noting for review: **37 and 39 needed no code change.** With the include
  fixed they pass against current `main` — built-in net resolution is already
  implemented and those two were stale-ignored. Their file comments predicting
  `wand [0,1] -> 1  WRONG` are outdated; left alone here to keep the diff
  minimal, happy to update them if you'd prefer.
- Only 38 and 40 needed the core work. Both were `TEST_FAIL count=7`.

### New: `44_eenet_rnm.sv`

The "EEnet" pattern from the DVCon Europe 2019 TI/Cadence paper *Enabling Digital
Mixed-Signal Verification of Loading Effects in Power Regulation using
SystemVerilog User-Defined Nettype*. It covers the combination that motivates
UDNs in practice, which 38 (scalar resolvers) and 40 (the LRM's `Tsum`) do not:

- a struct of **three reals** (V/I/R) resolved field-by-field;
- arithmetic over the driver set no fold can express — Millman's theorem,
  `V = (Σ Vk/Rk + Σ Ik) / (Σ 1/Rk)`;
- drivers differing in **nature** — voltage sources, current sinks and passive
  loads sharing one node;
- **2, 3 and 4** simultaneous drivers;
- KCL current summing on a 1.8 V rail with three loads.

Reference values are hand-derived circuit results, so a resolver that is skipped,
folded, or called with a truncated driver set cannot pass.

## Testing

| Configuration | Result |
|---|---|
| commit 1 alone + core @ `6e2f17c` (released) | 2241 passed, 0 failed |
| both commits + companion core PR | 2246 passed, 0 failed |
| both commits + companion core PR, `--features jit` | 2250 passed, 0 failed |

2241 → 2246 is +4 un-ignored resolution tests +1 new EEnet test; ignored 15 → 11.
The real-UVM integration tests (RAL frontdoor/backdoor, TLM bench, 1.2 /
1800.2-2017 / 1800.2-2020) stay green throughout.

## Note

Nettype **ports across module hierarchy** — slide 7 of that paper, where several
instances drive a shared node through module ports — are still unimplemented.
Everything here works within a single module scope. Happy to follow up.
