### PR TITLE
sim: clockgen must apply 4-state ~ (X never toggles)

### DIFF
--- a/tests/clockgen_x_clock_stays_x.sv
+++ b/tests/clockgen_x_clock_stays_x.sv
@@ -1,0 +1,41 @@
+`timescale 1ns/1ns
+// Pure-SystemVerilog reproduction of the clockgen 4-state `~` bug.
+//
+// An uninitialized 4-state `logic` is X at :0. Per LRM §6.8, ~1'bx == 1'bx,
+// so `always #5 clk = ~clk;` must NEVER toggle an X-start clock (no posedge,
+// no edge at all). xezim's clock-generator fast path used to treat any
+// non-One bit (X/Z included) as 0 and flip it to 1, synthesising a 0->1->0
+// clock out of `clkX` and firing 6 posedges. The explicit `clk0 = 0` clock
+// must still toggle normally (6 posedges over #60).
+//
+// Run: xezim --simulate -s top tests/clockgen_x_clock_stays_x.sv
+// Expect (both the reference simulator and fixed xezim): BOTH tags:
+//   TAG_PASS_clock_stays_x      xezim pre-fix: TAG_FAIL_clock_active pe=6
+//   TAG_PASS_explicit_toggles   both sims agree pe=6
+module top;
+  logic clkX;                     // 4-state, no init -> X at :0
+  always #5 clkX = ~clkX;         // ~X = X -> stays X, never edges
+
+  logic clk0 = 0;                 // explicit init -> genuine clock
+  always #5 clk0 = ~clk0;         // 0->1->0, posedges at 5,15,25,35,45,55
+
+  int unsigned peX = 0;
+  int unsigned pe0 = 0;
+
+  initial forever @(posedge clkX) peX++;
+  initial forever @(posedge clk0) pe0++;
+
+  initial begin
+    $display("CLKX t=%0t clkX=%b", $time, clkX); // report start of X clock
+    #60;                    // posedges on clk0 at 5,15,25,35,45,55 -> 6
+    if (peX == 0)
+      $display("TAG_PASS_clock_stays_x");
+    else
+      $display("TAG_FAIL_clock_active peX=%0d", peX);
+    if (pe0 == 6)
+      $display("TAG_PASS_explicit_toggles");
+    else
+      $display("TAG_FAIL_explicit pe0=%0d", pe0);
+    $finish;
+  end
+endmodule

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -53,6 +53,8 @@ mod case_wait_in_task;
 mod clock_gate_fanout;
 #[path = "scheduling/clock_t0_variable_delay_phase.rs"]
 mod clock_t0_variable_delay_phase;
+#[path = "scheduling/clockgen_x_clock_stays_x.rs"]
+mod clockgen_x_clock_stays_x;
 #[path = "scheduling/clocking_event_cycle_delay.rs"]
 mod clocking_event_cycle_delay;
 #[path = "scheduling/comb_result_clobbered_by_process.rs"]

--- a/tests/scheduling/clockgen_x_clock_stays_x.rs
+++ b/tests/scheduling/clockgen_x_clock_stays_x.rs
@@ -1,0 +1,54 @@
+//! Pure-SystemVerilog self-test: an uninitialized 4-state `logic` driven by
+//! `always #N clk = ~clk` must NOT produce a synthetic clock.
+//!
+//! In IEEE 1800 4-state semantics `~1'bx == 1'bx`, so a `logic clk;` with no
+//! initializer stays X forever and `always #N clk = ~clk` never toggles it —
+//! no posedge. xezim's built-in ClockGen fast path used to treat any non-One
+//! bit (X/Z included) as 0 and flip it to 1, synthesising a 0->1->0 clock out
+//! of an X signal and inventing posedges the reference never fires. A clock
+//! with an explicit `= 0` init must keep toggling normally.
+//!
+//! The driver shells the standalone pure-SV file
+//! `tests/clockgen_x_clock_stays_x.sv` through the CLI (same pattern as
+//! reg3456_pure_sv / reg4712_visitor_traversal) and asserts both of its
+//! TAG_PASS banners.
+
+use std::path::Path;
+use std::process::Command;
+
+const SV_FILE: &str = "clockgen_x_clock_stays_x.sv";
+
+#[test]
+fn clockgen_x_clock_stays_x() {
+    let test_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let test_file = test_dir.join(SV_FILE);
+    assert!(test_file.exists(), "Test file not found: {}", test_file.display());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xezim"))
+        .arg("--simulate")
+        .arg("-s")
+        .arg("top")
+        .arg(test_file.to_str().unwrap())
+        .output()
+        .expect("Failed to execute xezim");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    // Parse / simulation errors.
+    assert!(!combined.contains("Parse errors"), "Parse error:\n{combined}");
+    assert!(!combined.contains("Simulation error"), "Simulation error:\n{combined}");
+
+    // X-start `clkX = ~clkX` must stay X forever (reference idles; the bug
+    // fired 6 synthetic posedges). Pre-fix this printed TAG_FAIL_clock_active.
+    assert!(
+        combined.contains("TAG_PASS_clock_stays_x"),
+        "X-start self-toggle clock generated posedges (bug present):\n{combined}"
+    );
+    // Explicit `clk0 = 0` self-toggle must still clock normally (pe0 == 6).
+    assert!(
+        combined.contains("TAG_PASS_explicit_toggles"),
+        "explicit clk=0 self-toggle failed to clock (regression):\n{combined}"
+    );
+}


### PR DESCRIPTION
## Summary

The built-in clock-generator fast path (`always #N clk = ~clk` specialized to an O(1) toggle, in `fire_clock_generators`) turned **any non-`One` bit — including `X`/`Z` on an uninitialized 4-state `logic` — into `1`**, synthesising a 0→1→0 clock out of a signal that, per LRM §11.5.1, stays `X` forever and never produces an edge.

An uninitialized `logic` (no `= init`) is `X` at t=0; driving it with `always #N clk = ~clk` must keep it `X` (no posedge, no edge at all). xezim invented 6 synthetic posedges.

## Fix

`fire_clock_generators` now applies the real 4-state NOT (0→1, 1→0, X→X, Z→X) and **retires the generator** when the signal is currently unknown, so an `X` clock idles instead of clocking. Genuine `clk = 0` self-toggles still toggle byte-identically to the reference (6 posedges over `#60`).

## Verification

- **Standalone pure-SystemVerilog self-test** `tests/clockgen_x_clock_stays_x.sv` (driven via `tests/scheduling/clockgen_x_clock_stays_x.rs` through the CLI, same pattern as `reg3456_pure_sv`):
  - X-start (`logic clkX; always #5 clkX = ~clkX`) → **`TAG_PASS_clock_stays_x`**
  - explicit-0 (`logic clk0 = 0; always #5 clk0 = ~clk0`) → **`TAG_PASS_explicit_toggles`**
- **Pre-fix** the same `.sv` reports `TAG_FAIL_clock_active peX=6` (the bug, demonstrated live).
- Output **byte-identical to the reference simulator** on the fixed binary for both cases.
- Full `--test scheduling` group: 324 passed, 0 failed (the single `phase_jump_static_latch` failure is pre-existing and unrelated — it reproduces identically on the unmodified tree and exercises no clock generators).