### PR TITLE
tests: nettype nets across module hierarchy, and in packages (§6.6.7)

### DIFF
--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -293,6 +293,10 @@ fn test_sv_47_nettype_coercion() {
     run_positive_compliance_test("tests_advanced", "47_nettype_coercion.sv");
 }
 #[test]
+fn test_sv_48_nettype_inlined_real() {
+    run_positive_compliance_test("tests_advanced", "48_nettype_inlined_real.sv");
+}
+#[test]
 fn test_sv_41_genfor_localparam_idx() {
     run_positive_compliance_test("tests_advanced", "41_genfor_localparam_idx.sv");
 }

--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -281,6 +281,14 @@ fn test_sv_44_eenet_rnm() {
     run_positive_compliance_test("tests_advanced", "44_eenet_rnm.sv");
 }
 #[test]
+fn test_sv_45_package_nettype() {
+    run_positive_compliance_test("tests_advanced", "45_package_nettype.sv");
+}
+#[test]
+fn test_sv_46_nettype_hierarchy() {
+    run_positive_compliance_test("tests_advanced", "46_nettype_hierarchy.sv");
+}
+#[test]
 fn test_sv_41_genfor_localparam_idx() {
     run_positive_compliance_test("tests_advanced", "41_genfor_localparam_idx.sv");
 }

--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -289,6 +289,10 @@ fn test_sv_46_nettype_hierarchy() {
     run_positive_compliance_test("tests_advanced", "46_nettype_hierarchy.sv");
 }
 #[test]
+fn test_sv_47_nettype_coercion() {
+    run_positive_compliance_test("tests_advanced", "47_nettype_coercion.sv");
+}
+#[test]
 fn test_sv_41_genfor_localparam_idx() {
     run_positive_compliance_test("tests_advanced", "41_genfor_localparam_idx.sv");
 }

--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -47,3 +47,4 @@ file,topic,description
 44_eenet_rnm.sv,user-defined nettypes for RNM,EEnet struct-of-real UDN with Millman/KCL resolution over 2-4 simultaneous drivers (DVCon EU 2019 TI/Cadence pattern)
 45_package_nettype.sv,user-defined nettypes in packages,nettype declared in a package used via wildcard import and qualified Pkg::name reference
 46_nettype_hierarchy.sv,user-defined nettypes across hierarchy,nettype nets driven from several module instances through ports; Millman resolution over a nested dut catches per-port double resolution
+47_nettype_coercion.sv,nettype coercion of implicit nets,implicit net used as a port actual takes the port user-defined nettype (§6.6.8/§23.3.3)

--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -45,3 +45,5 @@ file,topic,description
 43_vif_writes.sv,virtual interface writes,blocking/NBA scalar+bit-select+vector writes through a virtual interface propagate to the bound instance
 43_packed_struct_assign.sv,packed struct assignment patterns,named/ordered patterns into packed struct packed by member offset; packed-2D element continuous assign emits full-width gate
 44_eenet_rnm.sv,user-defined nettypes for RNM,EEnet struct-of-real UDN with Millman/KCL resolution over 2-4 simultaneous drivers (DVCon EU 2019 TI/Cadence pattern)
+45_package_nettype.sv,user-defined nettypes in packages,nettype declared in a package used via wildcard import and qualified Pkg::name reference
+46_nettype_hierarchy.sv,user-defined nettypes across hierarchy,nettype nets driven from several module instances through ports; Millman resolution over a nested dut catches per-port double resolution

--- a/tests/sv_compliance/tests_advanced/45_package_nettype.sv
+++ b/tests/sv_compliance/tests_advanced/45_package_nettype.sv
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+//
+// 45_package_nettype.sv — §6.6.7 + §26.2: a user-defined nettype declared in a
+// PACKAGE. That is the natural place for one: a nettype used on both sides of a
+// port connection must be named identically in both modules, so it has to live
+// in a shared scope.
+//
+// Both reference forms are covered:
+//   - `import P::*;` then the bare name
+//   - the qualified `P::name` with no import (§26.3)
+//
+// Before package nettypes were registered, neither form classified the net as a
+// net at all: a second continuous driver failed elaboration with the generic
+// "Variable 'n' has multiple continuous drivers" instead of resolving.
+
+`include "../common/svtest_defs.svh"
+
+package EE;
+  typedef struct {
+    real v;
+    bit  tag;
+  } cell_t;
+
+  // Sum the reals, OR the tags — a fold no built-in net resolution expresses.
+  function automatic cell_t cell_sum (input cell_t driver []);
+    cell_sum.v   = 0.0;
+    cell_sum.tag = 1'b0;
+    foreach (driver[i]) begin
+      cell_sum.v   += driver[i].v;
+      cell_sum.tag |= driver[i].tag;
+    end
+  endfunction
+
+  nettype cell_t cellnet with cell_sum;
+
+  // A scalar real nettype in the same package, to pin that the registry keeps
+  // more than one entry per package.
+  function automatic real rmax (input real driver []);
+    rmax = driver[0];
+    foreach (driver[i]) if (driver[i] > rmax) rmax = driver[i];
+  endfunction
+
+  nettype real maxnet with rmax;
+endpackage
+
+import EE::*;
+
+module test_45_package_nettype;
+  `SVTEST_INIT
+
+  // ----- bare name after a wildcard import -----
+  cellnet a;
+  assign a = '{1.5, 1'b0};
+  assign a = '{2.5, 1'b1};
+
+  // ----- qualified reference, no import needed for this one -----
+  EE::cellnet b;
+  assign b = '{0.25, 1'b0};
+  assign b = '{0.75, 1'b0};
+  assign b = '{1.00, 1'b0};
+
+  // ----- second nettype from the same package, scalar real -----
+  maxnet m;
+  assign m = 3.5;
+  assign m = 9.25;
+  assign m = 1.0;
+
+  initial begin
+    #1;
+    `SVTEST_CHECK(a.v > 3.9999 && a.v < 4.0001,
+                  "imported package nettype: 1.5 + 2.5 = 4.0")
+    `SVTEST_CHECK(a.tag === 1'b1,
+                  "imported package nettype: tag OR = 1")
+    `SVTEST_CHECK(b.v > 1.9999 && b.v < 2.0001,
+                  "qualified EE::cellnet over 3 drivers = 2.0")
+    `SVTEST_CHECK(b.tag === 1'b0,
+                  "qualified EE::cellnet: tag OR = 0")
+    `SVTEST_CHECK(m > 9.2499 && m < 9.2501,
+                  "second package nettype (scalar real max) = 9.25")
+
+    `SVTEST_PASSFAIL
+  end
+endmodule

--- a/tests/sv_compliance/tests_advanced/46_nettype_hierarchy.sv
+++ b/tests/sv_compliance/tests_advanced/46_nettype_hierarchy.sv
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+//
+// 46_nettype_hierarchy.sv — §6.6.7 user-defined nettype nets driven from
+// several module INSTANCES through ports. This is the topology user-defined
+// nettypes exist for (DVCon Europe 2019, TI/Cadence, "Enabling Digital
+// Mixed-Signal Verification of Loading Effects in Power Regulation"): a shared
+// analog node with drivers and loads contributed by different blocks.
+//
+// Tests 38/40/44/45 all resolve within ONE module. The failure mode this file
+// pins is different in kind: a nettype net crossing a port boundary is
+// elaborated as a separate signal per port, joined by identity continuous
+// assigns. Resolving each of those separately runs the resolution function once
+// per port net and then AGAIN over the results.
+//
+// That compounding is INVISIBLE for an associative resolver — a plain sum gives
+// the right answer either way, which is exactly why it can go unnoticed — so
+// case C below deliberately uses Millman's theorem, where resolving twice does
+// not equal resolving once. It collapsed to 0.0 before nettype resolution
+// became a whole-design pass.
+//
+//   A: three instances on one scalar node        (sum, would pass either way)
+//   B: one parent driver + one instance driver   (mixed sources on a node)
+//   C: struct-valued node, NESTED hierarchy, real parameters through #()
+//      overrides, resolved by Millman's theorem  (catches double-resolution)
+
+`include "../common/svtest_defs.svh"
+
+// ---------------------------------------------------------------------------
+// Scalar real nettype, summed.
+// ---------------------------------------------------------------------------
+function automatic real rsum (input real d []);
+  rsum = 0.0;
+  foreach (d[i]) rsum += d[i];
+endfunction
+
+nettype real rnet with rsum;
+
+module rsrc #(parameter real VAL = 1.0) (inout rnet p);
+  assign p = VAL;
+endmodule
+
+// ---------------------------------------------------------------------------
+// Electrically-equivalent struct nettype: voltage / current / series R.
+// Resolution is Millman's theorem, which is NOT associative over partial
+// results — resolving per port net and again at the node gives a wrong answer.
+//   V = (sum Vk/Rk + sum Ik) / (sum 1/Rk),   R = 1 / (sum 1/Rk)
+// R == 0.0 marks an ideal current source: contributes I, no conductance.
+// ---------------------------------------------------------------------------
+typedef struct {
+  real V;
+  real I;
+  real R;
+} EEstruct;
+
+function automatic EEstruct res_EE (input EEstruct driver []);
+  real g_sum, i_sum, vg_sum;
+  g_sum = 0.0; i_sum = 0.0; vg_sum = 0.0;
+  foreach (driver[k]) begin
+    i_sum += driver[k].I;
+    if (driver[k].R != 0.0) begin
+      g_sum  += 1.0 / driver[k].R;
+      vg_sum += driver[k].V / driver[k].R;
+    end
+  end
+  if (g_sum == 0.0) begin
+    res_EE.V = 0.0;
+    res_EE.R = 0.0;
+  end else begin
+    res_EE.V = (vg_sum + i_sum) / g_sum;
+    res_EE.R = 1.0 / g_sum;
+  end
+  res_EE.I = i_sum;
+endfunction
+
+nettype EEstruct EEnet with res_EE;
+
+// Current source IA in parallel with RA.
+module isrc #(parameter real IA = 0.0, parameter real RA = 1.0) (inout EEnet p);
+  assign p = '{0.0, IA,  0.0};
+  assign p = '{0.0, 0.0, RA };
+endmodule
+
+// Thevenin source VB behind RB.
+module vsrc #(parameter real VB = 0.0, parameter real RB = 1.0) (inout EEnet p);
+  assign p = '{VB, 0.0, RB};
+endmodule
+
+// Passive load to ground.
+module eload #(parameter real RL = 1.0) (inout EEnet p);
+  assign p = '{0.0, 0.0, RL};
+endmodule
+
+// One level deeper, so the node is shared across TWO levels of hierarchy.
+module dut (inout EEnet node);
+  isrc #(.IA(0.010), .RA(1000.0)) u1 (.p(node));
+  vsrc #(.VB(5.0),   .RB(100.0))  u2 (.p(node));
+endmodule
+
+// ---------------------------------------------------------------------------
+module test_46_nettype_hierarchy;
+  `SVTEST_INIT
+
+  // ---- A: three instances driving one scalar node -> 1 + 2 + 4 = 7 ----
+  rnet node1;
+  rsrc #(.VAL(1.0)) a1 (.p(node1));
+  rsrc #(.VAL(2.0)) a2 (.p(node1));
+  rsrc #(.VAL(4.0)) a3 (.p(node1));
+
+  // ---- B: a driver in the parent plus one from an instance -> 8 + 16 = 24 ----
+  rnet node2;
+  assign node2 = 8.0;
+  rsrc #(.VAL(16.0)) b1 (.p(node2));
+
+  // ---- C: struct node shared by a nested dut and a parent-level load ----
+  //   G  = 1/1000 + 1/100 + 1/500 = 0.013
+  //   Vg = 5/100 = 0.05,  I = 0.010
+  //   V  = (0.05 + 0.010) / 0.013 = 4.615384615...
+  //   R  = 1 / 0.013           = 76.923076923...
+  EEnet node3;
+  dut   d0 (.node(node3));
+  eload #(.RL(500.0)) c1 (.p(node3));
+
+  initial begin
+    #1;
+
+    `SVTEST_CHECK(node1 > 6.9999 && node1 < 7.0001,
+                  "A: three instances on one scalar node -> 7.0")
+
+    `SVTEST_CHECK(node2 > 23.9999 && node2 < 24.0001,
+                  "B: parent driver + instance driver -> 24.0")
+
+    `SVTEST_CHECK(node3.V > 4.615384 && node3.V < 4.615386,
+                  "C: Millman over nested hierarchy -> V = 4.615385")
+    `SVTEST_CHECK(node3.R > 76.923076 && node3.R < 76.923078,
+                  "C: Thevenin R of three parallel legs -> 76.923077")
+    `SVTEST_CHECK(node3.I > 0.0099999 && node3.I < 0.0100001,
+                  "C: current-source contribution survives the port hops -> 0.01")
+
+    `SVTEST_PASSFAIL
+  end
+endmodule

--- a/tests/sv_compliance/tests_advanced/47_nettype_coercion.sv
+++ b/tests/sv_compliance/tests_advanced/47_nettype_coercion.sv
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+//
+// 47_nettype_coercion.sv — §6.6.8 / §23.3.3: an implicitly-declared net used as
+// a port actual takes its type from the port it connects to. When that port is
+// a user-defined nettype, the implicit net is that nettype — not a 1-bit wire.
+//
+// This is the "nets are automatically coerced" property that makes the
+// loading-effect modelling style practical: an analog node can be named at the
+// point of connection without a separate declaration.
+//
+// Current behaviour (xezim main + xezim-core#28): the implicit net is created
+// as a 1-bit wire, so a 64-bit nettype port truncates to it and the node
+// resolves to 0.0 with only a width warning. Silently wrong, not diagnosed.
+
+`include "../common/svtest_defs.svh"
+
+function automatic real rsum (input real d []);
+  rsum = 0.0;
+  foreach (d[i]) rsum += d[i];
+endfunction
+
+nettype real rnet with rsum;
+
+module src #(parameter real VAL = 1.0) (inout rnet p);
+  assign p = VAL;
+endmodule
+
+module snk (inout rnet p, output real seen);
+  assign seen = p;
+endmodule
+
+module test_47_nettype_coercion;
+  `SVTEST_INIT
+
+  // `node_a` is never declared — it exists only as a port actual, so §6.10
+  // creates it implicitly and §6.6.8/§23.3.3 give it the port's nettype.
+  real seen_a;
+  src #(.VAL(1.5)) u1 (.p(node_a));
+  src #(.VAL(2.5)) u2 (.p(node_a));
+  snk              u3 (.p(node_a), .seen(seen_a));
+
+  // Control: the identical topology on an explicitly declared net. This half
+  // passes today, so a failure here would mean something other than coercion
+  // regressed.
+  rnet node_b;
+  real seen_b;
+  src #(.VAL(1.5)) v1 (.p(node_b));
+  src #(.VAL(2.5)) v2 (.p(node_b));
+  snk              v3 (.p(node_b), .seen(seen_b));
+
+  initial begin
+    #1;
+    `SVTEST_CHECK(seen_a > 3.9999 && seen_a < 4.0001,
+                  "implicit net coerced to the port's nettype -> 4.0")
+    `SVTEST_CHECK(seen_b > 3.9999 && seen_b < 4.0001,
+                  "control: explicitly declared nettype net -> 4.0")
+    `SVTEST_PASSFAIL
+  end
+endmodule

--- a/tests/sv_compliance/tests_advanced/48_nettype_inlined_real.sv
+++ b/tests/sv_compliance/tests_advanced/48_nettype_inlined_real.sv
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+//
+// 48_nettype_inlined_real.sv — §6.6.7 a user-defined nettype net keeps its
+// REAL-ness when the module declaring it is instantiated rather than top-level.
+//
+// Inlining a child module's scalar declaration into its parent recomputed the
+// signal's is_real from the RAW declared type. A net declared with a nettype
+// carries a type NAME that only resolves to `real` through the nettype
+// registry, so the inlined net was created as an integer slot and every
+// resolution result was rounded on write. The identical declaration at TOP
+// level took a resolving path and stayed real.
+//
+// The rounding is what makes this pernicious: it is invisible whenever the
+// resolved value happens to be a whole number. A net resolving to 3.0 or 15.0
+// reads back correctly while the same net resolving to 0.001 reads 0.0. Every
+// value below is therefore deliberately non-integer, and case D pins the
+// rounding directly by checking a value that would round to a DIFFERENT
+// integer rather than to zero.
+//
+//   A: fractional sum on a node inside an instantiated module   (read 0.0)
+//   B: the same node at top level                               (control)
+//   C: RNM-scale currents through two levels of hierarchy       (read 0.0)
+//   D: 3.7 must survive intact, not land on a whole number      (rounding)
+
+`include "../common/svtest_defs.svh"
+
+function automatic real isum (input real d []);
+  isum = 0.0;
+  foreach (d[i]) isum += d[i];
+endfunction
+
+nettype real inet with isum;
+
+// A current-mode source: contributes a fractional current to a shared node.
+module isrc #(parameter real K = 1.0) (input real v, output real o);
+  assign o = K * v;
+endmodule
+
+// Declares the nettype node ITSELF, then is instantiated -- the case that broke.
+module leaf (input real v, output real seen);
+  inet node;
+  isrc #(.K(0.0011)) s0 (.v(v), .o(node));
+  isrc #(.K(0.0024)) s1 (.v(v), .o(node));
+  assign seen = node;
+endmodule
+
+// Two levels: the node lives one module deeper than the instantiation site.
+module mid (input real v, output real seen);
+  leaf l0 (.v(v), .seen(seen));
+endmodule
+
+// Single driver, value chosen to round to a DIFFERENT integer if truncated.
+module round_probe (input real v, output real seen);
+  inet node;
+  isrc #(.K(3.7)) s0 (.v(v), .o(node));
+  assign seen = node;
+endmodule
+
+module top;
+  `SVTEST_INIT
+
+  real drive;
+
+  // ---- A: fractional sum inside an instantiated module ----
+  //   0.0011 + 0.0024 = 0.0035 at v = 1.0
+  real seen_a;
+  leaf a0 (.v(drive), .seen(seen_a));
+
+  // ---- B: the same resolution at TOP level (control: always worked) ----
+  inet node_b;
+  isrc #(.K(0.0011)) b0 (.v(drive), .o(node_b));
+  isrc #(.K(0.0024)) b1 (.v(drive), .o(node_b));
+
+  // ---- C: RNM-scale currents, node two levels down ----
+  real seen_c;
+  mid c0 (.v(drive), .seen(seen_c));
+
+  // ---- D: 3.7 must survive as 3.7, not round to 4.0 ----
+  real seen_d;
+  round_probe d0 (.v(drive), .seen(seen_d));
+
+  initial begin
+    drive = 1.0;
+    #1;
+
+    `SVTEST_CHECK(seen_a > 0.00349 && seen_a < 0.00351,
+                  "A: fractional sum on a node inside an instance -> 0.0035")
+
+    `SVTEST_CHECK(node_b > 0.00349 && node_b < 0.00351,
+                  "B: same resolution at top level -> 0.0035")
+
+    `SVTEST_CHECK(seen_a > node_b - 0.000001 && seen_a < node_b + 0.000001,
+                  "A/B: instantiated and top-level nodes must agree")
+
+    `SVTEST_CHECK(seen_c > 0.00349 && seen_c < 0.00351,
+                  "C: node two levels down keeps RNM-scale current -> 0.0035")
+
+    `SVTEST_CHECK(seen_d > 3.6999 && seen_d < 3.7001,
+                  "D: 3.7 must not be rounded to an integer")
+
+    // Guard the specific corruption, not just the tolerance band: an integer
+    // slot reads a sub-1.0 resolution back as exactly 0.0.
+    `SVTEST_CHECK(seen_a != 0.0,
+                  "A: node must not collapse to an integer 0")
+
+    `SVTEST_PASSFAIL
+  end
+endmodule


### PR DESCRIPTION
# tests: nettype nets across module hierarchy, and in packages

Paired with [xezim-core#28](https://github.com/aionhw/xezim-core/pull/28), which implements the hierarchy resolution. Test 46 needs it; test 45 passes on current `main` as-is.

## 46_nettype_hierarchy.sv

Covers the gap you named when closing [#119](https://github.com/aionhw/xezim/issues/119) — nettype nets driven from several module **instances** through ports. Tests 38, 40 and 44 all resolve inside a single module, so none of them reach the topology user-defined nettypes exist for: a shared analog node with drivers and loads contributed by different blocks.

| | | |
|---|---|---|
| **A** | three instances driving one scalar node | `7.0` |
| **B** | a parent-level driver plus an instance driver | `24.0` |
| **C** | struct-valued node shared by a **nested** dut and a parent-level load, real parameters through `#()` overrides | `V=4.615385  R=76.923077  I=0.01` |

**Case C is the one that earns its place.** A nettype net crossing a port boundary is elaborated as a separate signal per port, joined by identity continuous assigns, so resolving them separately runs the resolution function once per port net and again over the results. That compounding is **invisible for an associative resolver** — a plain sum is right either way — so C resolves by Millman's theorem, where resolving twice does not equal resolving once. A and B alone would not catch it.

Reference values are hand-derived circuit results, so a resolver that is skipped, folded, or handed a truncated driver set cannot pass.

**Verified to fail without the fix:** against `main`, all five checks fail while single-module test 44 still passes — so it isolates hierarchy behaviour rather than re-testing what 44 covers.

## 45_package_nettype.sv

A nettype declared in a **package**, referenced both by bare name after a wildcard import and by the qualified `Pkg::name` form, plus two nettypes declared in one package.

The registration this covers landed in xezim-core#27, but nothing upstream exercises it — and a package is the idiomatic place to declare a nettype, since one used on both sides of a port connection has to be named identically in both modules. Before that registration, such a net was not classified as a net at all and a second driver failed with the generic *"Variable 'n' has multiple continuous drivers"*.

This one passes on current `main` with no code change; it is here so the behaviour stays pinned.

## Verification

Full suite **2258 / 0** with the paired core branch, interpreter and `--features jit`. Test 45 also confirmed green against unmodified `main`.

Beyond the compliance suite, the pair makes a UVM testbench able to drive a real-number model through module ports — a `uvm_test` pulling a virtual interface from `config_db`, programming a load resistance, and sampling the resolved node voltage:

```
rload=100.0  -> vnode=2.500000        rload=25.0   -> vnode=1.000000
rload=400.0  -> vnode=4.000000        rload=1000.0 -> vnode=4.545455
UVM_RNM_PASS      UVM_ERROR : 0
```

On current `main` that same testbench reports `vnode=0.000000` for all four. Worth noting it only became runnable at all after your #123 fix — the virtual-interface `config_db` round trip was aborting before that.
