### PR TITLE
Register fixed-size static class arrays under a shared name

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -5409,6 +5409,7 @@ impl Simulator {
                     || cd.array_properties.contains_key(pname)
                     || cd.array_nd_properties.contains_key(pname)
                     || cd.static_collections.iter().any(|(n, ..)| n == pname)
+                    || cd.static_fixed_arrays.iter().any(|(n, ..)| n == pname)
                 {
                     continue;
                 }
@@ -5440,6 +5441,27 @@ impl Simulator {
                         }
                         Some(UD::Queue { .. }) | Some(UD::Unsized(_)) => {
                             cd.static_collections.push((pname, false, w));
+                        }
+                        // Fixed-size static array reached through a typedef
+                        // (`typedef int arr_t[3]; static arr_t S;`) — same
+                        // shared-store treatment as the direct declaration
+                        // (see `static_fixed_arrays` in elaborate.rs).
+                        Some(UD::Expression { expr, .. }) => {
+                            if let Some(n) =
+                                super::elaborate::const_eval_i64_with_params(expr, Some(&params))
+                            {
+                                if n > 0 {
+                                    cd.static_fixed_arrays.push((pname, 0, n - 1, w));
+                                }
+                            }
+                        }
+                        Some(UD::Range { left, right, .. }) => {
+                            if let (Some(l), Some(r)) = (
+                                super::elaborate::const_eval_i64_with_params(left, Some(&params)),
+                                super::elaborate::const_eval_i64_with_params(right, Some(&params)),
+                            ) {
+                                cd.static_fixed_arrays.push((pname, l.min(r), l.max(r), w));
+                            }
                         }
                         _ => {}
                     }
@@ -11599,6 +11621,27 @@ impl Simulator {
                     .entry(name.clone())
                     .or_insert((0, 63, width));
                 self.set_queue_size(&name, 0);
+            }
+        }
+
+        // Fixed-size static array members (`static int S[3]`) share ONE store
+        // per class (§8.9), so — like the collections above — they register
+        // globally under the bare name rather than per-instance as
+        // `<handle>#name`. Bounds are real (not the 0..63 queue buffer), and
+        // every element is defaulted so an index read or `foreach` sees a
+        // populated range instead of x.
+        let static_fixed: Vec<(String, i64, i64, u32)> = self
+            .module
+            .classes
+            .values()
+            .flat_map(|c| c.static_fixed_arrays.iter().cloned())
+            .collect();
+        for (name, lo, hi, width) in static_fixed {
+            self.module.arrays.entry(name.clone()).or_insert((lo, hi, width));
+            for i in lo..=hi {
+                let elem = format!("{}[{}]", name, i);
+                self.widths.insert(elem.clone(), width);
+                self.signals.entry(elem).or_insert_with(|| Value::zero(width));
             }
         }
 
@@ -76992,6 +77035,12 @@ impl Simulator {
                 {
                     return None;
                 }
+                // A fixed-size STATIC array stores globally under its bare
+                // name, so its `[i]` element leaves are NOT reachable through
+                // the per-instance struct machinery either.
+                if cd.static_fixed_arrays.iter().any(|(n, ..)| n == prop) {
+                    return None;
+                }
                 if let Some(DataType::Struct(su)) = cd.property_types.get(prop) {
                     return Some(su.clone());
                 }
@@ -77809,6 +77858,9 @@ impl Simulator {
                 // too (§7.4.2) — route them to the collection paths, not
                 // the packed-select machinery.
                 || cd.static_collections.iter().any(|(n, _, _)| n == prop)
+                // A fixed-size static array indexes its unpacked dimension
+                // first as well — it is an array, just a globally-stored one.
+                || cd.static_fixed_arrays.iter().any(|(n, ..)| n == prop)
             {
                 return None;
             }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -13,6 +13,8 @@
 
 #[path = "classes/collection_of_handles_new.rs"]
 mod collection_of_handles_new;
+#[path = "classes/static_fixed_array_storage.rs"]
+mod static_fixed_array_storage;
 #[path = "classes/array_equality_class.rs"]
 mod array_equality_class;
 #[path = "classes/class_formal_typedef_widen.rs"]

--- a/tests/classes/static_fixed_array_storage.rs
+++ b/tests/classes/static_fixed_array_storage.rs
@@ -1,0 +1,159 @@
+//! §8.9: a fixed-size `static` array property in a class gets ONE shared
+//! store, like any other static member.
+//!
+//! Elaboration used to route only the *dynamic* static collections (queue,
+//! dynamic array, associative) into `static_collections`, and the whole
+//! `array_properties` registration was gated to non-statics — so a
+//! `static int S[3]` was registered nowhere at all and collapsed onto the
+//! plain scalar cell built for every property. That single wrong storage
+//! decision produced four symptoms at once (issue #126):
+//!
+//!   * `S[i]` read `x` — the index was a BIT select into a 32-bit scalar,
+//!   * writes through one handle were invisible through another (no sharing),
+//!   * `$size(S)` returned `32`, the collapsed scalar's WIDTH, not `3`,
+//!   * `foreach (S[i])` bound a single garbage element.
+//!
+//! Fixed-size static arrays now carry their constant bounds through
+//! `static_fixed_arrays` and are registered as one global array under the
+//! bare name at startup — the same shared-store treatment the static
+//! queue/assoc members already got.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+// ── the issue #126 repro ──────────────────────────────────────────────
+// A non-static `int M[3]` in the same class is the control: it stored and
+// read back correctly throughout, which is what isolated the bug to the
+// `static` path.
+
+const STATIC_FIXED_ARRAY_SRC: &str = r#"
+module top;
+  class C;
+    static int S[3];
+    int        M[3];
+
+    function void report_size();
+      $display("SIZE_S_%0d", $size(S));
+      $display("SIZE_M_%0d", $size(M));
+    endfunction
+  endclass
+
+  initial begin
+    C a = new();
+    C b = new();
+
+    a.S[0] = 10; a.S[1] = 20; a.S[2] = 30;
+    a.M[0] = 1;  a.M[1] = 2;  a.M[2] = 3;
+
+    $display("A_%0d_%0d_%0d", a.S[0], a.S[1], a.S[2]);
+    $display("M_%0d_%0d_%0d", a.M[0], a.M[1], a.M[2]);
+    // The point of `static`: b sees a's writes.
+    $display("B_%0d_%0d_%0d", b.S[0], b.S[1], b.S[2]);
+    a.report_size();
+
+    begin
+      int sum = 0;
+      foreach (a.S[i]) sum += a.S[i];
+      $display("SUM_%0d", sum);
+    end
+  end
+endmodule
+"#;
+
+#[test]
+fn test_static_fixed_array_shared_storage() {
+    let sim = simulate(STATIC_FIXED_ARRAY_SRC, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let has = |t: &str| msgs.iter().any(|m| m == t);
+
+    // Element reads land in real array storage, not a scalar bit-select.
+    assert!(has("A_10_20_30"), "static array element reads: {:?}", msgs);
+    // Control: the non-static member was never broken.
+    assert!(has("M_1_2_3"), "non-static control array: {:?}", msgs);
+    // §8.9 — one copy per class, shared across instances.
+    assert!(has("B_10_20_30"), "static array not shared across handles: {:?}", msgs);
+    // Array-query returns the SIZE, not the collapsed scalar's bit width.
+    assert!(has("SIZE_S_3"), "$size of static array: {:?}", msgs);
+    assert!(has("SIZE_M_3"), "$size of non-static array: {:?}", msgs);
+    // foreach walks all three elements, not one garbage one.
+    assert!(has("SUM_60"), "foreach over static array: {:?}", msgs);
+}
+
+// ── declaration forms that reach the same storage ─────────────────────
+// `[lo:hi]` ranges, parameter-sized dimensions, typedef-carried dims, a
+// narrow element type, inheritance, writes from a static method (no
+// `this`), and class-scoped `C::S[i]` access with no handle involved.
+
+const STATIC_FIXED_ARRAY_FORMS_SRC: &str = r#"
+module top;
+  parameter int N = 4;
+  typedef int arr_t[3];
+
+  class Base;
+    static int B[2];
+  endclass
+
+  class C extends Base;
+    static int   R[2:0];
+    static int   P[N];
+    static arr_t T;
+    static byte  W[2];
+
+    static function void bump();
+      R[1] = R[1] + 5;
+    endfunction
+  endclass
+
+  initial begin
+    C c1 = new();
+    C c2 = new();
+
+    c1.R[0] = 1; c1.R[1] = 2; c1.R[2] = 3;
+    c1.P[0] = 7; c1.P[3] = 9;
+    c1.T[1] = 42;
+    c1.W[0] = 8'hAB;
+    c1.B[0] = 99;
+
+    $display("R_%0d_%0d_%0d", c2.R[0], c2.R[1], c2.R[2]);
+    $display("P_%0d_%0d", c2.P[0], c2.P[3]);
+    $display("T_%0d", c2.T[1]);
+    $display("W_%0h", c2.W[0]);
+    $display("BASE_%0d", c2.B[0]);
+    $display("SIZES_%0d_%0d_%0d_%0d_%0d",
+             $size(C::R), $size(C::P), $size(C::T), $size(C::W), $size(C::B));
+
+    C::bump();
+    $display("BUMP_%0d", c2.R[1]);
+
+    C::R[2] = 77;
+    $display("SCOPED_%0d", c1.R[2]);
+  end
+endmodule
+"#;
+
+#[test]
+fn test_static_fixed_array_declaration_forms() {
+    let sim = simulate(STATIC_FIXED_ARRAY_FORMS_SRC, 200).expect("simulate failed");
+    let msgs = messages(&sim);
+    let has = |t: &str| msgs.iter().any(|m| m == t);
+
+    // `[2:0]` range form, shared across instances.
+    assert!(has("R_1_2_3"), "[lo:hi] static array: {:?}", msgs);
+    // Dimension sized by a parameter expression.
+    assert!(has("P_7_9"), "parameter-sized static array: {:?}", msgs);
+    // Dimensions carried by a typedef (classified at simulator startup, not
+    // in elaborate_class, so it is a genuinely separate registration path).
+    assert!(has("T_42"), "typedef-dims static array: {:?}", msgs);
+    // Sub-word element width must survive.
+    assert!(has("W_ab"), "byte-element static array: {:?}", msgs);
+    // A static array declared in a base class, reached through a subclass.
+    assert!(has("BASE_99"), "inherited static array: {:?}", msgs);
+    assert!(has("SIZES_3_4_3_2_2"), "$size across forms: {:?}", msgs);
+    // Write from a static method — no `this` handle in scope.
+    assert!(has("BUMP_7"), "write from static method: {:?}", msgs);
+    // Class-scoped write with no instance involved.
+    assert!(has("SCOPED_77"), "C::S[i] scoped write: {:?}", msgs);
+}


### PR DESCRIPTION

Runtime half of #126; the elaboration half is aionhw/xezim-core#29, which carries the full analysis. Requires the core pin bumped to that merge.

> **Draft until aionhw/xezim-core#29 merges.** This branch intentionally does
> not build from a bare clone yet: it consumes `static_fixed_arrays`, a field
> that only exists in that core PR, while `Cargo.toml` still pins `9eb0e40`.
> CI will fail on the stale pin — expected, not a broken branch. Once core
> merges I will bump both `rev = ...` fields to the merged SHA and amend it
> into this commit, matching the `Pin core <sha>; <dependent change>` convention
> in the history, so every commit stays independently buildable.
>
> It is opened now rather than after, because core#29 in isolation adds a field
> no code in that repo reads — the design question it asks (a separate bounds-
> carrying list, instead of `static_collections` or `array_properties`) is only
> answerable against this consumer, and all the tests and Verilator parity
> evidence live here.

Static members share one store per class (§8.9). Fixed-size static arrays now register **globally under their bare name** at startup rather than per-instance as `<handle>#name` — the same treatment the static queue and associative collections already get, right above this code. Bounds are the declared ones rather than the 0..63 queue buffer, and every element is defaulted so an index read or `foreach` sees a populated range instead of `x`.

Three call sites ask "is this property a static collection?" to choose between the collection paths and the per-instance packed-select / struct-leaf machinery. All three now count these arrays too:

- a fixed static array indexes its unpacked dimension first (§7.4.2), exactly like the dynamic collections, so it must not reach the packed bit-select path — that misrouting is what made `S[0]` a bit select in the first place;
- its `[i]` element leaves are not reachable per-instance, so the struct-member machinery must not claim them either.

The typedef-dims classifier (`classify_typedef_collection_properties`) gains the same two dimension arms as `elaborate_class`, so `typedef int arr_t[3]; static arr_t S;` reaches the same storage. This is a genuinely separate registration path: a typedef-typed property carries no declarator dims and recovers its shape from the typedef table at simulator startup.

### Testing

`tests/classes/static_fixed_array_storage.rs`, two tests:

- **the issue repro** — element reads, cross-handle sharing, `$size`, and `foreach`, with a non-static `int M[3]` in the same class as the control that was never broken;
- **declaration forms that reach this path** — `[lo:hi]`, parameter-sized `[N]`, typedef-carried dims, `byte` elements, a static array inherited from a base class, a write from a static method (no `this` in scope), and class-scoped `C::S[i]` access with no handle involved.

Every assertion was first confirmed against Verilator 5.050 as reference.

Full suite: **1887 passed**. The 7 failures are all `dpi_integration_tests` aborting at `cc failed`, which reproduces on a clean checkout too — building the DPI stubs `-shared` on macOS arm64 leaves the VPI symbols (`_vpi_get`, `_vpi_free_object`, …) undefined at link time, so it fails in `cc` before xezim runs. Unrelated to this change; needs `-Wl,-undefined,dynamic_lookup` on that platform.

Found 2 separate bugs, will file an issue later.
