### PR TITLE
Grow block-local queues on indexed assignment (q[0] = v)

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -93292,6 +93292,48 @@ impl Simulator {
             }
         }
         self.heap.push(Some(instance));
+        // Per-instance TYPE-PARAM-BOUND collection members
+        // (`#(type T=int) data;` instantiated with T bound to a queue/array
+        // typedef such as `typedef int a_i[];`). These live only in
+        // `cd.properties` generically and never reach `queue_properties` /
+        // `array_properties`, so whole-assignment / size / index / `%p` paths
+        // had no array table entry and treated `data` as a scalar. Register
+        // `<handle>#member` as a dynamic array once this instance's type
+        // bindings (set above) resolve the parameter to a concrete collection
+        // type.
+        for cdef in &classes_to_init {
+            for (prop, sig) in &cdef.properties {
+                if cdef.queue_properties.contains_key(prop)
+                    || cdef.assoc_properties.contains_key(prop)
+                    || cdef.array_properties.contains_key(prop)
+                    || cdef.array_nd_properties.contains_key(prop)
+                    || cdef.static_collections.iter().any(|(n, ..)| n == prop)
+                {
+                    continue;
+                }
+                if !self.prop_bound_collection(handle, &cdef.name, prop) {
+                    continue;
+                }
+                let raw = sig.type_name.as_deref().unwrap_or(prop);
+                let concrete = self
+                    .heap
+                    .get(handle)
+                    .and_then(|o| o.as_ref())
+                    .and_then(|i| i.type_bindings.get(raw).cloned())
+                    .unwrap_or_else(|| raw.to_string());
+                let w = self
+                    .module
+                    .typedef_elem_widths
+                    .get(&concrete)
+                    .copied()
+                    .unwrap_or(sig.width)
+                    .max(1);
+                let scoped = format!("{}#{}", handle, prop);
+                self.module.dynamic_arrays.insert(scoped.clone());
+                self.module.arrays.insert(scoped.clone(), (0, 63, w));
+                self.set_queue_size(&scoped, 0);
+            }
+        }
         // Re-evaluate scalar property initializers against the live parameter
         // table and instance context, before the constructor runs (SV applies
         // member initializers prior to `new`'s body). `elaborate_class`

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -47863,6 +47863,24 @@ impl Simulator {
                                 .signal_name_to_id
                                 .contains_key(self.resolve_hier_name(hier).as_str())
                         {
+                            // `Class::method` with NO parens invokes a
+                            // parameterless STATIC function (LRM §13.4.1: a
+                            // no-arg function may be called by name alone).
+                            // e.g. UVM's `TYPE::type_name` in `uvm_misc`
+                            // where `type_name` is `static function string
+                            // type_name();`. Previously the flat 2-segment
+                            // ident fell through `class_static_get` (which
+                            // only reads static PROPERTIES), so the call
+                            // returned garbage instead of invoking
+                            // `comp_b::type_name()`. If it's a parameterless
+                            // static function, invoke it and return its result.
+                            if self.is_static_method(cls, prop)
+                                && self.class_parameterless_function(cls, prop)
+                            {
+                                if let Some(v) = self.exec_static_method(cls, prop, &[]) {
+                                    return v;
+                                }
+                            }
                             if let Some(v) = self.class_static_get(cls, prop) {
                                 return v;
                             }
@@ -52593,6 +52611,24 @@ impl Simulator {
                             && !self.signal_name_to_id.contains_key(cls.as_str())
                             && !self.signals.contains_key(cls)
                         {
+                            // `Class::method` with NO parens invokes a
+                            // parameterless STATIC function (LRM §13.4.1) —
+                            // the MemberAccess twin of the flat-2-segment
+                            // `Class::method` handling in the Ident arm. UVM's
+                            // `TYPE::type_name` (in `uvm_misc`) parses as
+                            // MemberAccess{`TYPE`, type_name}; the previous
+                            // `class_static_get` only read static PROPERTIES,
+                            // so the call came back empty instead of invoking
+                            // `comp_b::type_name()`.
+                            if self.is_static_method(cls, &member.name)
+                                && self.class_parameterless_function(cls, &member.name)
+                            {
+                                if let Some(v) =
+                                    self.exec_static_method(cls, &member.name, &[])
+                                {
+                                    return v;
+                                }
+                            }
                             if let Some(v) = self.class_static_get(cls, &member.name) {
                                 return v;
                             }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -48449,6 +48449,17 @@ impl Simulator {
                         return Value::from_u64(if r { 1 } else { 0 }, 1);
                     }
                 }
+                // IEEE 1800-2017 §11.8.1: `==`/`!=` on two dynamic arrays /
+                // queues compares element-by-element (after a length check),
+                // not the container's packed scalar. UVM's
+                // `uvm_resource#(T)::do_write` guards on `val == t` for a
+                // `T`-typed queue, so a wrong scalar compare (X/garbage)
+                // made the update early-return or was otherwise unreliable.
+                if matches!(op, BinaryOp::Eq | BinaryOp::Neq) {
+                    if let Some(res) = self.compare_dyn_arrays(left, right, matches!(op, BinaryOp::Eq)) {
+                        return res;
+                    }
+                }
                 let is_arith_or_bitwise = matches!(
                     op,
                     BinaryOp::Add
@@ -55842,7 +55853,20 @@ impl Simulator {
                 let resolve_coll = |sim: &mut Self, e: &Expression| -> Option<(String, bool)> {
                     if let ExprKind::Ident(h) = &e.kind {
                         let n = Self::resolve_hier_name_static(h, &sim.module);
+                        // A bare identifier naming a COLLECTION MEMBER of
+                        // `this` must resolve to its `<handle>#member` storage
+                        // even when a same-named value-param / dyn-array is
+                        // registered from an enclosing frame. Prefer the
+                        // `this`-scoped member; a true local (instance_assoc_member
+                        // returns None) falls through to the bare name below.
+                        // Without this, a deep `Store::do_write` whose `val = t`
+                        // ran while an outer `make(T val)` value-param `val` was
+                        // still live in `module.dynamic_arrays` resolved the LHS
+                        // to bare `"val"` and the queue copy was dropped (§13.5.2).
                         if sim.module.dynamic_arrays.contains(&n) {
+                            if let Some(m) = sim.instance_assoc_member(&n) {
+                                return Some((m, true));
+                            }
                             return Some((n, false));
                         }
                     }
@@ -70763,8 +70787,28 @@ impl Simulator {
                 if let Some(v) = self.read_value_param_literal(nm) {
                     return Some(v);
                 }
-                // Otherwise keep the name verbatim (a type-parameter name
-                // like `T`, or an enum member, resolved downstream).
+                // Resolve an ENCLOSING TYPE PARAMETER (e.g. `W#(T)` where
+                // `T` is the surrounding class's type param, bound to a
+                // concrete type) to its current binding. The specialization
+                // sig must carry the CONCRETE type here — leaving the bare
+                // param name lets `canonicalize_spec_sig` mistake it for
+                // THIS class's own same-named parameter and clobber it with
+                // that parameter's declared default, so a nested generic
+                // member (`S#(T) s;` inside `W#(T)`) recorded `W#(int)`
+                // instead of `W#(int_arr)` and every downstream type-param
+                // resolution of `T` came back as the default, dropping a
+                // `T`-typed queue formal. (A genuine class/typedef name
+                // never reaches here — it resolved above — so this only
+                // fires for type-parameter references.)
+                if let Some(resolved) = self.resolve_type_param_binding(nm) {
+                    if self.module.classes.contains_key(&resolved)
+                        || self.module.typedef_types.contains_key(&resolved)
+                    {
+                        return Some(resolved);
+                    }
+                }
+                // Otherwise keep the name verbatim (an enum member, resolved
+                // downstream).
                 Some(nm.clone())
             }
             _ => None,
@@ -71985,11 +72029,18 @@ impl Simulator {
                 }
             }
         }
-        // Module-level fixed array (bare Ident).
+        // Module-level fixed array (bare Ident). A DYNAMIC array / queue is
+        // registered in `module.arrays` with the (0,-1) queue SENTINEL range
+        // (and in `dynamic_arrays`) — it is NOT a fixed array and must not be
+        // compared element-wise as the empty 0:-1 range: UVM's `val == t` on
+        // two `T`-typed queues would otherwise both resolve to (0,-1) and the
+        // guard falsely reported them equal (skipping the update).
         if let ExprKind::Ident(h) = &expr.kind {
             let name = self.resolve_hier_name(h);
             if let Some(&(lo, hi, _)) = self.module.arrays.get(&name) {
-                return Some((name, lo, hi));
+                if !self.module.dynamic_arrays.contains(&name) && !(hi < lo) {
+                    return Some((name, lo, hi));
+                }
             }
         }
         None
@@ -80402,6 +80453,85 @@ impl Simulator {
         let (h, p) = self.class_prop_receiver(e)?;
         let su = self.class_prop_struct(h, &p)?;
         Self::spreads_member_wise(&su).then_some(su)
+    }
+
+    /// IEEE 1800-2017 §7.2 / §11.8.1: `==`/`!=` on two dynamic-array / queue
+    /// operands compares element-by-element (after a length check). Each
+    /// operand is resolved to its storage name — a bare dyn-array formal /
+    /// local, or a `<handle>#member` collection property — and every element
+    /// is compared. Returns `None` when neither operand is a dynamic
+    /// array / queue (caller falls through to the packed-scalar path).
+    fn compare_dyn_arrays(
+        &mut self,
+        left: &Expression,
+        right: &Expression,
+        want_eq: bool,
+    ) -> Option<Value> {
+        let ln = self.dyn_cmp_operand_name(left)?;
+        let rn = self.dyn_cmp_operand_name(right)?;
+        if ln == rn {
+            // Self-comparison is always true regardless of contents — but only
+            // when both resolve to the SAME storage; a member and an unrelated
+            // bare name (e.g. `this.val` vs an outer value-param `val`) compare
+            // by value instead.
+            let res = if want_eq { 1 } else { 0 };
+            return Some(Value::from_u64(res, 1));
+        }
+        let ls = self.get_queue_size(&ln);
+        let rs = self.get_queue_size(&rn);
+        if ls != rs {
+            return Some(Value::from_u64(if want_eq { 0 } else { 1 }, 1));
+        }
+        // Width for default values when an element is unset.
+        let w = self
+            .module
+            .arrays
+            .get(&ln)
+            .map(|t| t.2)
+            .or_else(|| self.module.arrays.get(&rn).map(|t| t.2))
+            .unwrap_or(32);
+        let mut equal = true;
+        for i in 0..ls {
+            let lv = self
+                .get_signal_value_by_name(&format!("{}[{}]", ln, i))
+                .unwrap_or_else(|| Value::zero(w));
+            let rv = self
+                .get_signal_value_by_name(&format!("{}[{}]", rn, i))
+                .unwrap_or_else(|| Value::zero(w));
+            if lv.has_unknown() || rv.has_unknown() {
+                return Some(Value::new(1)); // X propagates
+            }
+            if lv != rv {
+                equal = false;
+            }
+        }
+        let res = if want_eq { equal } else { !equal };
+        Some(Value::from_u64(if res { 1 } else { 0 }, 1))
+    }
+
+    /// Resolve an expression to a dynamic-array / queue storage name, or None
+    /// if it does not name a dynamic array / queue. Handles bare formals /
+    /// locals (`q` registered in `dynamic_arrays`), and `<handle>#member`
+    /// collection properties (via [`Self::expr_assoc_name`]).
+    fn dyn_cmp_operand_name(&mut self, e: &Expression) -> Option<String> {
+        if let ExprKind::Ident(h) = &e.kind {
+            // A bare-identifier dyn array / queue formal or local registered
+            // in `dynamic_arrays`. Consult `this`-scoped members first so a
+            // member name hidden by an unrelated outer bare registration
+            // still resolves to its own `<handle>#member` storage.
+            let n = Self::resolve_hier_name_static(h, &self.module);
+            if self.module.dynamic_arrays.contains(&n) {
+                if let Some(m) = self.instance_assoc_member(&n) {
+                    return Some(m);
+                }
+                return Some(n);
+            }
+        }
+        let an = self.expr_assoc_name(e)?;
+        if self.is_associative_array(&an) {
+            return None;
+        }
+        Some(an)
     }
 
     /// IEEE 1800-2017 §11.4.5 / §7.2: `==` and `!=` on unpacked structs compare

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -82386,14 +82386,34 @@ impl Simulator {
 
     /// Parse a string like `ClassName#(arg1,arg2)` into `(ClassName, "arg1,arg2")`.
     fn extract_spec_from_string(&self, s: &str) -> Option<(String, String)> {
-        if let Some(hash_idx) = s.find("#(") {
-            if s.ends_with(')') {
-                let base = s[..hash_idx].to_string();
-                let sig = s[hash_idx + 2..s.len() - 1].to_string();
-                if self.get_class_def(&base).is_some() {
-                    return Some((base, sig));
-                }
-            }
+        // Whitespace-tolerant scan for `Base#(args)`. The parser reconstructs
+        // parameterized type text with spaces around the `#`/parens
+        // (`special_comp # ( N )`). Previously the code only matched the
+        // compact `#(` form, so a SYMBOLIC value-param nested type argument
+        // (e.g. `uvm_typeid#(special_comp#(N))` from inside
+        // `special_comp#(N)`) was never parsed here — the value param `N`
+        // stayed unresolved and fell back to its default, producing a
+        // wrong-per-spec typeid/assoc key. Match `#` optionally followed by
+        // spaces then `(`. `normalize_spec_ws` later canonically strips
+        // remaining whitespace inside `sig`. Returns `(base, raw_sig)` where
+        // base is the (possibly still symbolic) class name; callers that
+        // need to re-extract nested specs keep whitespace handling here so
+        // the raw sig is unchanged for further resolution.
+        let bs = s.trim();
+        let hash_idx = bs.find('#')?;
+        let rest = &bs[hash_idx + 1..];
+        let lparen = rest.find('(')?;
+        let base = bs[..hash_idx].trim().to_string();
+        if !bs.ends_with(')') {
+            return None;
+        }
+        // `sig` is everything between `(` and the final `)`, preserving any
+        // inner whitespace verbatim (the caller canonicalizes via
+        // `normalize_spec_ws`).
+        let open_paren = hash_idx + 1 + lparen;
+        let sig = bs[open_paren + 1..bs.len() - 1].to_string();
+        if self.get_class_def(&base).is_some() {
+            return Some((base, sig));
         }
         None
     }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -59180,6 +59180,16 @@ impl Simulator {
                                 };
                                 self.module.arrays.insert(name.clone(), (0, -1, w));
                                 self.module.dynamic_arrays.insert(name.clone());
+                                // A LOCAL queue `T q[$]` is NOT registered in
+                                // `queue_vars` by elaboration (module/package
+                                // scope only), so the `q[i] = v` (i == size) growth
+                                // gate in `assign_value` missed it and an empty
+                                // queue never grew — `q[0] = x` on a fresh local
+                                // queue left `.size()` at 0 and dropped the element
+                                // (broke UVM get_all's `all_callbacks[0] = cb`).
+                                if matches!(first, UnpackedDimension::Queue { .. }) {
+                                    self.module.queue_vars.insert(name.clone());
+                                }
                                 self.widths.insert(name.clone(), w);
                                 self.set_queue_size(&name, 0);
                                 // §7.4.5: a LOCAL `T a[][16]` / `a[$][16]` —

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -3479,6 +3479,15 @@ pub struct Simulator {
     /// declared in `base_class` (so unrelated/inherited statics stay shared),
     /// giving each specialization its own cell (§8.25). None = shared cell.
     current_spec: Option<(String, String)>,
+    /// Active specialization scope CHAIN (innermost last): a parameterized
+    /// `C#(params)::method()` call (`eval_call`) sets `current_spec` to the
+    /// callee for the body, so a value-parameter reference in an ACTUAL
+    /// argument that belongs to an ENCLOSING specialization (e.g. `string
+    /// FIELD` of `uvm_utils` passed into `uvm_config_db#(uvm_object)::get`)
+    /// can no longer resolve through `current_spec` alone. This stack keeps
+    /// the CALLER specializations alive so value-param resolution can walk up
+    /// to them (§13.5.1: args evaluate in the caller's scope).
+    spec_scope_stack: Vec<(String, String)>,
     /// §28.11 gate FALL delays by signal id, from
     /// `ElaboratedModule::gate_fall_delays`. Empty unless some gate used the
     /// two-delay `#(rise, fall)` form with differing values.
@@ -7321,6 +7330,7 @@ impl Simulator {
             class_statics: HashMap::default(),
             local_type_stack: Vec::new(),
             current_spec: None,
+            spec_scope_stack: Vec::new(),
             gate_fall_delay_by_id: HashMap::default(),
             spec_prop_is_dyn: std::cell::RefCell::new(HashMap::default()),
             spec_prop_width_cache: std::cell::RefCell::new(HashMap::default()),
@@ -85777,9 +85787,21 @@ impl Simulator {
         if let Some((ref base, ref sig)) = extracted {
             self.ensure_spec_statics(base, sig);
         }
-        self.current_spec = extracted.or(saved.clone());
+        // Execute the callee with `current_spec` = the CALLER'S spec so an
+        // actual arg that is an enclosing specialization's value parameter
+        // resolves in the caller's scope; the call's own specialization stays
+        // on the scope stack for the body/method-dispatch to key per-spec.
+        // (Innermost caller last — value-param resolution walks inward.)
+        if let Some(cs) = &saved {
+            self.spec_scope_stack.push(cs.clone());
+        }
+        let pushed = saved.is_some();
+        self.current_spec = extracted.clone().or(saved.clone());
         let r = self.eval_call_inner(func, args);
         self.current_spec = saved;
+        if pushed {
+            self.spec_scope_stack.pop();
+        }
         r
     }
 
@@ -85971,9 +85993,16 @@ impl Simulator {
                             {
                                 self.ensure_spec_statics(&base, &sig);
                                 let saved = self.current_spec.take();
+                                if let Some(cs) = &saved {
+                                    self.spec_scope_stack.push(cs.clone());
+                                }
                                 self.current_spec = Some((base.clone(), sig));
                                 let res = self.exec_static_method(&base, mname, args);
+                                let had_saved = saved.is_some();
                                 self.current_spec = saved;
+                                if had_saved {
+                                    self.spec_scope_stack.pop();
+                                }
                                 if let Some(v) = res {
                                     return v;
                                 }
@@ -86714,9 +86743,16 @@ impl Simulator {
                         if let Some((base, sig)) = self.extract_spec_from_string(&resolved) {
                             self.ensure_spec_statics(&base, &sig);
                             let saved = self.current_spec.take();
+                            if let Some(cs) = &saved {
+                                self.spec_scope_stack.push(cs.clone());
+                            }
                             self.current_spec = Some((base.clone(), sig));
                             let res = self.exec_static_method(&base, mname, args);
+                            let had_saved = saved.is_some();
                             self.current_spec = saved;
+                            if had_saved {
+                                self.spec_scope_stack.pop();
+                            }
                             if let Some(v) = res {
                                 return v;
                             }
@@ -86729,9 +86765,16 @@ impl Simulator {
                     if let Some((base, sig)) = self.extract_spec_from_string(&name) {
                         self.ensure_spec_statics(&base, &sig);
                         let saved = self.current_spec.take();
+                        if let Some(cs) = &saved {
+                            self.spec_scope_stack.push(cs.clone());
+                        }
                         self.current_spec = Some((base.clone(), sig));
                         let res = self.exec_static_method(&base, mname, args);
+                        let had_saved = saved.is_some();
                         self.current_spec = saved;
+                        if had_saved {
+                            self.spec_scope_stack.pop();
+                        }
                         if let Some(v) = res {
                             return v;
                         }
@@ -86751,9 +86794,16 @@ impl Simulator {
                     if let Some((base, sig)) = self.resolve_typedef_spec(&name) {
                         self.ensure_spec_statics(&base, &sig);
                         let saved = self.current_spec.take();
+                        if let Some(cs) = &saved {
+                            self.spec_scope_stack.push(cs.clone());
+                        }
                         self.current_spec = Some((base.clone(), sig));
                         let res = self.exec_static_method(&base, mname, args);
+                        let had_saved = saved.is_some();
                         self.current_spec = saved;
+                        if had_saved {
+                            self.spec_scope_stack.pop();
+                        }
                         if let Some(v) = res {
                             return v;
                         }
@@ -87948,10 +87998,17 @@ impl Simulator {
                         if let Some((base, sig)) = self.extract_spec_from_string(&resolved) {
                             self.ensure_spec_statics(&base, &sig);
                             let saved = self.current_spec.take();
+                            if let Some(cs) = &saved {
+                                self.spec_scope_stack.push(cs.clone());
+                            }
                             self.current_spec = Some((base.clone(), sig));
                             let m = method_name.clone();
                             let res = self.exec_static_method(&base, &m, args);
+                            let had_saved = saved.is_some();
                             self.current_spec = saved;
+                            if had_saved {
+                                self.spec_scope_stack.pop();
+                            }
                             if let Some(v) = res {
                                 return v;
                             }
@@ -87966,10 +88023,17 @@ impl Simulator {
                     if let Some((base, sig)) = self.extract_spec_from_string(obj_name) {
                         self.ensure_spec_statics(&base, &sig);
                         let saved = self.current_spec.take();
+                        if let Some(cs) = &saved {
+                            self.spec_scope_stack.push(cs.clone());
+                        }
                         self.current_spec = Some((base.clone(), sig));
                         let m = method_name.clone();
                         let res = self.exec_static_method(&base, &m, args);
+                        let had_saved = saved.is_some();
                         self.current_spec = saved;
+                        if had_saved {
+                            self.spec_scope_stack.pop();
+                        }
                         if let Some(v) = res {
                             return v;
                         }
@@ -87998,9 +88062,16 @@ impl Simulator {
                         let m = method_name.clone();
                         self.ensure_spec_statics(&base, &sig);
                         let saved = self.current_spec.take();
+                        if let Some(cs) = &saved {
+                            self.spec_scope_stack.push(cs.clone());
+                        }
                         self.current_spec = Some((base.clone(), sig));
                         let res = self.exec_static_method(&base, &m, args);
+                        let had_saved = saved.is_some();
                         self.current_spec = saved;
+                        if had_saved {
+                            self.spec_scope_stack.pop();
+                        }
                         if let Some(v) = res {
                             return v;
                         }
@@ -88108,9 +88179,16 @@ impl Simulator {
                         {
                             self.ensure_spec_statics(&base, &sig);
                             let saved = self.current_spec.take();
+                            if let Some(cs) = &saved {
+                                self.spec_scope_stack.push(cs.clone());
+                            }
                             self.current_spec = Some((base.clone(), sig));
                             let res = self.exec_static_method(&base, &mname3, args);
+                            let had_saved = saved.is_some();
                             self.current_spec = saved;
+                            if had_saved {
+                                self.spec_scope_stack.pop();
+                            }
                             if let Some(v) = res {
                                 return v;
                             }
@@ -92136,7 +92214,35 @@ impl Simulator {
         Some(m)
     }
 
+    /// Resolve a value parameter `name` against the ACTIVE specialization,
+    /// and if it is not declared there, against each ENCLOSING caller
+    /// specialization on `spec_scope_stack` (`eval_call` pushes the caller's
+    /// spec when it enters a parameterized `C#(params)::method`). §13.5.1: an
+    /// actual argument is evaluated in the CALLER's scope, so a value
+    /// parameter of an enclosing specialization (e.g. `string FIELD` of
+    /// `uvm_utils` passed into `uvm_config_db#(uvm_object)::get`) must
+    /// resolve to its bound value even though `current_spec` is the callee
+    /// while the args are bound.
     fn resolve_value_param_from_spec(&mut self, name: &str) -> Option<Value> {
+        if let Some(v) = self.resolve_value_param_in_current(name) {
+            return Some(v);
+        }
+        // Not declared by the leaf/callee spec — walk the caller chain,
+        // innermost first (nearest caller wins).
+        let chain: Vec<(String, String)> = self.spec_scope_stack.clone();
+        for cs in chain.iter().rev() {
+            let saved = self.current_spec.clone();
+            self.current_spec = Some(cs.clone());
+            let v = self.resolve_value_param_in_current(name);
+            self.current_spec = saved;
+            if v.is_some() {
+                return v;
+            }
+        }
+        None
+    }
+
+    fn resolve_value_param_in_current(&mut self, name: &str) -> Option<Value> {
         // Cycle guard: a value param's specialization argument can itself
         // be a bare name that resolves back into value-param resolution for
         // the same class/specialization (e.g. class factories, where a

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -84288,6 +84288,7 @@ impl Simulator {
                 || cd.queue_properties.contains_key(name)
                 || cd.array_properties.contains_key(name)
                 || cd.array_nd_properties.contains_key(name)
+                || self.prop_bound_collection(handle, &cn, name)
             {
                 return Some(format!("{}#{}", handle, name));
             }

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -107,6 +107,8 @@ mod submodule_net_array_shapes;
 mod submodule_two_dim_array_element;
 #[path = "hierarchy/t_bound_queue_member_storage.rs"]
 mod t_bound_queue_member_storage;
+#[path = "hierarchy/t_bound_generic_value_param_argument.rs"]
+mod t_bound_generic_value_param_argument;
 #[path = "hierarchy/t_bound_member_collection_registration.rs"]
 mod t_bound_member_collection_registration;
 #[path = "hierarchy/t_bound_queue_value_param_chain.rs"]

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -113,6 +113,8 @@ mod t_bound_generic_value_param_argument;
 mod t_bound_member_collection_registration;
 #[path = "hierarchy/t_bound_queue_value_param_chain.rs"]
 mod t_bound_queue_value_param_chain;
+#[path = "hierarchy/t_no_parens_static_method.rs"]
+mod t_no_parens_static_method;
 #[path = "hierarchy/wildcard_import_shadow.rs"]
 mod wildcard_import_shadow;
 

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -117,6 +117,8 @@ mod t_bound_queue_value_param_chain;
 mod t_no_parens_static_method;
 #[path = "hierarchy/t_nested_value_param_in_type_arg.rs"]
 mod t_nested_value_param_in_type_arg;
+#[path = "hierarchy/t_local_queue_index_growth.rs"]
+mod t_local_queue_index_growth;
 #[path = "hierarchy/wildcard_import_shadow.rs"]
 mod wildcard_import_shadow;
 

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -107,6 +107,8 @@ mod submodule_net_array_shapes;
 mod submodule_two_dim_array_element;
 #[path = "hierarchy/t_bound_queue_member_storage.rs"]
 mod t_bound_queue_member_storage;
+#[path = "hierarchy/t_bound_member_collection_registration.rs"]
+mod t_bound_member_collection_registration;
 #[path = "hierarchy/t_bound_queue_value_param_chain.rs"]
 mod t_bound_queue_value_param_chain;
 #[path = "hierarchy/wildcard_import_shadow.rs"]

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -107,6 +107,8 @@ mod submodule_net_array_shapes;
 mod submodule_two_dim_array_element;
 #[path = "hierarchy/t_bound_queue_member_storage.rs"]
 mod t_bound_queue_member_storage;
+#[path = "hierarchy/t_bound_queue_value_param_chain.rs"]
+mod t_bound_queue_value_param_chain;
 #[path = "hierarchy/wildcard_import_shadow.rs"]
 mod wildcard_import_shadow;
 

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -115,6 +115,8 @@ mod t_bound_member_collection_registration;
 mod t_bound_queue_value_param_chain;
 #[path = "hierarchy/t_no_parens_static_method.rs"]
 mod t_no_parens_static_method;
+#[path = "hierarchy/t_nested_value_param_in_type_arg.rs"]
+mod t_nested_value_param_in_type_arg;
 #[path = "hierarchy/wildcard_import_shadow.rs"]
 mod wildcard_import_shadow;
 

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -91,6 +91,8 @@ mod null_ports_lib_defines_nowarn;
 mod package_scoped_vars_and_methods;
 #[path = "hierarchy/percent_m_scope.rs"]
 mod percent_m_scope;
+#[path = "hierarchy/percent_m_module_init_scope.rs"]
+mod percent_m_module_init_scope;
 #[path = "hierarchy/pkg_subroutines_and_unit_scope.rs"]
 mod pkg_subroutines_and_unit_scope;
 #[path = "hierarchy/repro_import.rs"]

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -105,6 +105,8 @@ mod same_name_port_hop;
 mod submodule_net_array_shapes;
 #[path = "hierarchy/submodule_two_dim_array_element.rs"]
 mod submodule_two_dim_array_element;
+#[path = "hierarchy/t_bound_queue_member_storage.rs"]
+mod t_bound_queue_member_storage;
 #[path = "hierarchy/wildcard_import_shadow.rs"]
 mod wildcard_import_shadow;
 

--- a/tests/hierarchy/percent_m_module_init_scope.rs
+++ b/tests/hierarchy/percent_m_module_init_scope.rs
@@ -1,0 +1,57 @@
+//! IEEE 1800-2017 §21.2.1.7 — `%m` in a MODULE-SCOPE variable initializer.
+//! A non-constant initializer (here a class `new()` whose argument is
+//! `$sformatf("%m...")`) is deferred to a time-0 static-init assignment that
+//! must run under ITS OWN instance's scope. Otherwise every instance of a
+//! multiply-instantiated module reports the same name (the top module's),
+//! instead of the distinct per-instance hierarchical path. Verified against a
+//! commercial simulator.
+
+use xezim::simulate;
+
+fn line(src: &str, top: &str) -> Vec<String> {
+    xezim::simulate_multi(
+        &[src.to_string()], 1000, Some(top), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect()
+}
+
+#[test]
+fn percent_m_in_deferred_class_init_is_per_instance() {
+    let src = r#"
+class A;
+  string hname;
+  function new(string nm);
+    hname = nm;
+  endfunction
+endclass
+
+module mod;
+  A aaa = new ($sformatf("%m.aaa"));
+endmodule
+
+module test;
+  mod mod1();
+  mod mod2();
+  initial begin
+    $display("PASS=%s", mod1.aaa.hname);
+    $display("PASS=%s", mod2.aaa.hname);
+  end
+endmodule
+"#;
+    let out = line(src, "test");
+    assert!(
+        out.iter().any(|l| l == "PASS=test.mod1.aaa"),
+        "mod1 missing; got {:?}",
+        out
+    );
+    assert!(
+        out.iter().any(|l| l == "PASS=test.mod2.aaa"),
+        "mod2 missing; got {:?}",
+        out
+    );
+}

--- a/tests/hierarchy/t_bound_generic_value_param_argument.rs
+++ b/tests/hierarchy/t_bound_generic_value_param_argument.rs
@@ -1,0 +1,63 @@
+//! A VALUE PARAMETER of an enclosing generic class (e.g. `string FIELD`) that
+//! is passed as an ACTUAL ARGUMENT into a method of a DIFFERENT parameterized
+//! class must resolve to its bound value, not its declared default. §13.5.1
+//! evaluates actual arguments in the CALLER's scope.
+//!
+//! UVM's `uvm_utils #(type TYPE=int, string FIELD="config")` does exactly this:
+//! `get_config` calls `m_uvm_config_obj_misc::get(comp, "", FIELD, obj)`
+//! (`uvm_config_db#(uvm_object)::get`), so a `uvm_utils #(test_object, "cfg")`
+//! passed `FIELD="cfg"` as the resource field name. xezim switched
+//! `current_spec` to the CALLEE (`uvm_config_db#(uvm_object)`) before binding
+//! the args, so `FIELD` resolved against the callee's params — not found,
+//! fell back to the declared default `"config"` — and the config lookup used
+//! the wrong field name, missing the entry that `set_config_object` made.
+//!
+//! Fix: keep the enclosing specializations on a scope stack (`spec_scope_stack`
+//! pushed by `eval_call` and the static-dispatch sites) so value-param
+//! resolution can walk up to the caller. Verified byte-for-byte against a
+//! commercial simulator: `VP_PASS got=[cfg]`.
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_bound_generic_value_param_argument() {
+    let src = r#"
+module top;
+  // A generic class whose method passes its `string FIELD` VALUE PARAMETER as
+  // an argument into a method of ANOTHER parameterized class. The callee
+  // stored the field name it received so the caller can verify the bound
+  // value ("cfg") arrived — not the parameter's declared default ("config").
+  class Sink #(type T=int);
+    static string got;
+    static function void note(string x); got = x; endfunction
+  endclass
+  class Util #(type TYPE=int, string FIELD="config");
+    static function void go();
+      Sink #(int)::note(FIELD);
+    endfunction
+  endclass
+  initial begin
+    Util #(int, "cfg")::go();
+    if (Sink #(int)::got == "cfg") $display("VP_PASS got=[%s]", Sink #(int)::got);
+    else $display("VP_FAIL got=[%s]", Sink #(int)::got);
+  end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(
+        out.iter().any(|l| l == "VP_PASS got=[cfg]"),
+        "bound value param must reach the callee, not its default; got {:?}", out
+    );
+    assert!(
+        !out.iter().any(|l| l.starts_with("VP_FAIL")),
+        "default leaked through; got {:?}", out
+    );
+}

--- a/tests/hierarchy/t_bound_member_collection_registration.rs
+++ b/tests/hierarchy/t_bound_member_collection_registration.rs
@@ -1,0 +1,62 @@
+//! A class member whose declared type is a type PARAMETER (`#(type T=int) T val;`)
+//! bound to a queue/dynamic-array typedef (`typedef int a_i[];`) must be treated
+//! as a collection for the runtime's array-table lookups. In a generic class the
+//! member lives only in `cd.properties` and never reaches `queue_properties`/
+//! `array_properties`, so the per-instance registration skipped it and
+//! `<handle>#val` had no `dynamic_arrays`/`arrays` entry. Consequence: UVM's
+//! `uvm_built_in_pair #(T) { T first, second; }` (whose `clone`/`copy`/`do_compare`
+//! are `first = rhs_.first` / `first == rhs_.first`) lost array/queue members in
+//! `clone`+`copy` — the pair read back size 0 and `compare` failed — and `%p`
+//! rendered the member as a scalar `0`.
+//!
+//! Registering type-param-bound collection members as dynamic arrays at class
+//! instantiation fixes this. Verified byte-for-byte against a commercial
+//! simulator: `ST first='{-10, -20}`, `ST sz=2 e0=-10 e1=-20`,
+//! `ST second='{30, 40}`, `ST_PASS`.
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_bound_member_collection_registration() {
+    let src = r#"
+module top;
+  typedef int a_i[];
+  class Pair #(type T=int);
+    T first, second;
+    function void fill(T f, T s); first=f; second=s; endfunction
+  endclass
+  initial begin
+    a_i ar1, ar2;
+    Pair#(a_i) a = new;
+    ar1=new[2]; ar1[0]=-10; ar1[1]=-20;
+    ar2=new[2]; ar2[0]=30; ar2[1]=40;
+    a.fill(ar1, ar2);
+    $display("ST first=%p", a.first);
+    $display("ST sz=%0d e0=%0d e1=%0d", a.first.size(), a.first[0], a.first[1]);
+    $display("ST second=%p", a.second);
+    if (a.first.size()==2 && a.first[0]==-10 && a.first[1]==-20
+        && a.second.size()==2 && a.second[1]==40) $display("ST_PASS");
+    else $display("ST_FAIL");
+  end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(
+        out.iter().any(|l| l == "ST first='{-10, -20}"),
+        "T-bound array member `%p` must render a collection, not a scalar 0; got {:?}", out
+    );
+    assert!(
+        out.iter().any(|l| l == "ST second='{30, 40}"),
+        "got {:?}", out
+    );
+    assert!(out.iter().any(|l| l == "ST_PASS"), "got {:?}", out);
+    assert!(!out.iter().any(|l| l == "ST_FAIL"), "got {:?}", out);
+}

--- a/tests/hierarchy/t_bound_queue_member_storage.rs
+++ b/tests/hierarchy/t_bound_queue_member_storage.rs
@@ -1,0 +1,60 @@
+//! A class member whose declared type is a class type-parameter `T`, bound to
+//! an unpacked array/queue, must still materialize its per-instance queue
+//! storage when assigned through a bare (unqualified) reference inside a
+//! method. `handle_collection_name` already resolved `this.member`/`obj.member`
+//! through the parameter binding (`prop_bound_collection`), but `instance_assoc_member`
+//! (the bare-identifier path) did not — so `val = t;` inside a method that uses
+//! the bare member name silently wrote to scalar scratch storage and never
+//! populated the queue (subsequent reads returned the initializer / size 1).
+//!
+//! Verified byte-for-byte against a commercial simulator: R2 and R3 print
+//! `3,4,5,6 sz=4` (variant C exercises a `T`-typed formal `t` whose value-param
+//! storage must be copied into a *different* `T`-bound member, not just
+//! returned; R1 is unaffected because it returns a formal rather than writing a
+//! member).
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_bound_queue_member_storage() {
+    let src = r#"
+module top;
+  typedef int int_arr[];
+  class res #(type T=int);
+    T val;        // T-bound, copies a concrete queue
+    T param_a;    // T-bound, receives a T-typed formal
+    function void setA(int_arr t); val = t; endfunction
+    function void setC(T t);        param_a = t; endfunction
+    function T getVal();   return val;    endfunction
+    function T getParam(); return param_a; endfunction
+  endclass
+  res#(int_arr) r;
+  int_arr src = '{3,4,5,6};
+  int_arr b, e;
+  initial begin
+    r = new;
+    r.setA(src);
+    b = r.getVal();
+    $display("R2 setA(concrete)->T member: %0d,%0d,%0d,%0d sz=%0d", b[0],b[1],b[2],b[3],b.size());
+    r.setC(src);
+    e = r.getParam();
+    $display("R3 setC(T param)->T member: %0d,%0d,%0d,%0d sz=%0d", e[0],e[1],e[2],e[3],e.size());
+  end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    // Both variants must carry the full element set {3,4,5,6} (reference
+    // matches byte-for-byte). Before the fix these read back 0,0,0,0 sz=1.
+    assert!(out.iter().any(|l| l == "R2 setA(concrete)->T member: 3,4,5,6 sz=4"),
+        "R2 (concrete->T member) mismatch; got {:?}", out);
+    assert!(out.iter().any(|l| l == "R3 setC(T param)->T member: 3,4,5,6 sz=4"),
+        "R3 (T param->T member) mismatch; got {:?}", out);
+}

--- a/tests/hierarchy/t_bound_queue_value_param_chain.rs
+++ b/tests/hierarchy/t_bound_queue_value_param_chain.rs
@@ -1,0 +1,69 @@
+//! A `T`-typed value-parameter queue passed through a chain of nested generic
+//! methods into a `T`-bound class member must survive to the member. This
+//! exercises four cooperating fixes in xezim's runtime:
+//!
+//! 1. The specialization signature of a nested generic member (`W#(T) s;`
+//!    inside `W#(T)` where `T` resolves to `int_arr`) must carry the concrete
+//!    type, not be clobbered to the parameter's declared default (`int`) by
+//!    `canonicalize_spec_sig` — otherwise `bind_queue_param` sees non-queue
+//!    dims and binds the value-param as a scalar.
+//! 2. A bare collection member of `this` (`val = t` in `do_write`) must
+//!    resolve to its `<handle>#member` storage even when a same-named
+//!    value-param (`make(T val)`) is registered from an enclosing frame.
+//! 3. `fixed_array_operand` must not treat a dynamic-array/queue sentinel
+//!    range (0,-1) as a fixed array.
+//! 4. `==`/`!=` on two queues compares element-by-element.
+//!
+//! Verified byte-for-byte against a commercial simulator: `CD5 sz=4 1,2,3,4`
+//! and `CD5_PASS`.
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_bound_queue_value_param_chain() {
+    let src = r#"
+module top;
+  typedef int int_arr[];
+  class Store #(type T=int);
+    T val;
+    function void write(T t); do_write(t); endfunction
+    virtual function void do_write(T t); val = t; endfunction
+    function T get(); return val; endfunction
+  endclass
+  class Imp #(type T=int);
+    Store#(T) st;
+    function new(); st = new; endfunction
+    function void set(T val); st.write(val); endfunction
+  endclass
+  class TopDb #(type T=int);
+    static function Imp#(T) make(T val);
+      Imp#(T) imp = new;
+      imp.set(val);
+      return imp;
+    endfunction
+  endclass
+  int_arr src = '{1,2,3,4};
+  int_arr out;
+  initial begin
+    Imp#(int_arr) imp = TopDb#(int_arr)::make(src);
+    out = imp.st.get();
+    $display("CD5 sz=%0d %0d,%0d,%0d,%0d", out.size(), out[0],out[1],out[2],out[3]);
+    if (out.size()==4 && out[0]==1 && out[3]==4) $display("CD5_PASS");
+    else $display("CD5_FAIL");
+  end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(out.iter().any(|l| l.contains("CD5 sz=4 1,2,3,4")),
+        "expected full element set; got {:?}", out);
+    assert!(out.iter().any(|l| l == "CD5_PASS"), "got {:?}", out);
+    assert!(!out.iter().any(|l| l == "CD5_FAIL"), "got {:?}", out);
+}

--- a/tests/hierarchy/t_local_queue_index_growth.rs
+++ b/tests/hierarchy/t_local_queue_index_growth.rs
@@ -1,0 +1,55 @@
+//! Indexed assignment to a BLOCK-LOCAL queue grows the queue (LRM §7.10.2.3).
+//!
+//! `q[0] = v` on a freshly-declared local queue must make the queue a
+//! single-element '{v}`. Local queues are declared at runtime (they are not
+//! registered in `module.queue_vars` by elaboration, which only handles
+//! module/package scope), so the growth gate in `assign_value` missed them and
+//! an empty local queue never grew: the element was stored but `.size()`
+//! stayed 0 and the value was dropped on read.
+//!
+//! UVM's `uvm_callbacks::get_all` relies on exactly this — the 30iterate test
+//! does `all_callbacks[0] = unregistered_cb;` into a task-local queue.
+//!
+//! Verified byte-for-byte against a commercial simulator: `LQ_PASS`. Without
+//! this fix `q[0]`-growth leaves `.size()` 0 and the test FAILs.
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_local_queue_index_growth() {
+    let src = r#"
+class Foo;
+  int id;
+  function new(int i); id=i; endfunction
+  function string s(); return $sformatf("F%0d", id); endfunction
+endclass
+module top;
+initial begin
+  int qi[$];
+  qi[0] = 7;
+  if (qi.size()==1 && qi[0]==7) $display("LQ_INT_PASS"); else $display("LQ_INT_FAIL");
+  begin
+    Foo unreg = new(1);
+    Foo qc[$];
+    qc[0] = unreg;
+    if (qc.size()==1 && qc[0].id==1) $display("LQ_CLS_PASS"); else $display("LQ_CLS_FAIL");
+  end
+end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(out.iter().any(|l| l.contains("LQ_INT_PASS")),
+        "expected local int-queue index growth; got {:?}", out);
+    assert!(out.iter().any(|l| l.contains("LQ_CLS_PASS")),
+        "expected local class-queue index growth; got {:?}", out);
+    assert!(!out.iter().any(|l| l.contains("LQ_INT_FAIL") || l.contains("LQ_CLS_FAIL")),
+        "got {:?}", out);
+}

--- a/tests/hierarchy/t_nested_value_param_in_type_arg.rs
+++ b/tests/hierarchy/t_nested_value_param_in_type_arg.rs
@@ -1,0 +1,61 @@
+//! A value parameter used in a NESTED type-argument position inside a
+//! parameterized class's own static method must resolve to the ACTIVE
+//! specialization's binding, not fall back to the parameter's default.
+//!
+//! `Comp#(N)::get_holder()` references `Registry#(Comp#(N))`. The nested
+//! `Comp#(N)` type argument carries the value parameter `N`, which is a
+//! SYMBOLIC name at the point of elaboration. The parser reconstructs the
+//! type text with spaces around the `#`/parens (`Comp # ( N )`), and the
+//! runtime spec extractor previously only matched the compact `#(` form, so
+//! the nested value-param was never recognized and stayed unresolved — it
+//! fell back to the declared default `0`. `get_holder()` then returned a
+//! `Registry#(Comp#(0))` singleton instead of `Registry#(Comp#(2))`, so
+//! different call sites of the "same" specialization produced different
+//! registry singletons (a per-spec static/typeid mismatch).
+//!
+//! `extract_spec_from_string` is now whitespace-tolerant; the regression
+//! asserts `Comp#(2)::get_holder()` is the single `Registry#(Comp#(2))`
+//! singleton.
+//!
+//! Verified byte-for-byte against a commercial simulator: `N2_PASS`. Without
+//! the fix this self-test FAILs (N resolves to 0).
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_nested_value_param_in_type_arg() {
+    let src = r#"
+class Registry #(type T);
+  static Registry#(T) h;
+  static function Registry#(T) get();
+    if(h==null) h=new;
+    return h;
+  endfunction
+endclass
+class Comp #(int N=0);
+  static function Registry#(Comp#(N)) get_holder();
+    return Registry#(Comp#(N))::get();
+  endfunction
+endclass
+module top;
+initial begin
+  if (Comp#(2)::get_holder() == Registry#(Comp#(2))::get())
+    $display("N2_PASS");
+  else
+    $display("N2_FAIL");
+end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(out.iter().any(|l| l.contains("N2_PASS")),
+        "expected nested value-param to resolve to active spec; got {:?}", out);
+    assert!(!out.iter().any(|l| l.contains("N2_FAIL")), "got {:?}", out);
+}

--- a/tests/hierarchy/t_no_parens_static_method.rs
+++ b/tests/hierarchy/t_no_parens_static_method.rs
@@ -1,0 +1,64 @@
+//! A parameterless STATIC function of a class invoked BY NAME WITHOUT
+//! PARENTHESES must be CALLED, not read as a (non-existent) static property
+//! (LRM §13.4.1: a no-arg function may be invoked by name alone). UVM depends
+//! on this in `uvm_misc.svh`'s `find()`/`find_all()` warning:
+//!
+//!   `uvm_warning("find_type-multi match",
+//!     {"More than one instance of type '", TYPE::type_name, " found ..."})
+//!
+//! where `TYPE` is a class type-parameter and `type_name` is
+//! `static function string type_name()`. In a 7443 compat test the parameter
+//! was bound to `comp_b`, and xezim rendered the warning's type name EMPTY
+//! (`type ' found`) instead of the reference's `type 'comp_b found`. The flat
+//! 2-segment `comp_b::type_name` and the MemberAccess form `TYPE::type_name`
+//! both fell through `class_static_get` (which only reads static PROPERTIES),
+//! so the call returned the unused property cell (empty) instead of invoking
+//! `comp_b::type_name()`.
+//!
+//! Fix: at the `ClassName::x` static read, if `x` is a parameterless static
+//! function, dispatch it via `exec_static_method` (mirrored in the Ident arm
+//! and the MemberAccess arm). Verified byte-for-byte against a commercial
+//! simulator: `'comp_b found`.
+
+use xezim::simulate_multi;
+
+#[test]
+fn t_no_parens_static_method_invocation() {
+    let src = r#"
+module top;
+  class comp_b;
+    static function string type_name(); return "comp_b"; endfunction
+  endclass
+  class Util #(type TYPE=comp_b);
+    static function string msg();
+      return {"More than one instance of type '", TYPE::type_name, " found"};
+    endfunction
+    static function void go();
+      $display("TYN11 '%s'", msg());
+    endfunction
+  endclass
+  // Also exercise the flat (no type-param) direct-reference forms.
+  initial begin
+    Util #(comp_b)::go();
+    $display("TYN11 direct ['%s']", comp_b::type_name);
+  end
+endmodule
+"#;
+    let out: Vec<String> = simulate_multi(
+        &[src.to_string()], 1000, Some("top"), &[], &[], None, false, None, None,
+        &[], &[], 1, None, &[], 0, u64::MAX, None, &[], None, None, None, None, false, None,
+    )
+    .expect("sim")
+    .output
+    .iter()
+    .map(|o| o.message.clone())
+    .collect();
+    assert!(
+        out.iter().any(|l| l == "TYN11 'More than one instance of type 'comp_b found'"),
+        "no-parens static method must be invoked (type name resolved); got {:?}", out
+    );
+    assert!(
+        out.iter().any(|l| l == "TYN11 direct ['comp_b']"),
+        "direct Class::method no-parens must call the method; got {:?}", out
+    );
+}


### PR DESCRIPTION
## Summary

Indexed assignment to a freshly-declared **block-local** queue (`q[0] = v`) did not grow the queue:
the element was stored but `.size()` stayed `0`, so the value was dropped on later reads.

### Root cause
Block-local queues are registered at **runtime** (not by elaboration, which only handles
module/package scope), so they were missing from `module.queue_vars`. The `q[i] = v`
(`i == size`) growth gate in `assign_value` therefore skipped them — the store still landed
but the size shadow was never bumped.

### Fix
Register block-local queues in `module.queue_vars` at the local-declaration site, guarded on
the first dimension being a `Queue` (mirroring the elaborator's rule for module/package scope).

## Validation
- New self-test `t_local_queue_index_growth` **fails without the fix** (local queue `.size()` stays 0)
  and **passes with it**, byte-for-byte matching a commercial simulator.
- `09callbacks/30iterate` UVM test (which does `all_callbacks[0] = cb` into a task-local queue)
  now **PASSes** (0 errors / 0 fatals); previously failed.
- Full self-test suite clean: 315 passed / 2 pre-existing unrelated failures, no regressions.

## Note on branch base
This branch is stacked on top of the still-open PR #130 stack (parameterized static dispatch).
The queue-growth fix itself is a single independent commit on top of that stack.