### PR TITLE
tests: register the negative tests that never ran (neg09-neg11)

### DIFF
--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -81,10 +81,21 @@ fn run_negative_compliance_test(filename: &str) {
         filename,
         combined
     );
+    // A parse diagnostic carries a source prefix (`[file] 2:15: error: ...`);
+    // elaboration reports either `Simulation error: ...` or, for a check that
+    // runs before a scope is established, a BARE `error: ...` with no prefix
+    // at all. The bare form was not accepted here, so a test whose construct
+    // xezim correctly rejects still failed the harness -- which is why
+    // neg11_missing_named_port could not be registered. Matched at a line
+    // start so the "0 errors" summary line cannot satisfy it.
+    let has_diagnostic = combined.contains(": error:")
+        || combined.contains("Parse errors")
+        || combined.contains("Simulation error")
+        || combined
+            .lines()
+            .any(|l| l.trim_start().starts_with("error:"));
     assert!(
-        combined.contains(": error:")
-            || combined.contains("Parse errors")
-            || combined.contains("Simulation error"),
+        has_diagnostic,
         "Negative test {} failed without an error diagnostic. Output:\n{}",
         filename,
         combined
@@ -348,4 +359,12 @@ fn test_sv_neg07_bad_clocking_direction() {
 #[test]
 fn test_sv_neg08_bad_constraint_reference() {
     run_negative_compliance_test("neg08_bad_constraint_reference.sv");
+}
+#[test]
+fn test_sv_neg09_duplicate_port_name() {
+    run_negative_compliance_test("neg09_duplicate_port_name.sv");
+}
+#[test]
+fn test_sv_neg11_missing_named_port() {
+    run_negative_compliance_test("neg11_missing_named_port.sv");
 }

--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -365,6 +365,10 @@ fn test_sv_neg09_duplicate_port_name() {
     run_negative_compliance_test("neg09_duplicate_port_name.sv");
 }
 #[test]
+fn test_sv_neg10_duplicate_enum_literal() {
+    run_negative_compliance_test("neg10_duplicate_enum_literal.sv");
+}
+#[test]
 fn test_sv_neg11_missing_named_port() {
     run_negative_compliance_test("neg11_missing_named_port.sv");
 }


### PR DESCRIPTION
Paired with **[xezim-core#33](https://github.com/aionhw/xezim-core/pull/33)**. Opened as a draft: CI resolves the core dependency at `refs/heads/main`, so `neg10` cannot go green until #33 merges. Marking ready then.

`tests_negative/` has four tests — neg09 through neg12 — that `a79dad3` added but never registered in `sv_compliance_runner.rs`, so **they have never executed**. Registering them turned up that "four tests were never wired up" was hiding three different problems:

| test | what was actually wrong |
|---|---|
| neg09 duplicate port name | nothing — just unregistered |
| neg11 missing named port | the **harness** did not recognise a correct diagnostic |
| neg10 duplicate enum literal | a real elaboration gap — fixed in core#33 |
| neg12 duplicate case item | the **test's expectation** looks wrong |

## neg11 was a harness bug, not a tool bug

xezim rejects the construct properly — exit 1, precise, §-cited:

```
error: port 'missing' is not a port of module 'neg11_child' (LRM 1800-2017 §23.3.2)
```

But `run_negative_compliance_test` accepted only `": error:"`, `"Parse errors"`, or `"Simulation error"`. The first matches a *parse* diagnostic's source prefix (`[file] 2:15: error: ...`); the third matches elaboration errors raised inside a scope. Neither matches the **bare** `error:` an elaboration check emits when it runs before a scope is established — so a test whose construct xezim correctly rejects still failed the harness.

Widened to also accept a line **starting** with `error:`, matched at line start so the `"0 errors"` summary line cannot satisfy it.

## neg12 stays unregistered, deliberately

It expects `compile_fail` for a repeated `unique case` item. §12.5.3 makes unique/priority violations a **runtime** report, not a compile error, so registering it would pin an expectation the LRM does not support. A statically duplicated constant item is a reasonable *lint* — but the test's own expectation is what needs settling, not the tool. Left in place, unregistered, with the reasoning recorded in the commit message so it is not rediscovered from scratch.

## Result

Negative tests now run **11**, up from the 8 that were actually running before this branch.

## Verification

Against core#33:

- negative suite: **11 passed, 0 failed**
- full suite: **2303 passed / 0 failed** interpreter, **2307 passed / 0 failed** `--features jit`
