### PR TITLE
tests: Verilog-AMS  nets (pairs with xezim-core#36)

### DIFF
--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -380,3 +380,7 @@ fn test_sv_neg10_duplicate_enum_literal() {
 fn test_sv_neg11_missing_named_port() {
     run_negative_compliance_test("neg11_missing_named_port.sv");
 }
+#[test]
+fn test_sv_neg13_wreal_packed_range() {
+    run_negative_compliance_test("neg13_wreal_packed_range.sv");
+}

--- a/tests/misc/sv_compliance_runner.rs
+++ b/tests/misc/sv_compliance_runner.rs
@@ -312,6 +312,10 @@ fn test_sv_49_specparam_hierarchical() {
     run_positive_compliance_test("tests_advanced", "49_specparam_hierarchical.sv");
 }
 #[test]
+fn test_sv_50_wreal_nets() {
+    run_positive_compliance_test("tests_advanced", "50_wreal_nets.sv");
+}
+#[test]
 fn test_sv_41_genfor_localparam_idx() {
     run_positive_compliance_test("tests_advanced", "41_genfor_localparam_idx.sv");
 }

--- a/tests/sv_compliance/manifest.csv
+++ b/tests/sv_compliance/manifest.csv
@@ -49,3 +49,4 @@ file,topic,description
 46_nettype_hierarchy.sv,user-defined nettypes across hierarchy,nettype nets driven from several module instances through ports; Millman resolution over a nested dut catches per-port double resolution
 47_nettype_coercion.sv,nettype coercion of implicit nets,implicit net used as a port actual takes the port user-defined nettype (§6.6.8/§23.3.3)
 49_specparam_hierarchical.sv,specparam hierarchical access,specparam is a module-scoped elaboration constant reachable by hierarchical name (§6.20.5/§23.3.3) including through generate scopes and specify-block uses
+50_wreal_nets.sv,Verilog-AMS wreal nets,net whose value is a real with multiple drivers resolved by summing (KCL current summing); scalar and port forms

--- a/tests/sv_compliance/tests_advanced/50_wreal_nets.sv
+++ b/tests/sv_compliance/tests_advanced/50_wreal_nets.sv
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+//
+// 50_wreal_nets.sv — Verilog-AMS `wreal`: a net whose value is a real, with
+// multiple drivers resolved by SUMMING them.
+//
+// `wreal` is a NET TYPE that names no data type of its own, so a signal
+// declared with it has to be given real storage from the net type alone.
+// Declared as a plain net it lands as a bit vector and every value is
+// rounded on write -- 2.5 reads back 3.0, 1.25 reads back 1.0, and a
+// negative value wraps to a huge unsigned integer. Every value below is
+// therefore deliberately non-integer.
+//
+// Multi-driver resolution is the second half. Verilog-AMS leaves it
+// tool-defined; summing is the resolution that makes a current-summing
+// wrapper mean what it says -- several stages each drive their contribution
+// onto a shared node and the node sees the total, which is Kirchhoff's
+// current law. Bitwise wire resolution would instead call two drivers a
+// conflict and yield x.
+//
+//   A: a scalar wreal keeps a fractional value            (rounding)
+//   B: an undriven wreal reads 0.0
+//   C: two drivers on one wreal sum                       (resolution)
+//   D: the sum is signed, not an unsigned wrap
+//   E: a wreal crossing a module port keeps its fraction
+
+`include "../common/svtest_defs.svh"
+
+// Drives its input onto a wreal output -- the exact shape a generated
+// current-mode wrapper instantiates once per contributing stage.
+module idrv (input real i, output wreal o);
+  assign o = i;
+endmodule
+
+// A wreal that crosses a port boundary in both directions.
+module thru (input wreal a, output wreal b);
+  assign b = a;
+endmodule
+
+module top;
+  `SVTEST_INIT
+
+  // ---- A: scalar wreal, fractional ----
+  wreal single;
+  assign single = 2.5;
+
+  // ---- B/C/D: two drivers onto one node ----
+  real a, b;
+  wreal node;
+  idrv d0 (.i(a), .o(node));
+  idrv d1 (.i(b), .o(node));
+
+  // ---- E: across a port ----
+  wreal src, dst;
+  assign src = 1.25;
+  thru t0 (.a(src), .b(dst));
+
+  initial begin
+    a = 0.0;
+    b = 0.0;
+    #1;
+
+    `SVTEST_CHECK(single > 2.4999 && single < 2.5001,
+                  "A: a scalar wreal must keep 2.5, not round to 3.0")
+
+    `SVTEST_CHECK(node > -0.0001 && node < 0.0001,
+                  "B: two drivers of 0.0 sum to 0.0")
+
+    a = 1.5;
+    b = 2.25;
+    #1;
+    `SVTEST_CHECK(node > 3.7499 && node < 3.7501,
+                  "C: two drivers on one wreal sum (1.5 + 2.25 = 3.75)")
+
+    a = -0.75;
+    b = 2.25;
+    #1;
+    `SVTEST_CHECK(node > 1.4999 && node < 1.5001,
+                  "D: the sum is signed (-0.75 + 2.25 = 1.5)")
+
+    // Guard the specific corruption: an integer slot reads a negative
+    // contribution back as a huge unsigned value, not as a small sum.
+    `SVTEST_CHECK(node < 1000.0,
+                  "D: a negative driver must not wrap to a huge unsigned value")
+
+    `SVTEST_CHECK(dst > 1.2499 && dst < 1.2501,
+                  "E: a wreal crossing a module port keeps its fraction")
+
+    `SVTEST_PASSFAIL
+  end
+endmodule

--- a/tests/sv_compliance/tests_advanced/50_wreal_nets.sv
+++ b/tests/sv_compliance/tests_advanced/50_wreal_nets.sv
@@ -22,6 +22,12 @@
 //   C: two drivers on one wreal sum                       (resolution)
 //   D: the sum is signed, not an unsigned wrap
 //   E: a wreal crossing a module port keeps its fraction
+//   F: ONE driver is passed through, not doubled          (fold identity)
+//   G: three drivers sum                                  (fold is n-ary)
+//
+// F is the half of the resolution rule that a two-driver test cannot see: the
+// driver chain folds with `+`, so an accumulator seeded wrong gives 2x on a
+// single driver while every multi-driver case still looks right.
 
 `include "../common/svtest_defs.svh"
 
@@ -54,9 +60,25 @@ module top;
   assign src = 1.25;
   thru t0 (.a(src), .b(dst));
 
+  // ---- F: exactly one driver ----
+  real lone;
+  wreal solo;
+  idrv s0 (.i(lone), .o(solo));
+
+  // ---- G: three drivers ----
+  real t1, t2, t3;
+  wreal trio;
+  idrv e0 (.i(t1), .o(trio));
+  idrv e1 (.i(t2), .o(trio));
+  idrv e2 (.i(t3), .o(trio));
+
   initial begin
     a = 0.0;
     b = 0.0;
+    lone = 0.0;
+    t1 = 0.0;
+    t2 = 0.0;
+    t3 = 0.0;
     #1;
 
     `SVTEST_CHECK(single > 2.4999 && single < 2.5001,
@@ -84,6 +106,22 @@ module top;
 
     `SVTEST_CHECK(dst > 1.2499 && dst < 1.2501,
                   "E: a wreal crossing a module port keeps its fraction")
+
+    // F: a single driver must be passed through unchanged. A fold that
+    // seeds its accumulator instead of taking the first driver whole
+    // returns 5.0 here while every case above still reads correctly.
+    lone = 2.5;
+    #1;
+    `SVTEST_CHECK(solo > 2.4999 && solo < 2.5001,
+                  "F: one driver on a wreal is passed through, not doubled")
+
+    // G: the fold is n-ary, not pairwise-only.
+    t1 = 1.5;
+    t2 = 2.25;
+    t3 = -0.75;
+    #1;
+    `SVTEST_CHECK(trio > 2.9999 && trio < 3.0001,
+                  "G: three drivers sum (1.5 + 2.25 - 0.75 = 3.0)")
 
     `SVTEST_PASSFAIL
   end

--- a/tests/sv_compliance/tests_negative/neg13_wreal_packed_range.sv
+++ b/tests/sv_compliance/tests_negative/neg13_wreal_packed_range.sv
@@ -1,0 +1,13 @@
+// EXPECT: compile_fail
+//
+// Verilog-AMS 2.4 §3.8: a `wreal` net carries one REAL value, not a vector of
+// bits, so it has no packed range. Accepting one is not harmless -- the net
+// then behaves as an ordinary 4-bit wire and silently ROUNDS every value
+// written to it (2.5 reads back 3.0), which is the exact corruption `wreal`
+// exists to prevent, with nothing reported. Both spellings below were once
+// accepted in silence; the port form reaches the check by a different path
+// than the declaration form, so both are pinned here.
+module neg13_wreal_packed_range (input wreal [3:0] p);
+  wreal [3:0] w;
+  assign w = 2.5;
+endmodule


### PR DESCRIPTION
Compliance tests for the `wreal` support in **aionhw/xezim-core#36**.

- `50_wreal_nets.sv` — scalar and port forms; single-driver pass-through, and
  a three-driver sum checked against the arithmetic total rather than any one
  driver, so a "last write wins" resolution would fail it rather than pass by
  luck.
- `neg13_wreal_packed_range.sv` — a packed range on a `wreal` must be
  rejected. A `wreal` is a real; there are no bit positions to select.

### Ordering

xezim pins xezim-core by exact rev, so **core#36 must land and the rev be
bumped before this can pass CI**. Until then the two new tests fail here for
the expected reason: the pinned core (`5039f7e`) contains no `wreal` at all —
no `KwWreal` token, no `NetType::Wreal`, no `RealSum` resolution — so
`wreal x;` degrades to a default, integer-valued net. That accounts for every
assertion in the failing job: values rounding, negatives wrapping unsigned,
drivers not summing. Detail in the comment below.

### Verified locally against the core branch

CI runs two configurations, so both were checked, via
`scripts/use-local-core.sh`:

```
$ cargo test --release --test misc sv_compliance_runner
test sv_compliance_runner::test_sv_50_wreal_nets ... ok
test sv_compliance_runner::test_sv_neg13_wreal_packed_range ... ok
test result: ok. 69 passed; 0 failed; 1 ignored
```

```
$ cargo test --release --features jit --test misc wreal
test sv_compliance_runner::test_sv_50_wreal_nets ... ok
test sv_compliance_runner::test_sv_neg13_wreal_packed_range ... ok
test result: ok. 2 passed; 0 failed
```

The JIT needs no separate `wreal` work: it shares the same value
representation, so core's `RealSum` resolution carries through both paths.
Worth stating explicitly, since a reasonable reading of the failures is that
the JIT keeps its own representation and would need its own handling.

### Note on the test number

Originally written as `49_wreal_nets.sv`. `49_` was taken by
`49_specparam_hierarchical.sv` in the meantime, so this is renumbered to
`50_` on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
