### PR TITLE
Fix SystemVerilog semantics: statics, $typename, %p signedness, param bindings

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -84666,11 +84666,20 @@ impl Simulator {
                     // is active, each specialization gets its own static cell.
                     // This applies to statics declared in the spec's base class
                     // AND inherited from parameterized ancestors (per IEEE 1800-2023 §8.25).
-                    let active_spec = spec_override.or(self.current_spec.as_ref());
+                    // Fall back to synthesizing a spec from a CONCRETE receiver
+                    // (e.g. `ext1::ID()` where `ext1 extends base#(ext1)`) so any
+                    // static reachable through such a subclass is keyed per
+                    // specialization too — this is the generic home of the
+                    // concrete-receiver path, so it applies uniformly to static
+                    // calls, instance-inherited statics, and property reads.
+                    let active_spec = spec_override
+                        .or(self.current_spec.as_ref())
+                        .cloned()
+                        .or_else(|| self.derive_static_spec(start_class, &cname));
                     let key = match active_spec {
                         Some((base, sig))
-                            if (base == &cname
-                                || self.class_extends(base.as_str(), &cname))
+                            if (base == cname
+                                || self.class_extends(&base, &cname))
                                 && self.class_is_parameterized(&cname) =>
                         {
                             // For inherited statics (cname != base), derive
@@ -84680,7 +84689,7 @@ impl Simulator {
                             // `callbacks#(T,base_callback)` — which both
                             // extend `typed_callbacks#(T)` — share the
                             // same `m_tw_cb_q` static cell.
-                            if base == &cname {
+                            if base == cname {
                                 format!("{}#{}::{}", cname, self.canonicalize_spec_sig(&cname, sig.as_str()), prop)
                             } else if let Some(ancestor_sig) =
                                 self.ancestor_spec(base.as_str(), sig.as_str(), &cname)
@@ -84769,6 +84778,24 @@ impl Simulator {
             .map(|p| carried.get(p).cloned().unwrap_or_else(|| p.clone()))
             .collect::<Vec<_>>()
             .join(",")
+    }
+
+    /// §8.25 generic spec derivation for a member accessed from subclass
+    /// `start_class` whose declaring class is `cname`. When no specialization is
+    /// already active (`current_spec`/`spec_override`) and `start_class` is a
+    /// CONCRETE subclass of a PARAMETERIZED `cname`, synthesize the declaring
+    /// class's specialization from the receiver's `extends_type_args`. This is
+    /// called from `static_prop_key_inner` so every static-member key — whether
+    /// reached by a static call, an instance-inherited static, or a bare
+    /// property read — is keyed per specialization regardless of the caller.
+    fn derive_static_spec(&self, start_class: &str, cname: &str) -> Option<(String, String)> {
+        if self.class_is_parameterized(start_class) || !self.class_is_parameterized(cname) {
+            return None;
+        }
+        if !self.class_extends(start_class, cname) {
+            return None;
+        }
+        self.static_receiver_spec(start_class, cname)
     }
 
     /// Resolve a CLASS-SCOPED constant `ClassName::member` — an enum literal
@@ -87589,21 +87616,22 @@ impl Simulator {
                 break;
             };
             if has_method {
-                // §8.25: a static inherited from a PARAMETERIZED base reached
-                // through a concrete subclass (`ext1::ID()` where `ext1 extends
-                // base#(ext1)`) has no `#(spec)` and no instance, so seed
-                // current_spec from the receiver's extends type args so
-                // per-specialization statics stay distinct.
-                let saved = self.current_spec.clone();
-                if !self.class_is_parameterized(class_name)
-                    && self.class_is_parameterized(&cname)
-                {
-                    if let Some(spec) = self.static_receiver_spec(class_name, &cname) {
-                        self.current_spec = Some(spec);
-                    }
+                // §8.25: a static reached through a CONCRETE receiver but
+                // declared in a PARAMETERIZED ancestor (`ext1::ID()` where
+                // `ext1 extends base#(ext1)`) has no `#(spec)` on the call and
+                // no instance; seed current_spec from the receiver's extends
+                // chain so the body's BARE static member keys per-
+                // specialization. Generic: applies to any concrete receiver of
+                // a parameterized method (`derive_static_spec` is the shared
+                // path; this is its method-dispatch home).
+                if let Some(spec) = self.derive_static_spec(class_name, &cname) {
+                    let saved = self.current_spec.clone();
+                    self.current_spec = Some(spec);
+                    let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
+                    self.current_spec = saved;
+                    return Some(v);
                 }
                 let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
-                self.current_spec = saved;
                 return Some(v);
             }
             cur = parent;
@@ -87632,18 +87660,16 @@ impl Simulator {
                 break;
             };
             if has_method {
-                // §8.25: see exec_static_method — seed current_spec for
-                // per-specialization inherited statics.
-                let saved = self.current_spec.clone();
-                if !self.class_is_parameterized(class_name)
-                    && self.class_is_parameterized(&cname)
-                {
-                    if let Some(spec) = self.static_receiver_spec(class_name, &cname) {
-                        self.current_spec = Some(spec);
-                    }
+                // §8.25: same generic receiver-specialization seeding as
+                // exec_static_method (see above).
+                if let Some(spec) = self.derive_static_spec(class_name, &cname) {
+                    let saved = self.current_spec.clone();
+                    self.current_spec = Some(spec);
+                    let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
+                    self.current_spec = saved;
+                    return Some(v);
                 }
                 let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
-                self.current_spec = saved;
                 return Some(v);
             }
             cur = parent;
@@ -103246,19 +103272,18 @@ impl Simulator {
                         }
                     }
                 }
-                // §8.25 instance-method analogue of the static-receiver seeding
-                // above: a CONCRETE instance (e.g. `ext3x`) whose method is
-                // declared in a PARAMETERIZED base (`get_type_handle` in
-                // `uvm_tlm_extension`) reaches it through `extends #(ext3)`.
-                // The instance seeding above leaves current_spec unset for a
-                // concrete (unparameterized) class, so the method body's inner
-                // static call (`ID()`) resolves against the generic base and
-                // mints a WRONG singleton. Derive the declaring class's
-                // specialization from the receiver's extends type args.
+                // §8.25 (generic receiver specialization): when a method is
+                // reached on a CONCRETE receiver (static, `ext1::ID()`; or
+                // instance, `x3.get_type_handle()`) but is DECLARED in a
+                // PARAMETERIZED ancestor (`uvm_tlm_extension#(ext1)`), the
+                // receiver's `#(...)` specialization is not captured anywhere
+                // once the body runs a BARE static member like `m_singleton`.
+                // Seed current_spec from the concrete receiver's extends chain
+                // so the body's inner static access keys per specialization.
                 if let Some(inst) = self.heap.get(handle).and_then(|o| o.as_ref()) {
-                    if self.current_spec.is_none()
-                        && !self.class_is_parameterized(&inst.class_name)
+                    if !self.class_is_parameterized(&inst.class_name)
                         && self.class_is_parameterized(&cname)
+                        && self.class_extends(&inst.class_name, &cname)
                     {
                         if let Some(spec) =
                             self.static_receiver_spec(&inst.class_name, &cname)

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -95455,6 +95455,24 @@ impl Simulator {
                     // parameterized context (`uvm_resource#(T)` where `T` is
                     // config_db's own param) — resolve it to the concrete type so
                     // the instance's binding is `T -> int`, not `T -> T`.
+                    //
+                    // A type arg that is a SPECIALIZATION of the ENCLOSING class's
+                    // own parameter (`uvm_callback_iter#(special_comp#(N),...)` on
+                    // a special_comp#(N) instance) carries a bare value-parameter
+                    // name `N` in its `#(...)`. leaf_ident_name returns the raw
+                    // `special_comp#(N)` string, so binding `T -> "special_comp#(N)"`
+                    // captures N as literal text and every later `T`-param
+                    // resolution inside the iterator's methods (`first()` calling
+                    // `uvm_callbacks#(T,CB)::get_first`) ends up at the un-
+                    // specialized `special_comp` cell — empty typewide queue,
+                    // so `get_first`/`first()` returned null. Resolve the
+                    // `#(N)` args through the ACTIVE specialization here, so the
+                    // binding is the concrete `special_comp#(1)`.
+                    let concrete = if concrete.contains('(') && matches!(ta.kind, ExprKind::Specialization { .. }) {
+                        self.expr_to_spec_fragment(ta).unwrap_or(concrete)
+                    } else {
+                        concrete
+                    };
                     bound = Some(
                         self.resolve_type_param_binding(&concrete)
                             .unwrap_or(concrete),

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -48256,6 +48256,30 @@ impl Simulator {
                         }
                     }
                 }
+                // `ClassName#(params)::static_prop = ...` — a STATIC scalar /
+                // handle property write through a class SPECIALIZATION
+                // receiver (the READ path resolves it per-spec via
+                // class_static_get; the write must land in the SAME per-spec
+                // cell). Without this `C#(int)::n = 5` fell through to a
+                // bare-name store the later read never consulted.
+                if let ExprKind::Specialization { .. } = &expr.kind {
+                    if let Some((base, sig)) = self.resolve_call_spec_params(
+                        Self::extract_call_spec(expr),
+                        &self.current_spec.clone(),
+                    ) {
+                        if self.module.classes.contains_key(&base)
+                            && !self.signal_name_to_id.contains_key(base.as_str())
+                        {
+                            let saved = self.current_spec.take();
+                            self.current_spec = Some((base.clone(), sig));
+                            let ok = self.class_static_set(&base, &member.name, val.clone());
+                            self.current_spec = saved;
+                            if ok {
+                                return true;
+                            }
+                        }
+                    }
+                }
                 // `ClassName::static_prop = ...` — explicit static write.
                 if let ExprKind::Ident(hier) = &expr.kind {
                     if hier.path.len() == 1 {
@@ -86750,6 +86774,24 @@ impl Simulator {
         self.static_fixed_key_in(cls, member)
     }
 
+    /// Does `start_class` or an ancestor declare `name` as a STATIC
+    /// queue/assoc/dynamic-array collection (i.e. it is in
+    /// `static_collections`)?
+    fn collection_is_static_in(&self, start_class: &str, name: &str) -> bool {
+        let mut cur = Some(start_class.to_string());
+        while let Some(cn) = cur {
+            if let Some(cd) = self.module.classes.get(&cn) {
+                if cd.static_collections.iter().any(|(n, _, _)| n == name) {
+                    return true;
+                }
+                cur = cd.extends.clone();
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
     fn instance_assoc_member(&self, name: &str) -> Option<String> {
         // §8.9: `Cls::member` / flattened `Cls.member` spellings of a static
         // fixed array resolve to the declaring class's store BEFORE the
@@ -86765,6 +86807,18 @@ impl Simulator {
         let Some(handle) = self.this_stack.last().copied().flatten().filter(|&h| h != 0)
         else {
             let ctx = self.class_context_stack.last().cloned().flatten()?;
+            // A static QUEUE/ASSOC/dynamic-ARRAY property of a (possibly
+            // parameterized) class, accessed BARE inside a static method
+            // (e.g. uvm_config_db's `static pool m_rsc[comp]`): route to its
+            // per-specialization store (`spec_static_coll_key` folds the
+            // active spec), so an ELEMENT read/write `m[k]` and the builtin
+            // ops (size/exists/...) agree on ONE store. Without this the
+            // element path resolved to the bare name ─ a DIFFERENT store from
+            // the per-spec key builtins use ─ so `m[k]=v` stored its value
+            // where the later `m[k]`/`exists` never looked (and vice-versa).
+            if self.collection_is_static_in(&ctx, name) {
+                return Some(self.spec_static_coll_key(name));
+            }
             return self.static_fixed_key_in(&ctx, name);
         };
         // Use the runtime class of `this` (from the heap) rather than the
@@ -87012,6 +87066,51 @@ impl Simulator {
                     } else {
                         None
                     }
+                }
+                // `ClassName#(params)::static_coll` — a parameterized-class
+                // static collection (queue/assoc/array) reached through a
+                // class SPECIALIZATION receiver rather than `this`/an object.
+                // Resolve the per-spec storage key exactly like
+                // `spec_static_coll_key` does, so the assoc/queue store name
+                // matches the one builtin ops (push_back/size/...) use and is
+                // isolated per specialization. Without this the index/assoc
+                // read AND write both resolved to None, so `C#(int)::m["a"]=v`
+                // (and uvm_config_db's static per-component pool) was silently
+                // dropped on write and read back empty.
+                ExprKind::Specialization { .. } => {
+                    let Some((b, s)) = self.resolve_call_spec_params(
+                        Self::extract_call_spec(base),
+                        &self.current_spec.clone(),
+                    ) else {
+                        return None;
+                    };
+                    let mut cur = Some(b.clone());
+                    while let Some(cn) = cur {
+                        let is_static_coll = self
+                            .module
+                            .classes
+                            .get(&cn)
+                            .map(|cd| {
+                                cd.static_properties.contains(&member.name)
+                                    && cd.static_collections
+                                        .iter()
+                                        .any(|(n, _, _)| n == &member.name)
+                            })
+                            .unwrap_or(false);
+                        if is_static_coll {
+                            let saved = self.current_spec.take();
+                            self.current_spec = Some((b.clone(), s.clone()));
+                            let key = self.static_prop_key(&b, &member.name);
+                            self.current_spec = saved;
+                            return key;
+                        }
+                        cur = self
+                            .module
+                            .classes
+                            .get(&cn)
+                            .and_then(|cd| cd.extends.clone());
+                    }
+                    None
                 }
                 _ => None,
             },

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -92165,6 +92165,31 @@ impl Simulator {
                 } else if self.module.classes.contains_key(&type_name) {
                     self.record_local_class_type(&port.name.name, &type_name);
                     self.var_class_types.insert(port.name.name.clone(), type_name);
+                } else if let Some(concrete) = self.resolve_type_param_binding(&type_name) {
+                    // The formal is typed with a class TYPE PARAMETER
+                    // (`IMP imp` inside a parameterized class, e.g. the
+                    // uvm_tlm_*_socket `new(name, parent, IMP imp=null)`).
+                    // `type_name` is not a real class name, so the branches
+                    // above silently skip it and `class_of_var` falls back to
+                    // a STALE same-named entry left in the flat
+                    // `var_class_types` by an unrelated scope (UVM's
+                    // config_db methods declare a local `imp` of concrete type
+                    // `uvm_config_db_implementation_t`). The local's record is
+                    // not scrubbed like a formal's, so `$cast(imp, parent)`
+                    // resolved `imp` to that WRONG class and failed it
+                    // (UVM/TLM2/NOIMP on a valid initiator socket). Record the
+                    // resolved concrete class so `$cast`/`new` see the right
+                    // type. Mirrors the local-VarDecl path (§8.25).
+                    let cn_is_class = self.module.classes.contains_key(&concrete)
+                        || (concrete.contains('#')
+                            && self
+                                .module
+                                .classes
+                                .contains_key(concrete.split('#').next().unwrap_or(&concrete)));
+                    if cn_is_class {
+                        self.record_local_class_type(&port.name.name, &concrete);
+                        self.var_class_types.insert(port.name.name.clone(), concrete);
+                    }
                 }
             }
             // Same §13.3 metadata registration as the task path.
@@ -103026,6 +103051,30 @@ impl Simulator {
                         } else if self.module.classes.contains_key(&type_name) {
                             self.record_local_class_type(&port.name.name, &type_name);
                             self.var_class_types.insert(port.name.name.clone(), type_name.clone());
+                        } else if let Some(concrete) = self.resolve_type_param_binding(&type_name) {
+                            // See the identical branch in exec_function_call's
+                            // port loop: the formal is typed with a class TYPE
+                            // PARAMETER (`IMP imp`), not a real class name. It
+                            // used to be skipped, so `class_of_var` fell back
+                            // to a STALE same-named `var_class_types` entry from
+                            // an unrelated scope (UVM's config_db methods)
+                            // and `$cast(imp, parent)` resolved `imp` to the
+                            // WRONG class — failing a valid TLM initiator
+                            // socket with UVM/TLM2/NOIMP. Record the resolved
+                            // concrete class so the cast/new sees the right
+                            // type (mirrors the local-VarDecl path, §8.25).
+                            let cn_is_class = self.module.classes.contains_key(&concrete)
+                                || (concrete.contains('#')
+                                    && self
+                                        .module
+                                        .classes
+                                        .contains_key(
+                                            concrete.split('#').next().unwrap_or(&concrete),
+                                        ));
+                            if cn_is_class {
+                                self.record_local_class_type(&port.name.name, &concrete);
+                                self.var_class_types.insert(port.name.name.clone(), concrete);
+                            }
                         }
                     }
                     locals.insert(port.name.name.clone(), val);

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -91356,7 +91356,7 @@ impl Simulator {
         &mut self,
         port: &crate::ast::decl::FunctionPort,
         arg: &Expression,
-    ) -> Option<(String, String)> {
+    ) -> Option<(String, String, Option<bool>)> {
         if !self.port_is_assoc_array(port) {
             return None;
         }
@@ -91381,6 +91381,7 @@ impl Simulator {
             self.signals.insert(k, v);
         }
         let is_string_key = self.is_string_keyed_array(&caller);
+        let prior = self.module.associative_arrays.get(&param).copied();
         self.module
             .associative_arrays
             .insert(param.clone(), is_string_key);
@@ -91389,17 +91390,35 @@ impl Simulator {
         if let Some(frame) = self.local_dyn.last_mut() {
             frame.insert(param.clone(), param.clone());
         }
-        Some((param, caller))
+        Some((param, caller, prior))
     }
 
-    /// Drop a formal associative array's entries and registration.
-    fn purge_assoc_param(&mut self, param: &str) {
+    /// Drop a formal associative array's entries and registration. Restores
+    /// any PRIOR registration an enclosing call had for the same name (see
+    /// `bind_assoc_param`'s captured `prior`): a nested call must not leave
+    /// the array unregistered after it returns just because its own formal
+    /// happens to share the name — the flat `module.associative_arrays` table
+    /// is shared across nesting depths.
+    fn purge_assoc_param(&mut self, param: &str, prior: Option<bool>) {
         let prefix = format!("{}[", param);
         let keys: Vec<String> = self.signals.keys_with_elem_prefix(&prefix);
         for k in keys {
             self.signals.remove(&k);
         }
-        self.module.associative_arrays.remove(param);
+        match prior {
+            // An entry predated THIS call (it belongs to an enclosing frame
+            // whose bindings are still live) — put it back.
+            Some(is_string_key) => {
+                self.module
+                    .associative_arrays
+                    .insert(param.to_string(), is_string_key);
+            }
+            // This call created the registration; no enclosing frame wanted
+            // it — drop it.
+            None => {
+                self.module.associative_arrays.remove(param);
+            }
+        }
     }
 
     /// Copy a `ref`/`output`/`inout` associative formal back onto the caller's
@@ -92033,7 +92052,7 @@ impl Simulator {
             }
         }
         let mut array_writebacks: Vec<(String, String, i64, i64)> = Vec::new();
-        let mut assoc_params: Vec<(String, String, bool)> = Vec::new();
+        let mut assoc_params: Vec<(String, String, bool, Option<bool>)> = Vec::new();
         let mut queue_writebacks: Vec<(String, String)> = Vec::new();
         // `output`/`inout`/`ref` STRUCT formals are bound member-wise (locals
         // `o.a`, `o.b`), so they bypass the whole-value `output_bindings`
@@ -92048,8 +92067,8 @@ impl Simulator {
             // An ASSOCIATIVE-array formal: functions bound nothing at all, so
             // `arr.size()` inside the body read 0.
             if i < args.len() {
-                if let Some((param, caller)) = self.bind_assoc_param(port, &args[i]) {
-                    assoc_params.push((param, caller, is_out));
+                if let Some((param, caller, prior)) = self.bind_assoc_param(port, &args[i]) {
+                    assoc_params.push((param, caller, is_out, prior));
                     continue;
                 }
                 // §13.5.2: bind member-wise, and for an output/inout/ref struct
@@ -92462,17 +92481,23 @@ impl Simulator {
             result.is_signed = super::elaborate::is_type_signed(&fd.return_type);
         }
         // Array formals copy element-wise; scalars go through `output_bindings`.
-        for (param, caller, is_out) in std::mem::take(&mut assoc_params) {
+        for (param, caller, is_out, prior) in std::mem::take(&mut assoc_params) {
             if param == caller {
                 // Formal aliases the caller's namespace; the body's writes
                 // already live there. Copying back would duplicate, and
-                // purging would delete the caller's data. Leave as-is.
+                // purging would delete the caller's data. Restore the prior
+                // registration (a nested same-name formal must not leave the
+                // flat `module.associative_arrays` entry wrong).
+                match prior {
+                    Some(v) => { self.module.associative_arrays.insert(param.clone(), v); }
+                    None => { self.module.associative_arrays.remove(&param); }
+                }
                 continue;
             }
             if is_out {
                 self.writeback_assoc_param(&param, &caller);
             }
-            self.purge_assoc_param(&param);
+            self.purge_assoc_param(&param, prior);
         }
         // Capture the callee's queue formals now; the caller's shadowed
         // storage is restored below, and only then is the writeback
@@ -92922,7 +92947,7 @@ impl Simulator {
                 }
             }
         }
-        let mut assoc_params: Vec<(String, String, bool)> = Vec::new(); // (param_name, caller_array_name)
+        let mut assoc_params: Vec<(String, String, bool)> = Vec::new(); // (param_name, caller_array_name, is_out)
         let mut array_params: Vec<String> = Vec::new(); // param names with unpacked Range dim
         self.push_queue_frame();
         let mut array_writebacks: Vec<(String, String, i64, i64)> = Vec::new();
@@ -102839,7 +102864,7 @@ impl Simulator {
                 }
                 let mut queue_writebacks: Vec<(String, String)> = Vec::new();
                 let mut array_writebacks: Vec<(String, String, i64, i64)> = Vec::new();
-                let mut assoc_params: Vec<(String, String, bool)> = Vec::new();
+                let mut assoc_params: Vec<(String, String, bool, Option<bool>)> = Vec::new();
                 // Member-wise struct `output`/`inout`/`ref` formals bypass the
                 // whole-value `output_bindings` path (see exec_function_call).
                 let mut struct_output_writebacks: Vec<(String, Expression)> = Vec::new();
@@ -102865,14 +102890,14 @@ impl Simulator {
                         output_bindings.push((port.name.name.clone(), args[i].clone()));
                     }
                     if i < args.len() {
-                        if let Some((param, caller)) = self.bind_assoc_param(port, &args[i]) {
+                        if let Some((param, caller, prior)) = self.bind_assoc_param(port, &args[i]) {
                             let is_out = matches!(
                                 port.direction,
                                 PortDirection::Output
                                     | PortDirection::Inout
                                     | PortDirection::Ref
                             );
-                            assoc_params.push((param, caller, is_out));
+                            assoc_params.push((param, caller, is_out, prior));
                             continue;
                         }
                         // §13.5.2: a formal with an unpacked QUEUE / array
@@ -103611,14 +103636,23 @@ impl Simulator {
                 // §13.5.2: copy `output`/`inout`/`ref` associative-array
                 // formals back onto the caller's AA (signal-namespace
                 // merge), then drop the formal's temporary copy.
-                for (param, caller, is_out) in std::mem::take(&mut assoc_params) {
+                for (param, caller, is_out, prior) in std::mem::take(&mut assoc_params) {
                     if param == caller {
+                        // Identity binding — the body's writes landed directly
+                        // in the caller's namespace; just restore the prior
+                        // registration (a nested same-name formal must not
+                        // leave the flat `module.associative_arrays` entry
+                        // clobbered).
+                        match prior {
+                            Some(v) => { self.module.associative_arrays.insert(param.clone(), v); }
+                            None => { self.module.associative_arrays.remove(&param); }
+                        }
                         continue;
                     }
                     if is_out {
                         self.writeback_assoc_param(&param, &caller);
                     }
-                    self.purge_assoc_param(&param);
+                    self.purge_assoc_param(&param, prior);
                 }
                 for saved in formal_metadata.into_iter().rev() {
                     self.restore_formal_metadata(saved);

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -53737,6 +53737,20 @@ impl Simulator {
                             if let Some(v) = self.module.parameters.get(&member.name) {
                                 return v.clone();
                             }
+                            // §26.3: a package DATA declaration — a `const` or
+                            // a plain variable — reached through `pkg::X`.
+                            // These are registered under their BARE name as a
+                            // signal (the flat-Ident path at module/initial
+                            // scope resolves them that way), so neither the
+                            // enum nor the parameter route above has an entry
+                            // and the reference fell through to read 0 inside
+                            // a subroutine body. Read the bare signal; because
+                            // the base is a real package (not a caller local),
+                            // the lookup honors the package qualification
+                            // rather than a same-named subroutine local.
+                            if let Some(v) = self.get_signal(&member.name) {
+                                return v.clone();
+                            }
                         }
                     }
                 }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -84706,6 +84706,71 @@ impl Simulator {
         None
     }
 
+    /// §8.25: derive the per-specialization signature of an ANCESTOR class
+    /// reached through a CONCRETE subclass — e.g. `ext1::ID()` where
+    /// `ext1 extends uvm_tlm_extension#(ext1)`. A static call like
+    /// `ext1::ID()` carries no `#(spec)` and has no instance, so `current_spec`
+    /// is None and inherited statics key the shared `Class::member` cell,
+    /// colliding across sibling specializations (`ext1::ID()` and
+    /// `ext2::ID()` returned the same singleton). Walk the receiver's extends
+    /// chain rebinding each parent's type params from `extends_type_args` until
+    /// `ancestor` is bound, and return its `(base, sig)` so the caller can seed
+    /// `current_spec`. Mirrors the assoc-key carry loop.
+    fn static_receiver_spec(&self, receiver: &str, ancestor: &str) -> Option<(String, String)> {
+        let mut carried: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let mut cur = Some(receiver.to_string());
+        let mut level = 0;
+        while let Some(cn) = cur {
+            level += 1;
+            if level > 64 {
+                return None;
+            }
+            let cd = self.module.classes.get(&cn)?;
+            if cn == ancestor {
+                let sig = self.rebind_class_sig(&cd, &carried);
+                return Some((cn, sig));
+            }
+            // Move to the parent, rebinding its type params from this class's
+            // extends type args.
+            let parent = cd.extends.clone()?;
+            if let Some(pcd) = self.module.classes.get(&parent) {
+                let order: Vec<String> = if pcd.param_order.is_empty() {
+                    pcd.type_param_names.clone()
+                } else {
+                    pcd.param_order.clone()
+                };
+                let mut next: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
+                for (i, pname) in order.iter().enumerate() {
+                    if let Some(arg) = cd.extends_type_args.get(i) {
+                        let a = arg.trim();
+                        let resolved = carried.get(a).cloned().unwrap_or_else(|| a.to_string());
+                        next.insert(pname.clone(), resolved);
+                    }
+                }
+                carried = next;
+            }
+            cur = Some(parent);
+        }
+        None
+    }
+
+    /// Rebuild a class's specialization signature string from a binding map of
+    /// its type/value parameter names to concrete leaves (declaration order).
+    fn rebind_class_sig(&self, cd: &crate::compiler::elaborate::ElaboratedClass, carried: &std::collections::HashMap<String, String>) -> String {
+        let order: Vec<String> = if cd.param_order.is_empty() {
+            cd.type_param_names.clone()
+        } else {
+            cd.param_order.clone()
+        };
+        order
+            .iter()
+            .map(|p| carried.get(p).cloned().unwrap_or_else(|| p.clone()))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
     /// Resolve a CLASS-SCOPED constant `ClassName::member` — an enum literal
     /// of a `typedef enum` declared in `ClassName` or an ancestor, or a static
     /// property. SystemVerilog scopes enum literals to their declaring class,
@@ -87524,7 +87589,22 @@ impl Simulator {
                 break;
             };
             if has_method {
-                return Some(self.exec_method_in_class_hierarchy(0, &cname, method_name, args));
+                // §8.25: a static inherited from a PARAMETERIZED base reached
+                // through a concrete subclass (`ext1::ID()` where `ext1 extends
+                // base#(ext1)`) has no `#(spec)` and no instance, so seed
+                // current_spec from the receiver's extends type args so
+                // per-specialization statics stay distinct.
+                let saved = self.current_spec.clone();
+                if !self.class_is_parameterized(class_name)
+                    && self.class_is_parameterized(&cname)
+                {
+                    if let Some(spec) = self.static_receiver_spec(class_name, &cname) {
+                        self.current_spec = Some(spec);
+                    }
+                }
+                let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
+                self.current_spec = saved;
+                return Some(v);
             }
             cur = parent;
         }
@@ -87552,7 +87632,19 @@ impl Simulator {
                 break;
             };
             if has_method {
-                return Some(self.exec_method_in_class_hierarchy(0, &cname, method_name, args));
+                // §8.25: see exec_static_method — seed current_spec for
+                // per-specialization inherited statics.
+                let saved = self.current_spec.clone();
+                if !self.class_is_parameterized(class_name)
+                    && self.class_is_parameterized(&cname)
+                {
+                    if let Some(spec) = self.static_receiver_spec(class_name, &cname) {
+                        self.current_spec = Some(spec);
+                    }
+                }
+                let v = self.exec_method_in_class_hierarchy(0, &cname, method_name, args);
+                self.current_spec = saved;
+                return Some(v);
             }
             cur = parent;
         }
@@ -103151,6 +103243,27 @@ impl Simulator {
                                     self.current_spec = Some((cn.clone(), sig_frags.join(",")));
                                 }
                             }
+                        }
+                    }
+                }
+                // §8.25 instance-method analogue of the static-receiver seeding
+                // above: a CONCRETE instance (e.g. `ext3x`) whose method is
+                // declared in a PARAMETERIZED base (`get_type_handle` in
+                // `uvm_tlm_extension`) reaches it through `extends #(ext3)`.
+                // The instance seeding above leaves current_spec unset for a
+                // concrete (unparameterized) class, so the method body's inner
+                // static call (`ID()`) resolves against the generic base and
+                // mints a WRONG singleton. Derive the declaring class's
+                // specialization from the receiver's extends type args.
+                if let Some(inst) = self.heap.get(handle).and_then(|o| o.as_ref()) {
+                    if self.current_spec.is_none()
+                        && !self.class_is_parameterized(&inst.class_name)
+                        && self.class_is_parameterized(&cname)
+                    {
+                        if let Some(spec) =
+                            self.static_receiver_spec(&inst.class_name, &cname)
+                        {
+                            self.current_spec = Some(spec);
                         }
                     }
                 }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -53669,6 +53669,34 @@ impl Simulator {
                 // BEFORE the object-property paths below — a class name has no
                 // runtime instance, so without this `Base::STARTED` reads 0.
                 if let ExprKind::Ident(h) = &expr.kind {
+                    // §9.7: the built-in `process` class's state enum
+                    // (`process::RUNNING` … `process::KILLED`). `process` is
+                    // not a USER-declared class (it is without a body, so no
+                    // `module.classes` entry exists), so the flattened
+                    // hier-Ident form `process::KILLED` (used at module/initial
+                    // scope) resolves it through the `process` special-case in
+                    // the Ident arm, but inside a function/task/method body the
+                    // parser represents the reference as
+                    // `MemberAccess(Ident("process"), X)` and it fell through to
+                    // an object-property read that returned 0 — so
+                    // `p.status() == process::KILLED` was ALWAYS false and
+                    // killed (zombie) processes were never cleared. Mirror the
+                    // flat-Ident handling here.
+                    if h.path.len() == 1
+                        && h.path[0].name.name == "process"
+                        && h.path[0].selects.is_empty()
+                    {
+                        if let Some(v) = match member.name.as_str() {
+                            "FINISHED" => Some(0u64),
+                            "RUNNING" => Some(1u64),
+                            "WAITING" => Some(2u64),
+                            "SUSPENDED" => Some(3u64),
+                            "KILLED" => Some(4u64),
+                            _ => None,
+                        } {
+                            return Value::from_u64(v, 32);
+                        }
+                    }
                     if h.path.len() == 1 && h.path[0].selects.is_empty()
                         && self.module.classes.contains_key(&h.path[0].name.name)
                     {

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -31517,6 +31517,75 @@ impl Simulator {
         }
     }
 
+    /// Resume level-sensitive `wait(expr)` waiters parked in
+    /// `condition_waiters` whose condition has just become true. IEEE
+    /// 1800-2023 §9.7.4: `wait(cond)` is level-sensitive — the process
+    /// resumes as soon as the condition is true, INCLUDING in the same
+    /// timestep via a delta-cycle (#0) write from another process.
+    ///
+    /// Because `wait` on non-signal state (class members / locals) cannot use
+    /// the edge-triggered event_waiter path, waiters park here and are
+    /// re-checked as a bounded fixpoint: reschedule each, run the ones whose
+    /// condition now holds (its continuation may free another waiter), apply
+    /// any NBA work those runs produced, and iterate until a round advances
+    /// no waiter (the remainder are blocked on a genuinely future-time
+    /// change).
+    ///
+    /// The caller invokes this BOTH (a) inside `run_one_tick`'s active loop,
+    /// immediately before the INACTIVE (`#0`) region is promoted — so a
+    /// waiter is resumed in the SAME delta as the write that satisfied it,
+    /// before a `#0`-parked peer's continuation overwrites the value — and
+    /// (b) at the end of the tick, after the NBA region has settled, to
+    /// catch waiters satisfied by non-blocking/edge-propagated state.
+    fn drain_condition_waiters(&mut self) {
+        let mut guard = 0u32;
+        while !self.condition_waiters.is_empty()
+            && !self.finished
+            && !self.zero_delay_defer_pending
+        {
+            guard += 1;
+            if guard > 10000 {
+                break;
+            }
+            let prog_before = self.cond_progress;
+            let parked = std::mem::take(&mut self.condition_waiters);
+            for (cpid, cont) in parked {
+                self.event_queue.schedule(self.time, cpid, cont);
+            }
+            while self.event_queue.next_time() == Some(self.time)
+                && !self.finished
+                && !self.zero_delay_defer_pending
+            {
+                let Some((bpid, stmts)) = self.event_queue.pop_front(self.time) else {
+                    break;
+                };
+                self.run_scheduled_process(bpid, &stmts);
+                if !self.is_pid_suspended(bpid) {
+                    self.child_finished(bpid);
+                }
+            }
+            if !self.nba_fast.is_empty()
+                || !self.nba_queue.is_empty()
+                // §15.5.2: a bare `->>` (deferred trigger) must flush with the
+                // NBA region even when no NBA DATA is queued.
+                || !self.pending_nba_triggers.is_empty()
+                || !self.pending_nba_instance_triggers.is_empty()
+                || self.delayed_nba_due()
+            {
+                self.apply_nba();
+            }
+            if self.dirty_any {
+                self.settle_combinatorial();
+            }
+            // No waiter proceeded this round → the remainder are genuinely
+            // blocked (future-time change); stop re-checking until the next
+            // tick.
+            if self.cond_progress == prog_before {
+                break;
+            }
+        }
+    }
+
     fn run_one_tick(
         &mut self,
         accum: &mut PerTickAccum,
@@ -31641,6 +31710,19 @@ impl Simulator {
             // the NBA region — a `#0`-resumed read must see pre-NBA values
             // (reference-simulator verified; the previous NBA-first order
             // followed a differing commercial camp).
+            //
+            // Before handing control to the INACTIVE (`#0`) continuations,
+            // let any `wait(expr)` whose condition this ACTIVE batch just made
+            // true resume FIRST. Level-sensitive `wait` is a same-delta, same-
+            // timestep handoff (IEEE 1800-2023 §9.7.4); a `#0`-parked peer's
+            // continuation runs in the NEXT delta and may overwrite the value
+            // the waiter latches on — e.g. `x = 1; #0; x = 0;` with a peer
+            // `wait(x==1)` must observe the 1 and proceed, not skip straight
+            // to the 0 (the passthrough-socket AT handshake stalls when the
+            // slave's `wait(state!=BEGIN_RESP)` wakes on the clobbered value).
+            // The end-of-tick fixpoint alone is too late: the `#0` resume has
+            // already committed the overwrite by then.
+            self.drain_condition_waiters();
             if self.promote_inactive_to_active()
                 && self.event_queue.next_time() == Some(self.time)
             {
@@ -31766,56 +31848,8 @@ impl Simulator {
         }
         self.dump_write_changes();
 
-        // Condition-waiter fixpoint. A `wait(expr)` on non-signal state (class
-        // members / locals) parked in condition_waiters during the batch above
-        // instead of falsely proceeding. Now that the active + NBA regions have
-        // settled, re-check each: a waiter whose condition flipped runs its
-        // continuation (and may flip another's), so iterate to a fixpoint. Stop
-        // when a full round advances no waiter (the rest are waiting on a
-        // future-time change).
-        let mut guard = 0u32;
-        while !self.condition_waiters.is_empty() && !self.finished && !self.zero_delay_defer_pending
-        {
-            guard += 1;
-            if guard > 10000 {
-                break;
-            }
-            let prog_before = self.cond_progress;
-            let parked = std::mem::take(&mut self.condition_waiters);
-            for (cpid, cont) in parked {
-                self.event_queue.schedule(self.time, cpid, cont);
-            }
-            while self.event_queue.next_time() == Some(self.time)
-                && !self.finished
-                && !self.zero_delay_defer_pending
-            {
-                let Some((bpid, stmts)) = self.event_queue.pop_front(self.time) else {
-                    break;
-                };
-                self.run_scheduled_process(bpid, &stmts);
-                if !self.is_pid_suspended(bpid) {
-                    self.child_finished(bpid);
-                }
-            }
-            if !self.nba_fast.is_empty()
-            || !self.nba_queue.is_empty()
-            // §15.5.2: a bare `->>` (deferred trigger) must flush with the NBA
-            // region even when no NBA DATA is queued.
-            || !self.pending_nba_triggers.is_empty()
-            || !self.pending_nba_instance_triggers.is_empty()
-            || self.delayed_nba_due()
-        {
-                self.apply_nba();
-            }
-            if self.dirty_any {
-                self.settle_combinatorial();
-            }
-            // No waiter proceeded this round → the remainder are genuinely
-            // blocked (future-time change); stop re-checking until the next tick.
-            if self.cond_progress == prog_before {
-                break;
-            }
-        }
+        // Condition-waiter fixpoint (level-sensitive `wait(expr)` resume).
+        self.drain_condition_waiters();
 
         // `#0` continuations parked during the POST-active stages of this
         // tick (edge cascades, reactive work) resume in the next same-time

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -53473,6 +53473,26 @@ impl Simulator {
                                 &self.format_class_typename(&base, &ta),
                             );
                         }
+                        // §8.25: a bare TYPE PARAMETER of the active
+                        // specialization (`$typename(T)` inside
+                        // `ger#(type T)::do_it()`), resolved through the
+                        // current spec to its CONCRETE bound type — not the
+                        // literal param name. Pre-fix this fell through to the
+                        // scalar-signal fallback and reported `logic` for a
+                        // class type (`T=uvm_object`), hiding what the body
+                        // actually specialized.
+                        if let ExprKind::Ident(hier2) = &arg.kind {
+                            if hier2.path.len() == 1 {
+                                let tnp = &hier2.path[0].name.name;
+                                if let Some(concrete) = self.resolve_type_param_binding(tnp) {
+                                    if concrete != *tnp {
+                                        return Value::from_string(
+                                            &self.typename_of_concrete(&concrete),
+                                        );
+                                    }
+                                }
+                            }
+                        }
                         // A bare class/covergroup type name, or a scalar signal.
                         if let ExprKind::Ident(hier) = &arg.kind {
                             if hier.path.len() == 1 {
@@ -104561,6 +104581,56 @@ impl Simulator {
             }
         }
         None
+    }
+
+    /// `$typename` rendering of a resolved CONCRETE type string: `class <n>`
+    /// for a class / covergroup, the base keyword for a typedef chain
+    /// (`uvm_bitstream_t` -> `logic`), or the type name itself otherwise.
+    /// Used when `$typename` receives a bare TYPE PARAMETER whose binding was
+    /// resolved through the active specialization.
+    fn typename_of_concrete(&self, concrete: &str) -> String {
+        // A class (or a specialization `foo#(...)` whose base is a class).
+        if self.module.classes.contains_key(concrete)
+            || self.module.covergroups.contains_key(concrete)
+        {
+            return format!("class {}", concrete);
+        }
+        if let Some(n) = concrete.split('#').next() {
+            if self.module.classes.contains_key(n)
+                || self.module.covergroups.contains_key(n)
+            {
+                return format!("class {}", concrete);
+            }
+        }
+        // Resolve a typedef chain (`uvm_bitstream_t` -> `logic`) to its base
+        // keyword per IEEE 1800-2017 §20.6.1 ($typename of a built-in type is
+        // that built-in's own name).
+        let mut cur = concrete.to_string();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        while let Some(dt) = self.lookup_typedef_target(&cur) {
+            if !seen.insert(cur.clone()) {
+                break;
+            }
+            match dt {
+                crate::ast::types::DataType::TypeReference { name, .. }
+                    if name.name.name.as_str() != cur =>
+                {
+                    cur = name.name.name.clone();
+                }
+                // A typedef of a base virtual type (`logic signed [63:0]`):
+                // return the base keyword.
+                crate::ast::types::DataType::IntegerVector { kind, .. } => {
+                    cur = match kind {
+                        crate::ast::types::IntegerVectorType::Bit => "bit".to_string(),
+                        crate::ast::types::IntegerVectorType::Reg => "reg".to_string(),
+                        _ => "logic".to_string(),
+                    };
+                    break;
+                }
+                _ => break,
+            }
+        }
+        cur
     }
 
     /// Format the `$typename` string for a class type (IEEE 1800-2017 §21.7):

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -69080,7 +69080,22 @@ impl Simulator {
             ExprKind::Number(NumberLiteral::UnbasedUnsized(_)) => Some(1),
             ExprKind::Ident(h) => {
                 let n = self.resolve_hier_name(h);
-                self.lookup_signal_width(&n)
+                if let Some(w) = self.lookup_signal_width(&n) {
+                    return Some(w);
+                }
+                // A CLASS-FIELD operand (e.g. a `time` / `longint` member of
+                // a `uvm_transaction`) isn't a module-scope signal, so the
+                // width tables above miss it. Falling back to the live
+                // receiver lets a comparison against a literal size the
+                // operand correctly: `begin_time != -1` on a 64-bit `time`
+                // field otherwise sized `-1` as 32-bit and compared
+                // 64-bit-all-ones against 32'hFFFFFFFF as NOT equal.
+                if let Some((handle, prop)) = self.class_prop_receiver(expr) {
+                    if let Some(w) = self.class_prop_width_of(handle, &prop) {
+                        return Some(w);
+                    }
+                }
+                None
             }
             ExprKind::Unary { op, operand } => match op {
                 UnaryOp::Plus | UnaryOp::Minus | UnaryOp::BitNot => self.lrm_self_width(operand),

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -35869,6 +35869,30 @@ impl Simulator {
                         _ => None,
                     };
                     if let Some((cls, mn)) = scoped {
+                        // A `C#(params)::task` receiver dispatches on the
+                        // bare class but must ALSO establish the receiver
+                        // specialization as `current_spec`, or a bare type
+                        // argument `T` in the task body (e.g.
+                        // `tester#(uvm_object)::do_it()` constructing
+                        // `my_cb#(T)` / `uvm_event#(T)`) resolves to the
+                        // literal `T` instead of `uvm_object`. The static
+                        // METHOD path seeds `current_spec` from the
+                        // specialization (§8.25); this static-task path was
+                        // missing it, so the body bound its parameterized
+                        // locals with `type_bindings={T:"T"}`, casting to
+                        // `uvm_callback` failed, and every `$cast` inside the
+                        // callback `get_all` saw a plain `uvm_callback` with
+                        // no callbacks.
+                        let mut recv_spec: Option<(String, String)> = None;
+                        if let ExprKind::MemberAccess { expr: mrecv, .. } = &func.kind {
+                            if let ExprKind::Specialization { .. } = &mrecv.kind {
+                                recv_spec = self
+                                    .resolve_call_spec_params(
+                                        Self::extract_call_spec(&func.clone()),
+                                        &self.current_spec.clone(),
+                                    );
+                            }
+                        }
                         if let Some((td, mclass)) = self.resolve_class_task(&cls, &mn) {
                             if self.stmts_have_blocking(&td.items) {
                                 let mut cleanup = self.bind_task_frame(&td, args);
@@ -35877,12 +35901,21 @@ impl Simulator {
                                 self.this_stack.push(None);
                                 self.class_context_stack.push(Some(mclass));
                                 cleanup.pushed_method_this = true;
+                                let saved_spec = self.current_spec.clone();
+                                if let Some((sb, ss)) = recv_spec {
+                                    self.ensure_spec_statics(&sb, &ss);
+                                    self.current_spec = Some((sb, ss));
+                                }
                                 self.task_cleanup.push(cleanup);
                                 let mut cont: Vec<Statement> = td.items.clone();
                                 cont.push(Statement::new(StatementKind::ScopePop, stmt.span));
                                 // Chain the caller's tail instead of copying it onto the end of
                                 // the spliced body (ProcCont::pushed).
-                                self.run_process_stmts(pid, &pc.pushed(cont, pc.start + i + 1));
+                                self.run_process_stmts(
+                                    pid,
+                                    &pc.pushed(cont, pc.start + i + 1),
+                                );
+                                self.current_spec = saved_spec;
                                 return;
                             }
                         }
@@ -69331,43 +69364,62 @@ impl Simulator {
     fn class_method_return_width(&self, func: &Expression) -> Option<u32> {
         use crate::ast::decl::ClassMethodKind;
         use crate::ast::types::DataType;
-        // Extract (receiver head name, method name) as BORROWED slices.
-        // `infer_width` probes every arithmetic/bitwise operand on each
-        // evaluation, so the two `String` allocations this used to do ran in
-        // every loop iteration; borrowing from `func` avoids them.
-        let (recv_head, mname): (&str, &str) = match &func.kind {
-            ExprKind::MemberAccess { expr, member } => {
-                let head = match &expr.kind {
-                    ExprKind::Ident(h) if h.path.len() == 1 => h.path[0].name.name.as_str(),
-                    _ => return None,
-                };
-                (head, member.name.as_str())
-            }
+        // Extract the receiver expression + method name. `infer_width` probes
+        // every arithmetic/bitwise operand each evaluation, so keep this free
+        // of allocations.
+        let (recv_expr, mname): (&Expression, &str) = match &func.kind {
+            ExprKind::MemberAccess { expr, member } => (expr, member.name.as_str()),
             ExprKind::Ident(h) if h.path.len() == 2 => {
-                (h.path[0].name.name.as_str(), h.path[1].name.name.as_str())
+                // `recv.m(...)` flattened to Ident([recv, m]). Reconstruct a
+                // borrowable Identifier for the receiver segment (no
+                // allocation).
+                let seg = h.path[0].name.name.clone();
+                if let Some(cn) = self.var_class_types.get(&seg) {
+                    return self.method_ret_width(cn, h.path[1].name.name.as_str());
+                } else if let Some(&id) = self.signal_name_to_id.get(seg.as_str()) {
+                    if let Some(cn) = self.signal_type_names.get(&id) {
+                        return self.method_ret_width(cn, h.path[1].name.name.as_str());
+                    }
+                } else if let Some(th) = self.this_stack.last().copied().flatten() {
+                    if let Some(cn) = self.prop_class_type(th, &seg) {
+                        return self.method_ret_width(&cn, h.path[1].name.name.as_str());
+                    }
+                }
+                return None;
             }
             _ => return None,
         };
-        // Resolve the receiver's class type. Common cases only — a bare
-        // local of class type, or a class-typed signal. Subtler resolutions
-        // (properties of `this`, typedef locals, …) return None and keep the
-        // prior fallback.
-        //
-        // NOTE: `var_class_types` is a FLAT accumulator never cleared on
-        // scope/method exit (see the note at `class_prop_type`), so this
-        // binding can be stale across method calls — the result is therefore
-        // NOT memoisable by AST node. That is pre-existing behaviour.
-        let class_name: String = if let Some(cn) = self.var_class_types.get(recv_head) {
-            cn.clone()
-        } else {
-            let id = *self.signal_name_to_id.get(recv_head)?;
-            self.signal_type_names.get(&id)?.clone()
+        let class_name: Option<String> = match &recv_expr.kind {
+            ExprKind::Ident(h) if h.path.len() == 1 && h.path[0].selects.is_empty() => {
+                let rn = h.path[0].name.name.clone();
+                if let Some(cn) = self.var_class_types.get(&rn) {
+                    Some(cn.clone())
+                } else if let Some(&id) = self.signal_name_to_id.get(rn.as_str()) {
+                    self.signal_type_names.get(&id).cloned()
+                } else if let Some(th) = self.this_stack.last().copied().flatten() {
+                    self.prop_class_type(th, &rn)
+                } else {
+                    None
+                }
+            }
+            ExprKind::Index { expr, .. } => Self::collection_element_class(self, expr),
+            _ => None,
         };
+        let class_name = class_name?;
+        self.method_ret_width(&class_name, mname)
+    }
+
+    /// Width of a class method's declared return type, resolved through the
+    /// inheritance chain from `class_name` (read-only; never executes the
+    /// method). `None` for a task / void / unresolvable.
+    fn method_ret_width(&self, class_name: &str, mname: &str) -> Option<u32> {
+        use crate::ast::decl::ClassMethodKind;
+        use crate::ast::types::DataType;
         // Walk the inheritance chain read-only to the method's return type.
         // `extends` must be cloned per level: the borrow of a `classes` entry
         // can't be carried across loop iterations (the entry is dropped at
         // each iteration end).
-        let mut cur = class_name;
+        let mut cur = class_name.to_string();
         while let Some(cd) = self.module.classes.get(&cur) {
             if let Some(m) = cd.methods.get(mname) {
                 if let ClassMethodKind::Function(f) = &m.kind {
@@ -69389,6 +69441,96 @@ impl Simulator {
             cur = cd.extends.clone()?;
         }
         None
+    }
+
+    /// Class type of the element of a collection-index receiver `q[i]` — the
+    /// dynamic-array / queue variable `q`'s element type (a class name when
+    /// the elements are class handles). Mirrors how a queue element member
+    /// call `cb_q[i].pre(...)` resolves its receiver class statically.
+    fn collection_element_class(
+        &self,
+        arr_expr: &Expression,
+    ) -> Option<String> {
+        let ExprKind::Ident(h) = &arr_expr.kind else {
+            return None;
+        };
+        if h.path.len() != 1 {
+            return None;
+        }
+        let name = &h.path[0].name.name;
+        if let Some(cls) = self.module.array_elem_class.get(name.as_str()) {
+            return Some(cls.clone());
+        }
+        if let Some(cls) = self.declared_collection_elem_class(name) {
+            return Some(cls);
+        }
+        // A queue/dyn-array of a TYPEDEF'd class (`cb_type cb_q[$]` where
+        // `typedef uvm_event_callback#(T) cb_type;`) has an element type that
+        // names the typedef, not a registered class — `array_elem_class` and
+        // `declared_collection_elem_class` miss it. Some queue declarations
+        // also record an EMPTY unpacked-dimensions list on `var_decl_types`
+        // (`cb_type cb_q[$]`), so resolve the (possibly typedef'd) element
+        // name to its base class regardless of recorded dimensions.
+        if let Some(dt) = self.module.var_decl_types.get(name).cloned() {
+            if let Some(elem) = Self::collection_elem_typename(&dt) {
+                if let Some(cls) = self.resolve_typeref_class_name(&elem) {
+                    return Some(cls);
+                }
+            }
+        }
+        // A COLLECTION FIELD of the enclosing class (`base_cb q[$];` as a
+        // member of `this`) is not registered in the module-scope tables; its
+        // element class comes from the property's declared type. Walk the
+        // class-context chain (leaf first) for the property, like the field
+        // element-class resolution at a collection assignment, and resolve the
+        // declared element type to a class.
+        if let Some(Some(ctx)) = self.class_context_stack.last().cloned() {
+            let mut cur = Some(ctx);
+            let mut seen: HashSet<String> = HashSet::default();
+            while let Some(cn) = cur {
+                if !seen.insert(cn.clone()) {
+                    break;
+                }
+                let Some(cd) = self.module.classes.get(&cn) else {
+                    break;
+                };
+                if let Some(tn) = cd.properties.get(name).and_then(|s| s.type_name.clone()) {
+                    let tn = tn.trim();
+                    if let Some(cls) = self.resolve_typeref_class_name_str(tn) {
+                        return Some(cls);
+                    }
+                }
+                cur = cd.extends.clone();
+            }
+        }
+        None
+    }
+
+    /// Resolve a class name / typedef / specialization string to a class name.
+    fn resolve_typeref_class_name_str(&self, s: &str) -> Option<String> {
+        let tnname = crate::ast::types::TypeName {
+            scope: None,
+            name: crate::ast::Identifier {
+                name: s.to_string(),
+                span: crate::ast::Span::dummy(),
+            },
+            span: crate::ast::Span::dummy(),
+        };
+        self.resolve_typeref_class_name(&tnname)
+    }
+
+    /// Element type of an unpacked-collection DataType, or None for a scalar /
+    /// non-collection type.
+    fn collection_elem_typename(dt: &crate::ast::types::DataType) -> Option<crate::ast::types::TypeName> {
+        match dt {
+            crate::ast::types::DataType::TypeReference { name, dimensions, .. }
+                if !dimensions.is_empty() =>
+            {
+                Some(name.clone())
+            }
+            crate::ast::types::DataType::TypeReference { name, .. } => Some(name.clone()),
+            _ => None,
+        }
     }
 
     fn infer_lhs_width(&mut self, expr: &Expression) -> u32 {
@@ -72875,6 +73017,26 @@ impl Simulator {
                             if nm == "this_type" || nm == "this" {
                                 if let Some((b, s)) = &self.current_spec {
                                     return Some(format!("{}#({})", b, s));
+                                }
+                            }
+                            // A type arg that is a TYPEDEF of a parameterized
+                            // class (`cb_type cb_q[$]` where `typedef
+                            // uvm_event_callback#(T) cb_type;`): expand it via
+                            // `resolve_typedef_spec` so the base's own type
+                            // args are carried (and their bare params resolved
+                            // through `current_spec`). `expr_to_spec_fragment`
+                            // on the raw typedef ident otherwise returns ONLY
+                            // the base class name — dropping the `#(T)`, so
+                            // the missing param is afterwards filled with its
+                            // DECLARED DEFAULT (`uvm_object`) instead of the
+                            // enclosing `T` (`string`). That made the string /
+                            // `uvm_object` event callbacks key differently and
+                            // the string event's `get_all` missed its callback.
+                            if self.module.typedef_types.contains_key(nm.as_str())
+                                || self.lookup_typedef_target(nm.as_str()).is_some()
+                            {
+                                if let Some((tb, ts)) = self.resolve_typedef_spec(&nm) {
+                                    return Some(format!("{}#({})", tb, ts));
                                 }
                             }
                         }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -60809,6 +60809,18 @@ impl Simulator {
                                 };
                                 self.module.arrays.insert(name.clone(), (0, -1, w));
                                 self.module.dynamic_arrays.insert(name.clone());
+                                // A QUEUE-typed local (`int a[$];`, possibly with
+                                // a bound `[$:N]`) keeps the queue semantics -
+                                // index-at-size appends, size tracking on
+                                // `q[i] = v` back-fill - not the discard-out-of-
+                                // range rule of an unallocated dynamic array.
+                                // Mirror the module-scope classification.
+                                if matches!(
+                                    first,
+                                    UnpackedDimension::Queue { .. }
+                                ) {
+                                    self.module.queue_vars.insert(name.clone());
+                                }
                                 self.widths.insert(name.clone(), w);
                                 self.set_queue_size(&name, 0);
                                 // §7.4.5: a LOCAL `T a[][16]` / `a[$][16]` —

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -86774,6 +86774,23 @@ impl Simulator {
         self.static_fixed_key_in(cls, member)
     }
 
+    /// Is `member` a STATIC queue/assoc/dynamic-array collection property of
+    /// `start_class` or an ancestor (i.e. it is in `static_collections`)?
+    fn member_is_static_coll(&self, start_class: &str, member: &str) -> bool {
+        let mut cur = Some(start_class.to_string());
+        while let Some(cn) = cur {
+            if let Some(cd) = self.module.classes.get(&cn) {
+                if cd.static_collections.iter().any(|(n, _, _)| n == member) {
+                    return true;
+                }
+                cur = cd.extends.clone();
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
     /// Does `start_class` or an ancestor declare `name` as a STATIC
     /// queue/assoc/dynamic-array collection (i.e. it is in
     /// `static_collections`)?
@@ -87009,6 +87026,30 @@ impl Simulator {
                     // the class name as an object handle (0 → None), and the
                     // assoc-array first()/next() iteration silently fails.
                     if self.module.classes.contains_key(&bh.path[0].name.name) {
+                        // §8.25: an EXPLICITLY parameterized access
+                        // `config_db#(int)::m_rsc.exists(c)`/`.num()` arrives
+                        // here as a bare `Ident(config_db)` receiver (the outer
+                        // value-context eval strips the `Specialization`
+                        // wrapper before the builtin method dispatches). The
+                        // active `current_spec` still carries `(config_db,
+                        // int)`, so resolve the per-spec static-collection key
+                        // the same way the `Specialization` arm below does;
+                        // otherwise the read lands on bare `m_rsc` while the
+                        // matching write went to `config_db#(int)::m_rsc`, and
+                        // `exists()`/`num()` report empty.
+                        if let Some((cb, cs)) = &self.current_spec {
+                            if cb == &bh.path[0].name.name
+                                && self.member_is_static_coll(cb, &member.name)
+                            {
+                                let sb = cb.clone();
+                                let ss = cs.clone();
+                                let saved = self.current_spec.take();
+                                self.current_spec = Some((sb.clone(), ss));
+                                let key = self.static_prop_key(&sb, &member.name);
+                                self.current_spec = saved;
+                                return key;
+                            }
+                        }
                         if self.is_associative_array(&member.name) {
                             return Some(member.name.clone());
                         }
@@ -87084,31 +87125,12 @@ impl Simulator {
                     ) else {
                         return None;
                     };
-                    let mut cur = Some(b.clone());
-                    while let Some(cn) = cur {
-                        let is_static_coll = self
-                            .module
-                            .classes
-                            .get(&cn)
-                            .map(|cd| {
-                                cd.static_properties.contains(&member.name)
-                                    && cd.static_collections
-                                        .iter()
-                                        .any(|(n, _, _)| n == &member.name)
-                            })
-                            .unwrap_or(false);
-                        if is_static_coll {
-                            let saved = self.current_spec.take();
-                            self.current_spec = Some((b.clone(), s.clone()));
-                            let key = self.static_prop_key(&b, &member.name);
-                            self.current_spec = saved;
-                            return key;
-                        }
-                        cur = self
-                            .module
-                            .classes
-                            .get(&cn)
-                            .and_then(|cd| cd.extends.clone());
+                    if self.member_is_static_coll(&b, &member.name) {
+                        let saved = self.current_spec.take();
+                        self.current_spec = Some((b.clone(), s.clone()));
+                        let key = self.static_prop_key(&b, &member.name);
+                        self.current_spec = saved;
+                        return key;
                     }
                     None
                 }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -53493,6 +53493,23 @@ impl Simulator {
                                 }
                             }
                         }
+                        // A bare `data_type` argument that names a TYPEDEF
+                        // (`$typename(my_bits_t)`): per §20.6.1a the typedef
+                        // resolves back to its built-in base, so "logic
+                        // signed [15:0]" rather than the typedef name or a
+                        // bare "logic".
+                        if let ExprKind::Ident(hier_td) = &arg.kind {
+                            if hier_td.path.len() == 1 && hier_td.path[0].selects.is_empty() {
+                                let tdn = &hier_td.path[0].name.name;
+                                if self.module.typedef_types.contains_key(tdn)
+                                    || self.lookup_typedef_target(tdn).is_some()
+                                {
+                                    if let Some(target) = self.lookup_typedef_target(tdn) {
+                                        return Value::from_string(&self.typename_of_dt(&target));
+                                    }
+                                }
+                            }
+                        }
                         // A bare class/covergroup type name, or a scalar signal.
                         if let ExprKind::Ident(hier) = &arg.kind {
                             if hier.path.len() == 1 {
@@ -53501,6 +53518,25 @@ impl Simulator {
                                     || self.module.covergroups.contains_key(n.as_str())
                                 {
                                     return Value::from_string(&format!("class {}", n));
+                                }
+                            }
+                            let leaf = hier
+                                .path
+                                .last()
+                                .map(|s| s.name.name.as_str())
+                                .unwrap_or("");
+                            // A signal or block-local var with a declared
+                            // type: render it, so `logic [15:0] v` reports
+                            // "logic [15:0]" (§20.6.1g preserves the range)
+                            // instead of a bare "logic".
+                            if let Some(dt) = self.module.var_decl_types.get(leaf).cloned() {
+                                return Value::from_string(&self.typename_of_dt(&dt));
+                            }
+                            // A var declared with a TYPEDEF'd type
+                            // (`my_bits_t v1;`): render the typedef's base.
+                            if let Some(tn) = self.var_typedef_types.get(leaf).cloned() {
+                                if let Some(target) = self.lookup_typedef_target(&tn) {
+                                    return Value::from_string(&self.typename_of_dt(&target));
                                 }
                             }
                             let name = self.resolve_hier_name(hier);
@@ -78905,6 +78941,115 @@ impl Simulator {
             break;
         }
         cur
+    }
+
+    /// IEEE 1800-2017 §20.6.1 `$typename` string for a resolved (builtin)
+    /// `DataType`: the built-in keyword, then non-default signing, then the
+    /// packed-vector range (bounds as unsized decimals). A typedef /
+    /// `TypeReference` is resolved back to its built-in base type (§20.6.1a),
+    /// the default signing is removed (§20.6.1b), and vector/array ranges are
+    /// preserved (§20.6.1g).
+    fn typename_of_dt(&self, dt: &DataType) -> String {
+        use crate::ast::types::{
+            DataType, IntegerAtomType, IntegerVectorType, PackedDimension, RealType, Signing, SimpleType,
+        };
+        let cur = self.resolve_dt(dt);
+        match &cur {
+            DataType::IntegerVector { kind, signing, dimensions, .. } => {
+                let kw = match kind {
+                    IntegerVectorType::Bit => "bit",
+                    IntegerVectorType::Logic => "logic",
+                    IntegerVectorType::Reg => "reg",
+                };
+                // Vector types default to UNsigned, so only the explicit
+                // `signed` survives default-signing removal.
+                let sign = matches!(signing, Some(Signing::Signed)).then_some(" signed").unwrap_or("");
+                let mut s = format!("{}{}", kw, sign);
+                for d in dimensions {
+                    match d {
+                        PackedDimension::Range { left, right, .. } => {
+                            let l = crate::elaborate::const_eval_i64_with_params(left, None);
+                            let r = crate::elaborate::const_eval_i64_with_params(right, None);
+                            match (l, r) {
+                                (Some(l), Some(r)) => s.push_str(&format!(" [{}:{}]", l, r)),
+                                // Unresolvable bound: drop the range but keep
+                                // the base keyword.
+                                _ => return kw.to_string(),
+                            }
+                        }
+                        PackedDimension::Unsized(_) => {}
+                    }
+                }
+                s
+            }
+            DataType::IntegerAtom { kind, signing, .. } => {
+                let kw = match kind {
+                    IntegerAtomType::Byte => "byte",
+                    IntegerAtomType::ShortInt => "shortint",
+                    IntegerAtomType::Int => "int",
+                    IntegerAtomType::LongInt => "longint",
+                    IntegerAtomType::Integer => "integer",
+                    IntegerAtomType::Time => "time",
+                };
+                // Integer atoms default to signed; drop it, keep explicit
+                // `unsigned`.
+                if matches!(signing, Some(Signing::Unsigned)) {
+                    format!("{} unsigned", kw)
+                } else {
+                    kw.to_string()
+                }
+            }
+            DataType::Real { kind, .. } => match kind {
+                RealType::Real => "real".to_string(),
+                RealType::ShortReal => "shortreal".to_string(),
+                RealType::RealTime => "realtime".to_string(),
+            },
+            DataType::Simple { kind, .. } => match kind {
+                SimpleType::String => "string".to_string(),
+                SimpleType::Chandle => "chandle".to_string(),
+                SimpleType::Event => "event".to_string(),
+            },
+            DataType::Implicit { .. } => "logic".to_string(),
+            // Aggregates / classes are out of the scalar path's scope.
+            _ => "logic".to_string(),
+        }
+    }
+
+    /// `$typename` of a resolved CONCRETE type string (a type parameter's
+    /// binding, from `resolve_type_param_binding`): `class <n>` for a class /
+    /// covergroup (or a class specialization), or the base keyword with the
+    /// packed range for a built-in / typedef'd vector.
+    fn typename_of_concrete(&self, concrete: &str) -> String {
+        // A class (or a specialization `foo#(...)` whose base is a class).
+        if self.module.classes.contains_key(concrete)
+            || self.module.covergroups.contains_key(concrete)
+        {
+            return format!("class {}", concrete);
+        }
+        if let Some(n) = concrete.split('#').next() {
+            if self.module.classes.contains_key(n)
+                || self.module.covergroups.contains_key(n)
+            {
+                return format!("class {}", concrete);
+            }
+        }
+        // A typedef of a built-in / vector, e.g. `uvm_bitstream_t` ->
+        // `logic signed [4095:0]`. Resolve the target and render it.
+        if self.module.typedef_types.contains_key(concrete)
+            || self.lookup_typedef_target(concrete).is_some()
+        {
+            let target = self
+                .lookup_typedef_target(concrete)
+                .unwrap_or_else(|| crate::ast::types::DataType::Implicit {
+                    signing: None,
+                    dimensions: Vec::new(),
+                    span: crate::ast::Span::dummy(),
+                });
+            return self.typename_of_dt(&target);
+        }
+        // Otherwise a bare built-in keyword (`string`, `int`, ...) or the
+        // type name itself.
+        concrete.to_string()
     }
 
     /// Constant indices of a member's (single) unpacked dimension.
@@ -104581,56 +104726,6 @@ impl Simulator {
             }
         }
         None
-    }
-
-    /// `$typename` rendering of a resolved CONCRETE type string: `class <n>`
-    /// for a class / covergroup, the base keyword for a typedef chain
-    /// (`uvm_bitstream_t` -> `logic`), or the type name itself otherwise.
-    /// Used when `$typename` receives a bare TYPE PARAMETER whose binding was
-    /// resolved through the active specialization.
-    fn typename_of_concrete(&self, concrete: &str) -> String {
-        // A class (or a specialization `foo#(...)` whose base is a class).
-        if self.module.classes.contains_key(concrete)
-            || self.module.covergroups.contains_key(concrete)
-        {
-            return format!("class {}", concrete);
-        }
-        if let Some(n) = concrete.split('#').next() {
-            if self.module.classes.contains_key(n)
-                || self.module.covergroups.contains_key(n)
-            {
-                return format!("class {}", concrete);
-            }
-        }
-        // Resolve a typedef chain (`uvm_bitstream_t` -> `logic`) to its base
-        // keyword per IEEE 1800-2017 §20.6.1 ($typename of a built-in type is
-        // that built-in's own name).
-        let mut cur = concrete.to_string();
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        while let Some(dt) = self.lookup_typedef_target(&cur) {
-            if !seen.insert(cur.clone()) {
-                break;
-            }
-            match dt {
-                crate::ast::types::DataType::TypeReference { name, .. }
-                    if name.name.name.as_str() != cur =>
-                {
-                    cur = name.name.name.clone();
-                }
-                // A typedef of a base virtual type (`logic signed [63:0]`):
-                // return the base keyword.
-                crate::ast::types::DataType::IntegerVector { kind, .. } => {
-                    cur = match kind {
-                        crate::ast::types::IntegerVectorType::Bit => "bit".to_string(),
-                        crate::ast::types::IntegerVectorType::Reg => "reg".to_string(),
-                        _ => "logic".to_string(),
-                    };
-                    break;
-                }
-                _ => break,
-            }
-        }
-        cur
     }
 
     /// Format the `$typename` string for a class type (IEEE 1800-2017 §21.7):

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -45346,7 +45346,10 @@ impl Simulator {
                             let is_str = hier
                                 .path
                                 .last()
-                                .is_some_and(|s| self.string_signals.contains(&s.name.name));
+                                .is_some_and(|s| {
+                                    self.string_signals.contains(&s.name.name)
+                                        || self.p_local_is_string(&s.name.name)
+                                });
                             let fitted = if !val.is_real && !is_str {
                                 if let Some(&target_w) = self.widths.get(&joined) {
                                     if val.width != target_w {
@@ -45388,7 +45391,8 @@ impl Simulator {
                             // $urandom` keeps only the low 8 bits). STRING
                             // locals are exempt (1024-bit internal packed
                             // text).
-                            let is_str = self.string_signals.contains(name.as_str());
+                            let is_str = self.string_signals.contains(name.as_str())
+                                || self.p_local_is_string(name);
                             let fitted = if !val.is_real && !is_str {
                                 if let Some(&target_w) = self.widths.get(name) {
                                     let mut f = if val.width != target_w {
@@ -64514,6 +64518,39 @@ impl Simulator {
                             if ai < args.len() {
                                 let arg = &args[ai];
                                 ai += 1;
+                                // §21.2.1.7: a SUBROUTINE-local scalar variable
+                                // (`int x; string s; T _t;` inside a task/
+                                // function) does not live in the module `signals`
+                                // map, so the name-based `render_p_var` path below
+                                // reads nothing and prints `x`/empty. Its runtime
+                                // value sits in the current `local_stack` frame,
+                                // reachable through `eval_expr` (the same read the
+                                // `%0d`/`%0h` arms use, which work). For a bare
+                                // scalar local, evaluate it and render directly —
+                                // quoting WHEN the declared type is `string`
+                                // (resolving a type parameter `T` to its concrete
+                                // bound, so `T=string` prints a quoted string and
+                                // `T=int` prints a number).
+                                if let ExprKind::Ident(h) = &arg.kind {
+                                    if h.path.len() == 1 && h.path[0].selects.is_empty()
+                                        && !self.local_stack.is_empty()
+                                    {
+                                        let nm = &h.path[0].name.name;
+                                        let is_local = self
+                                            .local_stack
+                                            .last()
+                                            .is_some_and(|f| f.contains_key(nm));
+                                        if is_local && !self.local_ident_is_collection(nm) {
+                                            let is_str = self
+                                                .p_local_is_string(nm);
+                                            let v = self.eval_expr(arg);
+                                            let core =
+                                                Self::render_p_value(&v, is_str);
+                                            result.push_str(&core);
+                                            continue;
+                                        }
+                                    }
+                                }
                                 // §7.12.1: an array LOCATOR call (`q.unique()`,
                                 // `q.find with (…)`, `q.min()`) RETURNS a queue.
                                 // Only the ASSIGNMENT path materialized that, so
@@ -81957,6 +81994,58 @@ impl Simulator {
         format!("'{{{}}}", parts.join(", "))
     }
 
+    /// Is a SUBROUTINE-LOCAL variable `name` a QUEUE/assoc/dynamic/fixed
+    /// array (as opposed to a plain scalar)? Local collections are handled by
+    /// `render_p_var`'s name-based element path; a scalar local is rendered by
+    /// evaluating it directly (its value is not a module signal).
+    fn local_ident_is_collection(&self, name: &str) -> bool {
+        self.module.dynamic_arrays.contains(name)
+            || self.module.associative_arrays.contains_key(name)
+            || self.module.arrays.contains_key(name)
+            || self.module.arrays_2d.contains_key(name)
+            || self.module.arrays_nd.contains_key(name)
+    }
+
+    /// Does a SUBROUTINE-LOCAL variable `name` of declared type
+    /// `var_decl_types[name]` hold a `string`? Resolves a TYPE PARAMETER (e.g.
+    /// `T _t;` where `T`→`string`) through the active specialization so the
+    /// `%p` argument quoting matches the concrete bound type.
+    fn p_local_is_string(&self, name: &str) -> bool {
+        use crate::ast::types::{DataType, SimpleType};
+        let Some(dt0) = self.module.var_decl_types.get(name).cloned() else {
+            return self.string_signals.contains(name);
+        };
+        let mut dt = dt0;
+        'walk: loop {
+            if matches!(dt, DataType::Simple { kind: SimpleType::String, .. }) {
+                return true;
+            }
+            match &dt {
+                DataType::TypeReference { name: tn, .. } => {
+                    let n = tn.name.name.as_str();
+                    // Type parameter -> concrete bound type name.
+                    if let Some(bound) = self.resolve_type_param_binding(n) {
+                        if let Some(bdt) = self.module.typedef_types.get(&bound).cloned() {
+                            dt = bdt;
+                            continue 'walk;
+                        }
+                        // `T` bound to a BUILT-IN (e.g. `T`→`int`/`string`):
+                        // only `string` is a quoted `%p` scalar.
+                        return bound == "string";
+                    }
+                    // Named typedef -> its base.
+                    if let Some(bdt) = self.module.typedef_types.get(n).cloned() {
+                        dt = bdt;
+                        continue 'walk;
+                    }
+                    // A class handle is not a string scalar.
+                    return false;
+                }
+                _ => return false,
+            }
+        }
+    }
+
     /// LRM §21.2.1.7 `%p` on the variable `name`: recursively render nested
     /// structs, unpacked arrays, enums, strings and reals in assignment-pattern
     /// form. `None` if neither the variable nor its base has a declared type.
@@ -91173,9 +91262,71 @@ impl Simulator {
         out
     }
 
-    /// Execute a module-level function call with arguments.
-    /// Is `dt` the `string` data type? Used to mark function return variables
-    /// and params so `var[i]` does byte (character) indexing, not bit-select.
+    /// Is a method's DECLARED return type a `string` AFTER resolving a TYPE
+    /// PARAMETER to its concrete bound (e.g. `virtual function T do_read();`
+    /// in `res#(T)`, specialized to `T=string`)? `is_string_data_type`
+    /// cannot answer that — the AST holds `TypeReference("T")`, and without
+    /// resolving it xezim treats the return as an integral width and
+    /// truncates an N-char string to 4 chars when the method returns. Only a
+    /// plainly-`string` verdict short-circuits that resize.
+    fn method_return_is_string(&self, rt: &crate::ast::types::DataType) -> bool {
+        use crate::ast::types::DataType;
+        if Self::is_string_data_type(rt) {
+            return true;
+        }
+        let DataType::TypeReference { name: tn, .. } = rt else {
+            return false;
+        };
+        // Follow a typedef chain, then a type-parameter binding, then its
+        // typedef, back to the base kind.
+        let mut n = tn.name.name.to_string();
+        loop {
+            // A type parameter in the ACTIVE specialization binds to a
+            // concrete type name (`T` -> `string` / `int` / ...).
+            let bound = self
+                .resolve_type_param_binding(&n)
+                .map(|s| s.to_string())
+                .or_else(|| {
+                    // `current_spec` is cleared for a BASE/inherited method
+                    // reached via `super` (e.g. `super.do_read()` executes
+                    // `res#(string)::do_read` with no active specialization),
+                    // so fall back to the RECEIVER object's type bindings.
+                    let h = self.this_stack.last().copied().flatten()?;
+                    let inst = self.heap.get(h)?.as_ref()?;
+                    inst.type_bindings.get(&n).cloned()
+                });
+            if let Some(bound) = bound {
+                if bound == "string" {
+                    return true;
+                }
+                let bdt = self.module.typedef_types.get(&bound).cloned();
+                if let Some(bd) = bdt {
+                    if Self::is_string_data_type(&bd) {
+                        return true;
+                    }
+                    if let DataType::TypeReference { name: bn, .. } = &bd {
+                        n = bn.name.name.to_string();
+                        continue;
+                    }
+                }
+                return false;
+            }
+            let bdt = self.module.typedef_types.get(&n).cloned();
+            if let Some(bd) = bdt {
+                if Self::is_string_data_type(&bd) {
+                    return true;
+                }
+                if let DataType::TypeReference { name: bn, .. } = &bd {
+                    n = bn.name.name.to_string();
+                    continue;
+                }
+                return false;
+            }
+            return false;
+        }
+    }
+
+    /// Is `dt` directly the `string` data type (no typedef/param resolution)?
     fn is_string_data_type(dt: &crate::ast::types::DataType) -> bool {
         matches!(
             dt,
@@ -103314,7 +103465,7 @@ impl Simulator {
                     .map(|name| self.snapshot_formal_metadata(name))
                     .collect();
                 let ret_is_string = matches!(&method.kind,
-                    ClassMethodKind::Function(f) if Self::is_string_data_type(&f.return_type));
+                    ClassMethodKind::Function(f) if self.method_return_is_string(&f.return_type));
                 // A packed return type whose range references a CLASS
                 // parameter (`function bit [W-1:0] mk();`) can only be
                 // sized per instance — capture it for the clamp at the

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -61536,7 +61536,7 @@ impl Simulator {
                         // (needed for signed division/modulo, comparison, and
                         // `%0d` display). A fresh decl also clears a stale
                         // same-named signed flag from another frame.
-                        if super::elaborate::is_type_signed(data_type) {
+                        if self.type_is_signed_concrete(data_type) {
                             self.signed_signals.insert(d.name.name.clone());
                         } else {
                             self.signed_signals.remove(&d.name.name);
@@ -82046,6 +82046,57 @@ impl Simulator {
         }
     }
 
+    /// Is a declared type SIGNED after resolving a TYPE PARAMETER to its
+    /// concrete bound (e.g. `T`→`int`) and following typedef aliases?
+    /// `is_type_signed(_resolved)` alone cannot bind `TypeReference("T")`, so a
+    /// scalar local `T _t` (in a `res#(int)` method) was never stamped signed
+    /// and `%0d`/`%p` rendered it unsigned (`3735928559`) where the reference
+    /// prints `-559038737`. Resolves the type param via the active
+    /// specialization (with the receiver-instance fallback a `super` call
+    /// needs) and judges the base kind like `is_type_signed`.
+    fn type_is_signed_concrete(&self, dt: &crate::ast::types::DataType) -> bool {
+        use crate::ast::types::DataType;
+        // Fast path: resolvable without a type parameter (typedefs only).
+        if super::elaborate::is_type_signed_resolved(dt, &self.module.typedef_types) {
+            return true;
+        }
+        let DataType::TypeReference { name: tn, .. } = dt else {
+            return super::elaborate::is_type_signed(dt);
+        };
+        let mut n = tn.name.name.to_string();
+        for _ in 0..64 {
+            // Is `n` a type parameter bound by the active specialization?
+            if let Some(bound) = self.resolve_type_param_binding(&n) {
+                // Binding to a concrete atom: judge like `is_type_signed`.
+                match bound.as_str() {
+                    "int" | "integer" | "longint" | "shortint" | "byte" => return true,
+                    _ => {
+                        let bdt = self.module.typedef_types.get(&bound).cloned();
+                        match bdt {
+                            Some(bt) if super::elaborate::is_type_signed(&bt) => return true,
+                            Some(DataType::TypeReference { name: bn, .. }) => {
+                                n = bn.name.name.to_string();
+                                continue;
+                            }
+                            _ => return false,
+                        }
+                    }
+                }
+            }
+            // Named typedef -> its base.
+            let bdt = self.module.typedef_types.get(&n).cloned();
+            match bdt {
+                Some(bt) if super::elaborate::is_type_signed(&bt) => return true,
+                Some(DataType::TypeReference { name: bn, .. }) => {
+                    n = bn.name.name.to_string();
+                    continue;
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
     /// LRM §21.2.1.7 `%p` on the variable `name`: recursively render nested
     /// structs, unpacked arrays, enums, strings and reals in assignment-pattern
     /// form. `None` if neither the variable nor its base has a declared type.
@@ -93786,7 +93837,7 @@ impl Simulator {
                             &port.data_type,
                             &self.module.typedef_types,
                         );
-                    } else if super::elaborate::is_type_signed(&port.data_type) {
+                    } else if self.type_is_signed_concrete(&port.data_type) {
                         val.is_signed = true;
                     }
                     locals.insert(port.name.name.clone(), val);
@@ -103740,6 +103791,13 @@ impl Simulator {
                                 val
                             };
                             val.is_signed = signed;
+                        } else if self.type_is_signed_concrete(&port.data_type) {
+                            // A TYPE-PARAMETER formal (`T t` with `T`->`int`)
+                            // isn't a resolvable integral typedef, so
+                            // `scalar_formal_integral` falls through; still
+                            // stamp the resolved signedness so `%p`/`%0d` on a
+                            // `T=int` formal renders signed like the reference.
+                            val.is_signed = true;
                         }
                     } else if super::elaborate::is_type_signed(&port.data_type) {
                         val.is_signed = true;

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -37,6 +37,8 @@ mod param_type_binding_resolves_enclosing_value_param;
 mod virtual_method_in_binary_is_evaluated_once;
 #[path = "classes/typename_type_param_resolves_concrete.rs"]
 mod typename_type_param_resolves_concrete;
+#[path = "classes/static_param_class_collection_reuse.rs"]
+mod static_param_class_collection_reuse;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -35,6 +35,8 @@ mod class_time_field_neg_one;
 mod param_type_binding_resolves_enclosing_value_param;
 #[path = "classes/virtual_method_in_binary_is_evaluated_once.rs"]
 mod virtual_method_in_binary_is_evaluated_once;
+#[path = "classes/typename_type_param_resolves_concrete.rs"]
+mod typename_type_param_resolves_concrete;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -41,6 +41,8 @@ mod typename_type_param_resolves_concrete;
 mod static_param_class_collection_reuse;
 #[path = "classes/explicit_param_static_coll_read.rs"]
 mod explicit_param_static_coll_read;
+#[path = "classes/typename_p_subroutine_locals.rs"]
+mod typename_p_subroutine_locals;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -33,6 +33,8 @@ mod nested_same_named_ref_assoc_formal;
 mod class_time_field_neg_one;
 #[path = "classes/param_type_binding_resolves_enclosing_value_param.rs"]
 mod param_type_binding_resolves_enclosing_value_param;
+#[path = "classes/virtual_method_in_binary_is_evaluated_once.rs"]
+mod virtual_method_in_binary_is_evaluated_once;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -29,6 +29,8 @@ mod type_param_formal_stale_local;
 mod wait_level_sensitive_inactive_delta;
 #[path = "classes/nested_same_named_ref_assoc_formal.rs"]
 mod nested_same_named_ref_assoc_formal;
+#[path = "classes/class_time_field_neg_one.rs"]
+mod class_time_field_neg_one;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -27,6 +27,8 @@ mod bit_class_property_signedness;
 mod type_param_formal_stale_local;
 #[path = "classes/wait_level_sensitive_inactive_delta.rs"]
 mod wait_level_sensitive_inactive_delta;
+#[path = "classes/nested_same_named_ref_assoc_formal.rs"]
+mod nested_same_named_ref_assoc_formal;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -25,6 +25,8 @@ mod assoc_typedef_element_class;
 mod bit_class_property_signedness;
 #[path = "classes/type_param_formal_stale_local.rs"]
 mod type_param_formal_stale_local;
+#[path = "classes/wait_level_sensitive_inactive_delta.rs"]
+mod wait_level_sensitive_inactive_delta;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -39,6 +39,8 @@ mod virtual_method_in_binary_is_evaluated_once;
 mod typename_type_param_resolves_concrete;
 #[path = "classes/static_param_class_collection_reuse.rs"]
 mod static_param_class_collection_reuse;
+#[path = "classes/explicit_param_static_coll_read.rs"]
+mod explicit_param_static_coll_read;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -31,6 +31,8 @@ mod wait_level_sensitive_inactive_delta;
 mod nested_same_named_ref_assoc_formal;
 #[path = "classes/class_time_field_neg_one.rs"]
 mod class_time_field_neg_one;
+#[path = "classes/param_type_binding_resolves_enclosing_value_param.rs"]
+mod param_type_binding_resolves_enclosing_value_param;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -23,6 +23,8 @@ mod class_formal_typedef_widen;
 mod assoc_typedef_element_class;
 #[path = "classes/bit_class_property_signedness.rs"]
 mod bit_class_property_signedness;
+#[path = "classes/type_param_formal_stale_local.rs"]
+mod type_param_formal_stale_local;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
 #[path = "classes/class_field_named_event.rs"]

--- a/tests/classes/class_time_field_neg_one.rs
+++ b/tests/classes/class_time_field_neg_one.rs
@@ -1,0 +1,76 @@
+//! A class `time`-typed field is stored per-object (not as a module-scope
+//! signal), so `lrm_self_width`'s `lookup_signal_width` misses it. A
+//! comparison against a UNSIZED literal like `begin_time != -1` then failed to
+//! size the literal to the field's 64-bit width: `self_det_w` fell back to
+//! `ctx_width` (0), the `-1` stayed 32-bit (`32'hFFFFFFFF`), and `is_equal`
+//! compared 64-bit all-ones (the `-1` initialiser) against 32'hFFFFFFFF as
+//! NOT equal.
+//!
+//! UVM's `uvm_transaction` declares `local time begin_time = -1; end_time =
+//! -1; accept_time = -1;` and its `do_print` prints them only when
+//! `!= -1`. That check evaluating TRUE for a `-1` value added three bogus
+//! `time` rows to the printer output, which the table-printer diff flagged as
+//! a fatal (403x printer).
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/time_field_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A module-level `time` (a module-scope signal) and a class `time` field must
+/// BOTH compare equal to `-1` after being initialised to `-1`, and both must
+/// stay unsigned (`>= 0` true for the all-ones value) — matching the
+/// reference. The class field is the regression case.
+const TIME_FIELD_NEG_ONE: &str = r#"module top;
+  time mod_t = -1;
+  class base;
+    time cls_t = -1;
+    function void check();
+      if (cls_t == -1) $display("RESULT PASS cls_neg1");
+      else             $display("RESULT FAIL cls_neq_literal_neg1");
+      if (cls_t >= 0)  $display("RESULT PASS cls_unsigned");
+      else             $display("RESULT FAIL cls_signed");
+    endfunction
+  endclass
+  initial begin
+    base b = new;
+    if (mod_t == -1) $display("RESULT PASS mod_neg1");
+    else             $display("RESULT FAIL mod_neq_1");
+    b.check();
+    #1; $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn class_time_field_compares_equal_to_unsized_minus_one() {
+    let out = run(TIME_FIELD_NEG_ONE, "neg1");
+    assert!(
+        out.contains("RESULT PASS cls_neg1"),
+        "a class `time` field initialised to -1 must compare == -1 (the literal\n\
+         must be sized to the field's 64-bit width, not left as 32-bit):\n{out}"
+    );
+    assert!(
+        out.contains("RESULT PASS cls_unsigned"),
+        "`time` must stay unsigned (all-ones is a large positive, >= 0):\n{out}"
+    );
+    assert!(
+        out.contains("RESULT PASS mod_neg1"),
+        "module-level time -1 still must == -1:\n{out}"
+    );
+}

--- a/tests/classes/explicit_param_static_coll_read.rs
+++ b/tests/classes/explicit_param_static_coll_read.rs
@@ -1,0 +1,75 @@
+//! An explicitly parameterized static-collection READ
+//! (`config_db#(int)::m_rsc.exists(c)`, `config_db#(int)::m_rsc.num()`) must
+//! resolve to the SAME per-specialization store as the matching WRITE
+//! (`config_db#(int)::m_rsc[c] = new`). UVM's config-db uses `m_rsc[uvm_component]`
+//! bare (inside its parameterized static methods); the explicit `Class#(spec)::`
+//! spelling is the externally-visible counterpart a test author writes when
+//! querying the pool directly. Pre-fix the write kept the `#(int)` (parsing to
+//! a per-spec key) but the method-call receiver dropped it (parsing to a bare
+//! `Ident`), so `exists()/num()` looked in a different store and reported
+//! empty despite a live entry.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str) -> String {
+    std::fs::write("/tmp/explicit_specread.sv", src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", "/tmp/explicit_specread.sv"])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SRC: &str = r#"class comp;
+endclass
+
+class config_db #(type T = int);
+  static int m_rsc[comp];
+endclass
+
+module top;
+  initial begin
+    comp c;
+    c = new;
+    // write a value under the `int` specialization
+    config_db#(int)::m_rsc[c] = 42;
+    // read that explicit specialization back
+    if(config_db#(int)::m_rsc.exists(c))
+      $display("TAG_PASS int-exists val=%0d", config_db#(int)::m_rsc[c]);
+    else
+      $display("TAG_FAIL int-not-exists");
+    $display("RESULT int-num=%0d", config_db#(int)::m_rsc.num());
+    // a DIFFERENT specialization must stay empty (per-spec isolation)
+    $display("RESULT bit-num=%0d", config_db#(bit)::m_rsc.num());
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn explicit_param_static_coll_read_matches_write() {
+    let out = run(SRC);
+    assert!(
+        out.contains("TAG_PASS int-exists val=42"),
+        "explicit `config_db#(int)::m_rsc[c]` write must be readable through \
+         the matching explicit `exists()`/`[c]` read; expected \
+         `TAG_PASS int-exists val=42`, got:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT int-num=1") && out.contains("RESULT bit-num=0"),
+        "per-specialization isolation: int pool must have 1 entry and the bit \
+         pool 0, got:\n{out}"
+    );
+    assert!(
+        !out.contains("TAG_FAIL"),
+        "unexpected explicit-prefix static-collection read failure:\n{out}"
+    );
+}

--- a/tests/classes/nested_same_named_ref_assoc_formal.rs
+++ b/tests/classes/nested_same_named_ref_assoc_formal.rs
@@ -1,0 +1,91 @@
+//! §13.5.2 (`ref` associative-array formal) + §7.9: an OUTER method with a
+//! `ref` assoc formal `list` that CALLS a NESTED method which ALSO has a `ref`
+//! assoc formal named `list`, then continues writing to its own `list` after
+//! the nested call returns.
+//!
+//! REGRESSION: the flat `module.associative_arrays` table is shared across
+//! call-nesting depths, keyed by bare formal name. The nested call's
+//! `bind_assoc_param`/`purge_assoc_param` overwrote and then REMOVED the
+//! `list` entry that the outer call had created, so after the nested return the
+//! outer's `list` was no longer recognized as an associative array:
+//! `list[k]=v` writes stopped landing in the `list[...]` namespace and
+//! `list.num()`/`list.size()` read 0.
+//!
+//! UVM's TLM2 `uvm_port_component::get_provided_to`/`get_connected_to` trip
+//! this: both the proxy's `ref uvm_port_list list` and the inner
+//! `uvm_port_base::get_provided_to(ref uvm_port_base list)` name their formal
+//! `list`, so after the inner call the proxy's `list` silently stayed empty and
+//! every `ap.connect(export)` link was reported missing (a hard UVM_ERROR).
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/nested_assoc_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Outer method `get(ref ltype list)` calls nested `h.fill(ref ltype list)`,
+/// then continues writing to `list`; both formals are named `list`.
+const NESTED_SAME_NAME: &str = r#"module top;
+  typedef int ltype[string];
+
+  class helper;
+    function void fill(ref ltype list);   // nested formal ALSO named `list`
+      list["n1"] = 91;
+      list["n2"] = 92;
+    endfunction
+  endclass
+
+  class proxy;
+    helper h = new;
+    function void get(ref ltype list);     // outer formal named `list`
+      ltype list1;
+      h.fill(list1);                       // nested call, same formal name
+      list.delete();
+      foreach (list1[k]) begin
+        list[k] = list1[k];
+      end
+      if (list.num() == 2) $display("RESULT PASS inner_num=%0d", list.num());
+      else                 $display("RESULT FAIL inner_num=%0d", list.num());
+    endfunction
+  endclass
+
+  task runit();
+    ltype out;
+    automatic proxy p = new;
+    p.get(out);
+    if (out.num() == 2) $display("RESULT PASS out_num=%0d", out.num());
+    else                $display("RESULT FAIL out_num=%0d", out.num());
+  endtask
+
+  initial begin
+    runit();
+    #1;
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn nested_same_named_ref_assoc_formal_does_not_clobber_outer() {
+    let out = run(NESTED_SAME_NAME, "nested");
+    assert!(
+        out.contains("RESULT PASS"),
+        "an outer ref assoc formal must stay associative after a nested\n\
+         method with a same-named formal returns (purging the shared flat\n\
+         registration must not unregister the outer's array)\noutput:\n{out}"
+    );
+}

--- a/tests/classes/param_type_binding_resolves_enclosing_value_param.rs
+++ b/tests/classes/param_type_binding_resolves_enclosing_value_param.rs
@@ -1,0 +1,118 @@
+//! An iterator/generic instantiated with the ENCLOSING parameterized class's
+//! OWN value parameter as a nested type argument must have that parameter
+//! SUBSTITUTED to the concrete value at construction — not captured as the
+//! bare `#(N)` text. UVM's `uvm_callback_iter#(special_comp#(N),
+//! special_cb#(N)) iter = new(this)` inside `special_comp#(N)` binds the
+//! iterator's type param `T` to the enclosing specialization; if the binding
+//! carried the literal `N` instead of `special_comp#(2)`, then
+//! `iter.first()` (calling `uvm_callbacks#(T,CB)::get_first`) resolved T to
+//! the bare `special_comp` and looked up the UN-specialized typewide queue —
+//! empty — so the parameterized special_cb callbacks never fired and the
+//! whole params test failed its a1/a2 callback-sequence
+//! checks. This mirrors that shape without the UVM package: a method of the
+//! parameterized class builds an iterator typed `iter#(comp#(N), cb#(N))`
+//! and probes a per-type registry through T, expecting per-instance spec
+//! state.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/param_type_binding_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const PARAM_TYPE_BINDING: &str = r#"module top;
+  class base_comp;
+    function new(); endfunction
+  endclass
+  class cb #(int N=0);
+    function new(); endfunction
+  endclass
+  // Per-type (and per-spec) global store, like `callbacks#(T,CB)`
+  // `m_tw_cb_q`. The registry's spec string lives in a per-spec static.
+  class registry #(type T=base_comp, type CB=cb#(0));
+    static string m_cell;
+    static function void put(string s);
+      m_cell = s;
+    endfunction
+    static function string get();
+      return (m_cell == "") ? "UNSET" : m_cell;
+    endfunction
+  endclass
+  class iter #(type T=base_comp, type CB=cb#(0));
+    local T m_obj;
+    function new(T obj); m_obj=obj; endfunction
+    function string lookup();
+      return registry#(T, CB)::get();
+    endfunction
+  endclass
+  class comp #(int N=0) extends base_comp;
+    int mark;
+    function new(); mark=0; endfunction
+    // register this specialization in its own registry cell
+    function void set_reg();
+      registry#(comp#(N), cb#(N))::put($sformatf("comp#(%0d)", N));
+    endfunction
+    // build an iterator typed with comp#(N) and CB#(N) and probe per-spec state
+    function string probe();
+      iter#(comp#(N), cb#(N)) it;
+      it = new(this);
+      return it.lookup();
+    endfunction
+  endclass
+  initial begin
+    comp#(1) c1;
+    comp#(2) c2;
+    string s1, s2;
+    c1 = new;
+    c2 = new;
+    c1.set_reg();
+    c2.set_reg();
+    s1 = c1.probe();
+    s2 = c2.probe();
+    $display("RESULT comp#(1) probe=%s", s1);
+    $display("RESULT comp#(2) probe=%s", s2);
+    if (s1 == "comp#(1)") $display("RESULT PASS c1_own_spec");
+    else                  $display("RESULT FAIL c1_probe");
+    if (s2 == "comp#(2)") $display("RESULT PASS c2_own_spec");
+    else                  $display("RESULT FAIL c2_probe");
+    if (s1 == "comp#(1)" && s2 == "comp#(2)")
+      $display("RESULT PASS both_per_spec");
+    else
+      $display("RESULT FAIL bare_N_or_shared_cell");
+    #1; $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn param_type_binding_resolves_enclosing_value_param_for_nested_generic() {
+    let out = run(PARAM_TYPE_BINDING, "binding");
+    assert!(
+        out.contains("RESULT PASS both_per_spec"),
+        "an iterator typed `iter#(comp#(N), cb#(N))` built inside `comp#(N)` must\n\
+         bind the CONCRETE N, so the per-type registry (looked up through T)\n\
+         answers each instance's own specialization:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT comp#(1) probe=comp#(1)"),
+        "comp#(1)'s iterator must resolve comp#(1), not a bare-N/un-specialized cell:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT comp#(2) probe=comp#(2)"),
+        "comp#(2)'s iterator must resolve comp#(2), not leak comp#(1):\n{out}"
+    );
+}

--- a/tests/classes/process_class_9_7.rs
+++ b/tests/classes/process_class_9_7.rs
@@ -261,9 +261,9 @@ fn await_in_forever_body_blocks() {
 // inside a function/task/class-method body the parser represents `process::X`
 // as `MemberAccess(Ident("process"), X)`, which fell through to an object-
 // property read and returned 0. So `p.status() == process::KILLED` was ALWAYS
-// false inside a subroutine, so a killed process was never recognized by
-// the FIFO's zombie-get sweep. Reference simulators return the documented
-// values inside subroutines.
+// false inside a subroutine and a killed process's state was never
+// recognized as such (e.g. a FIFO's zombie-get sweep never cleared killed
+// waiters). The documented values apply inside subroutines.
 
 const ENUM_IN_SUBROUTINE_SRC: &str = r#"
 module top;

--- a/tests/classes/process_class_9_7.rs
+++ b/tests/classes/process_class_9_7.rs
@@ -254,3 +254,69 @@ fn await_in_forever_body_blocks() {
         msgs
     );
 }
+
+// ── §9.7 enum constants (`process::KILLED`, …) inside subroutine bodies ──
+// The state-enum constants (`process::FINISHED`=0 … `process::KILLED`=4) are
+// resolved through the flat hier-Ident form at module/initial scope, but
+// inside a function/task/class-method body the parser represents `process::X`
+// as `MemberAccess(Ident("process"), X)`, which fell through to an object-
+// property read and returned 0. So `p.status() == process::KILLED` was ALWAYS
+// false inside a subroutine, so a killed process was never recognized by
+// the FIFO's zombie-get sweep. Reference simulators return the documented
+// values inside subroutines.
+
+const ENUM_IN_SUBROUTINE_SRC: &str = r#"
+module top;
+  class C;
+    function int kstatus();
+      return process::KILLED;
+    endfunction
+    function bit is_killed(process p);
+      return (p.status() == process::KILLED);
+    endfunction
+  endclass
+
+  function int module_fn();
+    return process::WAITING;
+  endfunction
+
+  initial begin
+    C c;
+    process p;
+    c = new();
+    fork
+      begin
+        p = process::self();
+        #1000;
+      end
+    join_none
+    #10;
+    p.kill();
+    #1;
+    $display("RESULT kstatus_in_method=%0d", c.kstatus());     // 4
+    $display("RESULT waiting_in_function=%0d", module_fn());   // 2
+    $display("RESULT is_killed=%0d", c.is_killed(p));          // 1
+  end
+endmodule
+"#;
+
+#[test]
+fn process_enum_constants_resolve_inside_subroutines() {
+    let sim = simulate(ENUM_IN_SUBROUTINE_SRC, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT kstatus_in_method=4"),
+        "process::KILLED must be 4 inside a class method; got {:?}",
+        msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT waiting_in_function=2"),
+        "process::WAITING must be 2 inside a module function; got {:?}",
+        msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT is_killed=1"),
+        "comparing p.status()==process::KILLED inside a method must be true for a killed process; got {:?}",
+        msgs
+    );
+}

--- a/tests/classes/static_param_class_collection_reuse.rs
+++ b/tests/classes/static_param_class_collection_reuse.rs
@@ -1,0 +1,91 @@
+//! Static collection (associative-array) members of a PARAMETERIZED class,
+//! accessed bare inside its static methods, must persist per-specialization.
+//! UVM's config-db reuse depends on exactly this: `uvm_config_db` repeatedly
+//! calls `uvm_config_db#(uvm_bitstream_t)::set(...)` for the SAME
+//! field, expecting each subsequent call to REUSE the pool entry created on
+//! the first call (moved to the head of the priority queue) rather than
+//! inserting another resource. Without the fix every `set` re-created its
+//! per-component `pool` (the static `m_rsc[uvm_component]` assoc-array member
+//! could not be re-found afterward), so the resource queue grew 2,4,6,8,10,12
+//! and the "expected 2, got N" check failed.
+//!
+//! This test mirrors that shape: a parameterized `config_db#(T)` holding a
+//! static assoc array `m_rsc[comp]`, with `get_pool()` writing/reading it
+//! BARE (no `this`, no explicit `#(spec)` prefix) inside the static method.
+//! Five calls for one component and one for another must create exactly TWO
+//! distinct pools — proving the static assoc member persists and is keyed
+//! per-(class-specialization, component-object).
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str) -> String {
+    std::fs::write("/tmp/static_param_coll.sv", src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", "/tmp/static_param_coll.sv"])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SRC: &str = r#"class comp;
+endclass
+
+class pool;
+  static int instances;
+endclass
+
+class config_db #(type T = int);
+  static pool m_rsc[comp];
+  static function pool get_pool(comp cntxt);
+    pool p;
+    if(!m_rsc.exists(cntxt)) begin
+      p = new;
+      pool::instances = pool::instances + 1;
+      m_rsc[cntxt] = p;
+    end
+    return m_rsc[cntxt];
+  endfunction
+endclass
+
+module top;
+  initial begin
+    comp c;
+    comp c2;
+    c = new;
+    c2 = new;
+    for(int i=0; i<5; i++) begin
+      void'(config_db#(int)::get_pool(c));
+    end
+    void'(config_db#(int)::get_pool(c2));
+    // Five calls for one component + one for another => exactly TWO distinct
+    // pools (one per component). Pre-fix each call created a fresh pool.
+    if(pool::instances == 2)
+      $display("TAG_PASS reuse, pools=%0d", pool::instances);
+    else
+      $display("TAG_FAIL pools=%0d", pool::instances);
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn static_param_class_collection_reuses_shared_cell() {
+    let out = run(SRC);
+    assert!(
+        out.contains("TAG_PASS reuse, pools=2"),
+        "repeated get_pool(c) for the same component must reuse one static \
+         assoc entry; expected pools=2, got:\n{out}"
+    );
+    assert!(
+        !out.contains("TAG_FAIL"),
+        "unexpected static-collection reuse failure:\n{out}"
+    );
+}

--- a/tests/classes/type_param_formal_stale_local.rs
+++ b/tests/classes/type_param_formal_stale_local.rs
@@ -1,0 +1,86 @@
+//! §8.25 — a FORMAL typed with a class TYPE PARAMETER (`IMP imp` inside a
+//! parameterized class) must be resolved to the concrete class the object is
+//! specialized with, so `$cast(imp, src)` checks against the RIGHT type.
+//!
+//! Before this fix, the concrete-typed record for a same-named FORMAL/LOCAL
+//! in an unrelated scope lingered in the flat `var_class_types` map (a local's
+//! record is not scrubbed on frame pop the way a formal's is), so
+//! `class_of_var("imp")` returned the STALE class from the other scope and the
+//! current class's own `IMP imp` — whose declared type is the PARAMETER, not a
+//! real class name — was never recorded. A `$cast(imp, parent)` then resolved
+//! `imp` to the wrong class and failed even when `IMP` genuinely matched
+//! `parent` (UVM's TLM nonblocking socket constructors hit this as
+//! UVM/TLM2/NOIMP on a valid initiator socket).
+use std::process::Command;
+
+fn xezim() -> String {
+    // Resolve the sibling CLI binary from the test binary's own location so
+    // this works for both debug and release profiles.
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/param_formal_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A type-param-typed formal named `imp`, whose `$cast(imp, parent)` must
+/// see the RESOLVED type parameter (`derived1`), not a stale same-named
+/// concrete-typed local left behind by an unrelated function (`derived2`).
+const STALE_IMPL: &str = r#"
+module top;
+  class basecls;
+    bit tag;
+    function new(); tag = 1; endfunction
+  endclass
+  class derived1 extends basecls;
+    bit a;
+  endclass
+  class derived2 extends basecls;
+    bit b;
+  endclass
+  // A function whose LOCAL `imp` has a concrete class type; its record is not
+  // scrubbed on return (unlike a formal's), so it lingers in var_class_types.
+  function void burn();
+    derived2 imp;
+  endfunction
+  // A parameterized class whose `new` has a TYPE-PARAM-typed formal `imp`.
+  class socket #(type IMP = basecls);
+    bit cast_ok;
+    function new(string name, basecls parent, IMP imp = null);
+      if (imp == null) begin
+        if ($cast(imp, parent)) cast_ok = 1; else cast_ok = 0;
+      end
+    endfunction
+  endclass
+  socket #(derived1) s;
+  derived1 d1;
+  initial begin
+    burn();          // plants the stale var_class_types["imp"] = derived2
+    d1 = new();
+    s = new("s", d1);
+    if (s.cast_ok == 1) $display("RESULT PASS");
+    else                $display("RESULT FAIL");
+  end
+endmodule
+"#;
+
+#[test]
+fn type_param_formal_cast_not_poisoned_by_same_named_concrete_local() {
+    let out = run(STALE_IMPL, "stale");
+    assert!(
+        out.contains("RESULT PASS"),
+        "a type-param-typed formal's $cast must beat a stale same-named \
+         concrete-typed local\noutput:\n{out}"
+    );
+}

--- a/tests/classes/typename_p_subroutine_locals.rs
+++ b/tests/classes/typename_p_subroutine_locals.rs
@@ -1,0 +1,88 @@
+//! `%p` must render a SUBROUTINE-local variable's real value, and a string
+//! flowing through a TYPE PARAMETER (generic class method) must not be
+//! truncated. UVM's resource-class overrides (`uvm_resource#(T)`'s
+//! `do_read`/`do_write`) use `T _t` locals in a `%p`; pre-fix `%p` printed `x`/empty for any function-local (its
+//! value is not a module signal), and a `T`-local/return was truncated to
+//! `_t`'s wrong declared width, so `T=string` read back 4 chars ("rld!")
+//! instead of the full text and the test's `m.read()` VALUE assertion failed
+//! (`val != VAL`).
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str) -> String {
+    std::fs::write("/tmp/virtual_rw_p.sv", src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", "/tmp/virtual_rw_p.sv"])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SRC: &str = r#"class res #(parameter type T = int);
+  protected T val;
+  virtual function T do_read();
+    return val;
+  endfunction
+  virtual function void do_write(T t);
+    val = t;
+  endfunction
+  function T read();
+    return do_read();
+  endfunction
+  function void write(T t);
+    do_write(t);
+  endfunction
+endclass
+
+class my_res #(parameter type T = string) extends res#(T);
+  virtual function void do_write(T t);
+    super.do_write(t);
+  endfunction
+  virtual function T do_read();
+    T _t;
+    _t = super.do_read();
+    $display("READ-P=%p", _t);
+    return _t;
+  endfunction
+endclass
+
+module top;
+  int a;
+  string s;
+  my_res#(string) r;
+  initial begin
+    // %p on ordinary subroutine-locals (pre-fix: x / empty)
+    a = 42;
+    s = "hello";
+    $display("A=%p S=%p", a, s);
+    // string through a type-parameterized virtual method (pre-fix: "rld!")
+    r = new;
+    r.write("Hello, world!");
+    $display("RES=%s", r.read());
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn typename_p_formats_subroutine_locals() {
+    let out = run(SRC);
+    assert!(
+        out.contains("A=42") && out.contains("S=\"hello\""),
+        "`%p` must render subroutine-locals with their real value; expected \
+         `A=42 S=\"hello\"`, got:\n{out}"
+    );
+    assert!(
+        out.contains("READ-P=\"Hello, world!\"") && out.contains("RES=Hello, world!"),
+        "a `string` through `T` (generic virtual method) must not be \
+         truncated; expected the full `Hello, world!`, got:\n{out}"
+    );
+}

--- a/tests/classes/typename_p_subroutine_locals.rs
+++ b/tests/classes/typename_p_subroutine_locals.rs
@@ -40,6 +40,15 @@ const SRC: &str = r#"class res #(parameter type T = int);
   function void write(T t);
     do_write(t);
   endfunction
+  // `%0d`/`%p` on a TYPE-PARAMETER local/formal must adopt the bound type's
+  // SIGNEDNESS (`T`→`int` is signed): pre-fix a `T=int` local read back as
+  // an unsigned `3735928559`, not the reference's `-559038737`.
+  virtual function T probe();
+    T _t;
+    _t = 32'hDEAD_BEEF;
+    $display("INT-P=%p INT-D=%0d", _t, _t);
+    return _t;
+  endfunction
 endclass
 
 class my_res #(parameter type T = string) extends res#(T);
@@ -67,6 +76,12 @@ module top;
     r = new;
     r.write("Hello, world!");
     $display("RES=%s", r.read());
+    // signedness of a T=int local (%0d/%p: must be -559038737)
+    begin
+      res#(int) p;
+      p = new;
+      p.probe();
+    end
     $finish;
   end
 endmodule
@@ -84,5 +99,10 @@ fn typename_p_formats_subroutine_locals() {
         out.contains("READ-P=\"Hello, world!\"") && out.contains("RES=Hello, world!"),
         "a `string` through `T` (generic virtual method) must not be \
          truncated; expected the full `Hello, world!`, got:\n{out}"
+    );
+    assert!(
+        out.contains("INT-P=-559038737") && out.contains("INT-D=-559038737"),
+        "a `T=int` local must render SIGNED (%p and %0d); expected \
+         `INT-P=-559038737 INT-D=-559038737`, got:\n{out}"
     );
 }

--- a/tests/classes/typename_type_param_resolves_concrete.rs
+++ b/tests/classes/typename_type_param_resolves_concrete.rs
@@ -1,0 +1,84 @@
+//! `$typename` must reflect the actual type, preserving vector widths.
+//!
+//! (1) `$typename(T)` where `T` is a TYPE PARAMETER of the active class
+//! specialization reports the CONCRETE bound type — not the literal param
+//! name and not a generic fallback. A parameterized event callback (for
+//! T = uvm_object, string, and uvm_bitstream_t) logs `$typename(T)` in each
+//! `do_it()`; pre-fix every specialization reported `logic` regardless of `T`.
+//!
+//! (2) Per IEEE 1800-2017 §20.6.1 the vector RANGE is preserved: a typedef'd
+//! or declared `logic signed [15:0]` reports `logic signed [15:0]`, not a
+//! bare `logic`.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str) -> String {
+    std::fs::write("/tmp/typename_type_param.sv", src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", "/tmp/typename_type_param.sv"])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SRC: &str = r#"module top;
+  typedef logic signed [15:0] my_bits_t;
+  typedef bit [7:0] my_bytes_t;
+  class a; endclass
+  logic [9:0] vec_sig;
+  class ger#(type T=a);
+    static function void do_it();
+      $display("RESULT T=%s int=%s str=%s", $typename(T), $typename(int), $typename(string));
+    endfunction
+  endclass
+  initial begin
+    my_bits_t bv;
+    my_bytes_t by;
+    ger#(a)::do_it();
+    ger#(my_bits_t)::do_it();
+    ger#(string)::do_it();
+    $display("RESULT td=%s tdbit=%s", $typename(my_bits_t), $typename(my_bytes_t));
+    $display("RESULT sig=%s if-local=%s", $typename(vec_sig), $typename(bv));
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn typename_type_param_resolves_concrete_binding() {
+    let out = run(SRC);
+    let lines: Vec<&str> = out.lines().filter(|l| l.contains("RESULT")).collect();
+    assert!(
+        lines.iter().any(|l| l.contains("T=class a")),
+        "class-typed type param must report `class a`:
+{out}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("T=logic signed [15:0]")),
+        "a typedef'd vector type param must keep the base `logic signed [15:0]`, not a bare `logic`:
+{out}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("str=string")) && lines.iter().any(|l| l.contains("int=int")),
+        "builtin type params must report `int` and `string`:
+{out}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("td=logic signed [15:0]"))
+            && lines.iter().any(|l| l.contains("tdbit=bit [7:0]")),
+        "direct `$typename(typedef)` must preserve range/base (logic signed [15:0], bit [7:0]):\n{out}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("sig=logic [9:0]"))
+            && lines.iter().any(|l| l.contains("if-local=logic signed [15:0]")),
+        "vector signals and block-local vars must report their range (logic [9:0], logic signed [15:0]):\n{out}"
+    );
+}

--- a/tests/classes/virtual_method_in_binary_is_evaluated_once.rs
+++ b/tests/classes/virtual_method_in_binary_is_evaluated_once.rs
@@ -1,0 +1,106 @@
+//! A VIRTUAL method call used as a binary operand / compound-assignment RHS
+//! must evaluate ONCE. UVM's `uvm_event#(T)::trigger` does
+//! `skip += cb_q[i].pre_trigger(this, data)` where `cb_q[i]` is a queue
+//! element; with a CLASS-METHOD receiver the width-probe once ran the method
+//! purely to read its width and then re-ran it for the value — so a
+//! counter-flip callback (every other trigger) fired `pre_trigger` TWICE per
+//! `trigger` and a parameterized event-callback test reported
+//! `pre_trigger of 10, saw: 20`. The width comes from the method's declared
+//! return type, resolved through the inheritance chain and the receiver's
+//! class (a class FIELD of `this`, or a queue element), NEVER from executing
+//! the method.
+//!
+//! This also covers the TYPEDEF'd element type: `cb_type cb_q[$]` where
+//! `typedef event_cb cb_type` holds the receiver class, so a queue of a
+//! typedef'd callback still resolves the method width without running it.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str) -> String {
+    std::fs::write("/tmp/event_cb_binary_eval.sv", src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", "/tmp/event_cb_binary_eval.sv"])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SRC: &str = r#"module top;
+  class evt;
+    function int d(); return 7; endfunction
+  endclass
+  class base_cb;
+    virtual function bit pre(evt e, int x); return 0; endfunction
+    virtual function bit post(evt e, int x); return 0; endfunction
+  endclass
+  class my_cb extends base_cb;
+    int pre_count;
+    int post_count;
+    virtual function bit pre(evt e, int x);
+      pre_count++;
+      return (pre_count % 2);   // block every other trigger
+    endfunction
+    virtual function bit post(evt e, int x);
+      post_count++;
+      return 0;
+    endfunction
+  endclass
+  class boxer;
+    // a TYPEDEF'd element type, like `cb_type cb_q[$]` in UVM's event
+    typedef base_cb cb_type;
+    my_cb m;                 // class-FIELD receiver of this
+    base_cb q[$];            // a queue of class elements (holds my_cb dyn)
+    evt e;
+    function new();
+      m = new;
+      e = new;
+      q.push_back(m);        // upcast my_cb -> base_cb (dyn type preserved)
+    endfunction
+    function void trigger();
+      int skip;
+      skip = 0;
+      // field receiver inside a class method, compound `+=`
+      skip += m.pre(e, 1);
+      // queue-element receiver
+      skip += q[0].post(e, 2);
+    endfunction
+    function int pre_cnt(); return m.pre_count; endfunction
+    function int post_cnt(); return m.post_count; endfunction
+  endclass
+  initial begin
+    boxer b;
+    b = new;
+    repeat(10) b.trigger();
+    $display("RESULT pre=%0d post=%0d", b.pre_cnt(), b.post_cnt());
+    if (b.pre_cnt() == 10 && b.post_cnt() == 10)
+      $display("RESULT PASS single_eval");
+    else
+      $display("RESULT FAIL double_eval");
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn virtual_method_in_binary_is_evaluated_once() {
+    let out = run(SRC);
+    assert!(
+        out.contains("RESULT PASS single_eval"),
+        "a class method used in a binary/compound-assignment must run ONCE per\n\
+         call (width comes from the declared return type, not from executing\n\
+         the method). Pre-fix the event callback fired twice per trigger\n\
+         (pre=20, post=20 for 10 triggers):\n{out}"
+    );
+    assert!(
+        out.contains("RESULT pre=10 post=10"),
+        "expected exactly 10 pre and 10 post callback executions:\n{out}"
+    );
+}

--- a/tests/classes/wait_level_sensitive_inactive_delta.rs
+++ b/tests/classes/wait_level_sensitive_inactive_delta.rs
@@ -1,0 +1,75 @@
+//! IEEE 1800-2023 §9.7.4 / §4.5: `wait(cond)` is LEVEL-sensitive — a process
+//! resumes the MOMENT its condition is true, including in the SAME timestep
+//! via a delta-cycle handoff. If a blocking write makes the condition true and
+//! then a `#0`-resumed continuation OVERWRITES the watched value within the
+//! same timestep, the waiter must observe the intermediate value and proceed on
+//! it — not skip straight to the clobbered one.
+//!
+//! REGRESSION: xezim parked `wait(expr)` on non-signal state in a deferred
+//! end-of-tick fixpoint, which ran AFTER the INACTIVE (`#0`) region. So in
+//!
+//!     x = 1;  #0;  x = 0;      // peer process
+//!     wait(x != 0)             // waiter, must see x==1
+//!
+//! the waiter woke after the `#0` had already overwritten x to 0 and observed
+//! the wrong value. The UVM TLM2 nonblocking (AT) passthrough handshake trips
+//! this: the slave's `wait(state != BEGIN_RESP)` is released by the master
+//! sending END_RESP, but the master's trailing `#0` immediately re-drives a
+//! new request, so the slave saw the next request's phase instead of END_RESP
+//! and never advanced its state machine (its completed-transaction count
+//! stayed 0 while the master's climbed — a hard UVM_ERROR mismatch).
+use std::process::Command;
+
+fn xezim() -> String {
+    // Resolve the sibling CLI binary from the test binary's own location so
+    // this works for both debug and release profiles.
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/wait_inactive_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A waiter on `st` must wake at the delta where `st` becomes 4, BEFORE the
+/// writer's `#0` (inactive region) overwrites it to 1 in the same timestep.
+const WAIT_DELTA: &str = r#"module top;
+  int st = 3;
+  task sla();
+    wait(st != 3);
+    if (st == 4) $display("RESULT PASS");
+    else         $display("RESULT FAIL st=%0d", st);
+  endtask
+  task mst();
+    #8;
+    st = 4;   // first change: wait(st!=3) must wake here
+    #0;       // yield one delta (inactive region)
+    st = 1;   // clobber within same timestep
+  endtask
+  initial begin
+    fork sla(); mst(); join_none
+    #20;
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn wait_wakes_on_intermediate_delta_value_before_inactive_clobber() {
+    let out = run(WAIT_DELTA, "delta");
+    assert!(
+        out.contains("RESULT PASS"),
+        "a level-sensitive wait must observe the intermediate value written\n\
+         before a #0-resumed overwrite (not the clobbered one)\noutput:\n{out}"
+    );
+}

--- a/tests/collections.rs
+++ b/tests/collections.rs
@@ -85,5 +85,7 @@ mod queue_dyn_write_semantics;
 
 #[path = "collections/assoc_of_struct.rs"]
 mod assoc_of_struct;
+#[path = "collections/queue_concat_index_prefilled_prefix.rs"]
+mod queue_concat_index_prefilled_prefix;
 #[path = "collections/foreach_live_size_bounds.rs"]
 mod foreach_live_size_bounds;

--- a/tests/collections/queue_concat_index_prefilled_prefix.rs
+++ b/tests/collections/queue_concat_index_prefilled_prefix.rs
@@ -1,0 +1,74 @@
+//! A block-local QUEUE variable (`int a[$];` inside an `initial`) was
+//! registered as a plain dynamic array but not as a queue var, so the
+//! queue's index-at-size APPEND semantics were lost: `a[0] = v` on an empty
+//! queue wrote the element but did NOT bump `a.size`, and a later
+//! concatenation `c = { a, b }` read the prefix `a` as empty and dropped it.
+//!
+//! UVM's `uvm_callbacks#(T,CB)::get_all` prepopulates its result queue with
+//! an unregistered callback at index 0, then does `all_callbacks = {
+//! all_callbacks, unique_callbacks_to_append }`. With this bug the
+//! prepopulated element (index 0 of the prefix) was lost, so get_all
+//! reported 1 callback instead of 2 and the iterate test
+//! failed its `all_callbacks.size() != 2` check.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/queue_concat_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A queue prefilled by index assignment must keep its size and be preserved
+/// as the prefix of a concatenation, byte-for-byte like the reference.
+const QUEUE_CONCAT_PREFIX: &str = r#"module top;
+  initial begin
+    int a[$];
+    int b[$];
+    int c[$];
+    a[0] = 10;   // prefix, populated via index assignment (back-fill)
+    b = '{20};   // suffix
+    if (a.size() != 1) $display("RESULT FAIL prefix_size=%0d", a.size());
+    else               $display("RESULT PASS prefix_size=%0d", a.size());
+    c = { a, b };
+    if (c.size() != 2) $display("RESULT FAIL concat_size=%0d", c.size());
+    else               $display("RESULT PASS concat_size=%0d", c.size());
+    if (c.size() == 2 && c[0] == 10 && c[1] == 20)
+      $display("RESULT PASS concat_elems=%0d,%0d", c[0], c[1]);
+    else
+      $display("RESULT FAIL concat_elems");
+    #1; $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn queue_concat_preserves_index_prefilled_prefix() {
+    let out = run(QUEUE_CONCAT_PREFIX, "prefill");
+    assert!(
+        out.contains("RESULT PASS prefix_size=1"),
+        "a queue prefilled via `a[0]=v` must report size 1 (index-at-size append\n\
+         must bump the size):\n{out}"
+    );
+    assert!(
+        out.contains("RESULT PASS concat_size=2"),
+        "`c = {{a, b}}` with a size-1 prefilled prefix a must produce 2 elements,\n\
+         not drop the prefix:\n{out}"
+    );
+    assert!(
+        out.contains("RESULT PASS concat_elems=10,20"),
+        "the concatenated queue must be {{10, 20}}, byte-for-byte like the reference:\n{out}"
+    );
+}

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -310,5 +310,7 @@ mod zero_width_select_confidence;
 mod typedef_chain_local_namespace;
 #[path = "types/package_data_members_in_subroutine.rs"]
 mod package_data_members_in_subroutine;
+#[path = "types/per_spec_static_singletons.rs"]
+mod per_spec_static_singletons;
 #[path = "types/signed_unsigned_compare_extension.rs"]
 mod signed_unsigned_compare_extension;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -308,5 +308,7 @@ mod packed_member_self_determined_width;
 mod zero_width_select_confidence;
 #[path = "types/typedef_chain_local_namespace.rs"]
 mod typedef_chain_local_namespace;
+#[path = "types/package_data_members_in_subroutine.rs"]
+mod package_data_members_in_subroutine;
 #[path = "types/signed_unsigned_compare_extension.rs"]
 mod signed_unsigned_compare_extension;

--- a/tests/types/package_data_members_in_subroutine.rs
+++ b/tests/types/package_data_members_in_subroutine.rs
@@ -1,0 +1,122 @@
+//! §26.3: package data declarations (`const` and plain variables) referenced
+//! with `pkg::X` from inside a SUBROUTINE body (function/task/class method).
+//!
+//! The elaborator collapses `pkg::X` into a flat two-segment `Ident` for
+//! always/initial/continuous-assign code (where it resolves via the bare-name
+//! signal/parameter read), but inside a subroutine body the reference arrives
+//! as `MemberAccess(Ident(["pkg"]), "X")`. That arm resolved package ENUM
+//! members and package PARAMETER/localparams but had no case for a package
+//! DATA declaration — a `const` or a plain variable — which are registered
+//! under their bare name as a signal. Those fell through to an object-property
+//! read returning 0, so `pkg::MYCONST` (a `const int`) read 0 inside a
+//! function while the same reference at module scope read its true value.
+//!
+//! The const, variable, and parameter cases are cross-checked against an
+//! independent tool's output, including the shadowing rule: an explicit
+//! `pkg::X` qualification is NOT shadowed by a same-named subroutine local.
+
+use xezim::simulate;
+
+#[test]
+fn package_data_members_resolve_inside_subroutines() {
+    let src = r#"
+package pkg;
+  const int CONSTC = 42;
+  int PLAINV = 100;          // package variable
+  parameter int PARAMC = 7;  // parameter (already worked)
+endpackage
+
+module top;
+  function int get_const();
+    return pkg::CONSTC;
+  endfunction
+  function int get_var();
+    return pkg::PLAINV;
+  endfunction
+  function int get_param();
+    return pkg::PARAMC;
+  endfunction
+
+  class C;
+    function int get_const_m();
+      return pkg::CONSTC;
+    endfunction
+  endclass
+
+  initial begin
+    C c = new();
+    $display("RESULT const_fn=%0d", get_const());      // 42
+    $display("RESULT var_fn=%0d", get_var());          // 100
+    $display("RESULT param_fn=%0d", get_param());      // 7
+    $display("RESULT const_m=%0d", c.get_const_m());   // 42, class method
+    $display("RESULT const_top=%0d", pkg::CONSTC);     // 42 (module scope)
+    $display("RESULT var_top=%0d", pkg::PLAINV);       // 100
+  end
+endmodule
+"#;
+    let sim = simulate(src, 1000).expect("simulate failed");
+    let msgs: Vec<String> =
+        sim.output.iter().map(|o| o.message.clone()).collect();
+    assert!(
+        msgs.iter().any(|m| m == "RESULT const_fn=42"),
+        "package const must read 42 inside a function; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT var_fn=100"),
+        "package variable must read 100 inside a function; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT param_fn=7"),
+        "package parameter inside a function; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT const_m=42"),
+        "package const inside a class method; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT const_top=42"),
+        "module-scope reference unchanged; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT var_top=100"),
+        "module-scope variable unchanged; got {:?}", msgs
+    );
+}
+
+#[test]
+fn package_qualification_is_not_shadowed_by_subroutine_local() {
+    let src = r#"
+package pkg;
+  const int CONSTC = 42;
+  int PLAINV = 100;
+endpackage
+
+module top;
+  function int get_const_shadow();
+    int CONSTC;              // local shadows the bare name
+    CONSTC = 999;
+    return pkg::CONSTC;      // must still be 42 (qualified)
+  endfunction
+  function int get_var_shadow();
+    int PLAINV;
+    PLAINV = 999;
+    return pkg::PLAINV;      // must still be 100 (qualified)
+  endfunction
+  initial begin
+    $display("RESULT const_shadow=%0d", get_const_shadow());
+    $display("RESULT var_shadow=%0d", get_var_shadow());
+  end
+endmodule
+"#;
+    let sim = simulate(src, 1000).expect("simulate failed");
+    let msgs: Vec<String> =
+        sim.output.iter().map(|o| o.message.clone()).collect();
+    assert!(
+        msgs.iter().any(|m| m == "RESULT const_shadow=42"),
+        "explicit pkg::const bypasses a same-named local; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT var_shadow=100"),
+        "explicit pkg::var bypasses a same-named local; got {:?}", msgs
+    );
+}

--- a/tests/types/per_spec_static_singletons.rs
+++ b/tests/types/per_spec_static_singletons.rs
@@ -1,0 +1,128 @@
+//! §8.25: per-specialization `static` members of a parameterized class when a
+//! CONCRETE subclass (e.g. `ext1 extends base#(ext1)`) calls an inherited
+//! static like `ext1::ID()`.
+//!
+//! A static call `ext1::ID()` carries no `#(spec)` on the call and has no
+//! instance, so the interpreter had no way to know `ID()` belongs to the
+//! `base#(ext1)` specialization: `current_spec` stayed unset and every
+//! specialization keyed the shared `base::m_singleton` cell. Two sibling
+//! subclasses therefore shared one singleton (`ext1::ID()` returned `ext2::ID()`),
+//! and a handle-keyed associative array ("one extension per type") could never
+//! tell a stored key from a different type's key — a miss returned the stored
+//! element. This is the mechanism UVM's TLM generic-payload extensions rely on
+//! (`uvm_tlm_extension#(T)::ID()`), so GP extension get/set/clone were all
+//! broken. The fix seeds `current_spec` from the concrete subclass's extends
+//! type args when dispatching the inherited static (and the instance-method
+//! analogue for a concrete instance calling a parameterized base's method).
+//!
+//! Cross-checked against an independent tool's output.
+
+use xezim::simulate;
+
+fn messages(sim: &xezim::compiler::Simulator) -> Vec<String> {
+    sim.output.iter().map(|o| o.message.clone()).collect()
+}
+
+/// Two concrete subclasses of a parameterized base must get DISTINCT static
+/// singletons from the inherited static-ID method.
+#[test]
+fn per_specialization_static_singletons_are_distinct() {
+    let src = r#"
+package p;
+  class base_t;
+    int tag;
+  endclass
+  class keyed_t #(type T = int) extends base_t;
+    static keyed_t#(T) m_singleton = null;
+    static function keyed_t#(T) ID();
+      if (m_singleton == null) m_singleton = new();
+      return m_singleton;
+    endfunction
+  endclass
+  class ext_a extends keyed_t#(ext_a); endclass
+  class ext_b extends keyed_t#(ext_b); endclass
+endpackage
+
+module top;
+  import p::*;
+  keyed_t#(ext_a) a;
+  keyed_t#(ext_b) b;
+  initial begin
+    a = ext_a::ID();
+    b = ext_b::ID();
+    a.tag = 111;
+    b.tag = 222;
+    if (a.tag == 111 && b.tag == 222 && a != b)
+      $display("RESULT statics_isolated=1");
+    else
+      $display("RESULT statics_isolated=0");
+    // Re-fetch: each specialization's ID() must still yield its own cell.
+    if (ext_a::ID().tag == 111 && ext_b::ID().tag == 222)
+      $display("RESULT refetch=1");
+    else
+      $display("RESULT refetch=0");
+  end
+endmodule
+"#;
+    let sim = simulate(src, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT statics_isolated=1"),
+        "distinct specializations must have distinct static singletons; got {:?}", msgs
+    );
+    assert!(
+        msgs.iter().any(|m| m == "RESULT refetch=1"),
+        "each specialization's static must persist; got {:?}", msgs
+    );
+}
+
+/// A handle-keyed associative array: a lookup with a DIFFERENT class's ID
+/// must MISS (return null), not fall through to the single stored element.
+#[test]
+fn handle_keyed_assoc_miss_with_sibling_specialization_ids() {
+    let src = r#"
+package p;
+  class base_t;
+  endclass
+  class keyed_t #(type T = int) extends base_t;
+    static keyed_t#(T) m_singleton = null;
+    static function keyed_t#(T) ID();
+      if (m_singleton == null) m_singleton = new();
+      return m_singleton;
+    endfunction
+  endclass
+  class ext1 extends keyed_t#(ext1); endclass
+  class ext2 extends keyed_t#(ext2); endclass
+  class gp extends base_t;
+    base_t m_exts[base_t];
+    function void set_ext(base_t hk, base_t e); m_exts[hk] = e; endfunction
+    function base_t get_ext(base_t hk);
+      base_t r;
+      if (!m_exts.exists(hk)) r = null; else r = m_exts[hk];
+      return r;
+    endfunction
+  endclass
+endpackage
+
+module top;
+  import p::*;
+  ext1 x1;
+  gp g;
+  int miss_is_null;
+  initial begin
+    x1 = new();
+    g = new();
+    g.set_ext(ext1::ID(), x1);
+    // Storing under ext1::ID(); a lookup under ext2::ID() must MISS.
+    miss_is_null = (g.get_ext(ext2::ID()) == null) ? 1 : 0;
+    $display("RESULT miss_is_null=%0d", miss_is_null);
+  end
+endmodule
+"#;
+    let sim = simulate(src, 1000).expect("simulate failed");
+    let msgs = messages(&sim);
+    assert!(
+        msgs.iter().any(|m| m == "RESULT miss_is_null=1"),
+        "assoc miss under a different specialization's ID must return null; got {:?}", msgs
+    );
+}

--- a/tests/types/property_value_param_binding.rs
+++ b/tests/types/property_value_param_binding.rs
@@ -26,7 +26,7 @@ module top;
   endclass
 
   class test;
-    // PROPERTIES typed with value params (like 25params's a1/a2)
+    // PROPERTIES typed with value params (like the a1/a2 specialization check)
     special_comp#(1) a1;
     special_comp#(2) a2;
     function void build;


### PR DESCRIPTION
Fixes a set of SystemVerilog semantics bugs, each with a self-test that produces byte-for-byte-identical output to the reference simulator. Also rebased onto current main (drops a redundant xezim-core pin bump that main already carries) and removes remaining uvm-tests test-path references from commit messages and committed comments.

### Changes

- Resolve built-in process class state enum constants inside subroutine bodies
- Resolve package data members (const / variable) inside subroutine bodies
- Give parameterized-base statics per-specialization storage for concrete subclasses
- Make per-specialization statics a generic receiver-derived mechanism
- Resolve class type-parameter formals before casting in socket construction
- Wake level-sensitive wait at the satisfying delta before an inactive #0 clobber
- Restore enclosing assoc-array registration after a nested same-named ref formal clears it
- Size a class-field operand to its declared width in a comparison's self width
- Classify a block-local QUEUE declaration as a queue var
- Resolve an enclosing value param in a nested generic's type-arg binding
- Parameterized-event callbacks, static-task spec, and single-eval method width
- `$typename` of a type parameter reports the concrete bound type
- `$typename` preserves packed-vector ranges and base types
- Fix static collection reuse of parameterized classes
- Fix explicit-spec static-collection reads for parameterized classes
- Fix `%p` on subroutine locals and string truncation through type params
- Fix signedness of type-param locals/formals in `%d`/`%p`
