### PR TITLE
fix: sequence body dispatch, #0 objection yield, and procedural NBA waiter scheduling

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -4590,6 +4590,11 @@ pub struct Simulator {
     /// the event queue only at the END of the current tick, after
     /// `apply_nba` has run (see `promote_inactive_to_active`).
     inactive_queue: Vec<(usize, ProcCont)>,
+    /// Processes waiting for the NBA region to commit (e.g.
+    /// `uvm_wait_for_nba_region`: `nba <= next_nba; @(nba)` where `nba` is a
+    /// procedural variable). Resumed in `run_one_tick` after all active +
+    /// inactive (`#0`) deltas have settled and `apply_nba` has committed.
+    nba_region_waiters: Vec<(usize, ProcCont)>,
     /// Bumped whenever a `wait(expr)` condition evaluates true (a parked waiter
     /// proceeds). The condition-waiter fixpoint uses it to detect "no progress
     /// this round" and stop (genuine stall).
@@ -8217,6 +8222,7 @@ impl Simulator {
             cond_waiter_reads: HashMap::default(),
             cond_waiter_conditions: HashMap::default(),
             inactive_queue: Vec::new(),
+            nba_region_waiters: Vec::new(),
             cond_progress: 0,
             real_time: 0.0,
             mailbox_get_waiters: HashMap::default(),
@@ -34805,6 +34811,7 @@ impl Simulator {
         // region — so they observe post-edge state and this cycle's samples.
         self.drain_deferred_clocking_conts();
         self.drain_reactive_region();
+        self.drain_nba_region_waiters();
         self.fire_vpi_synch_cbs();
         self.check_monitor();
         self.drain_pending_strobes();
@@ -35287,10 +35294,19 @@ impl Simulator {
                 None
             };
             let next_delayed = self.next_delayed_time();
+            let next_nba_time = if !self.nba_fast.is_empty()
+                || !self.nba_queue.is_empty()
+                || !self.nba_region_waiters.is_empty()
+            {
+                Some(self.time)
+            } else {
+                None
+            };
             let next_time = [
                 next_eq_time,
                 next_clk_time,
                 next_delayed,
+                next_nba_time,
                 self.next_vpi_cb_time(),
             ]
                 .into_iter()
@@ -39519,9 +39535,10 @@ impl Simulator {
                                 // waited on (uvm_wait_for_nba_region:
                                 // `nba <= next_nba; @(nba)`). Its event_waiter
                                 // would resolve to no signal_id and park forever;
-                                // treat it as a one-delta yield (its purpose is to
-                                // yield across the NBA region).
-                                self.event_queue.schedule(self.time, pid, cont);
+                                // park in nba_region_waiters so it resumes only
+                                // after the active + inactive (#0) deltas have
+                                // settled and the NBA region has committed.
+                                self.nba_region_waiters.push((pid, cont));
                             }
                             return;
                         }
@@ -69160,6 +69177,26 @@ impl Simulator {
         self.run_process_stmts(pid, &ProcCont::from_vec(stmts));
     }
 
+    /// Resume processes waiting on NBA-region completion (such as
+    /// `uvm_wait_for_nba_region`: `nba <= next_nba; @(nba)`). Resumes in the
+    /// Reactive region after all active + inactive (`#0`) deltas have settled
+    /// and `apply_nba` has committed the NBA region.
+    fn drain_nba_region_waiters(&mut self) {
+        if self.nba_region_waiters.is_empty() {
+            return;
+        }
+        let waiters = std::mem::take(&mut self.nba_region_waiters);
+        for (pid, cont) in waiters {
+            if self.finished {
+                break;
+            }
+            self.run_scheduled_process(pid, &cont);
+            if !self.is_pid_suspended(pid) {
+                self.child_finished(pid);
+            }
+        }
+    }
+
     /// LRM §16.5: edge-detect each registered SVA clock, then for each
     /// fired clock site:
     ///   1. Drain any deferred consequents whose cycle counter reaches 0.
@@ -75323,6 +75360,9 @@ impl Simulator {
         if self.inactive_queue.iter().any(|(p, _)| *p == pid) {
             return true;
         }
+        if self.nba_region_waiters.iter().any(|(p, _)| *p == pid) {
+            return true;
+        }
         // A process blocked on `fork...join`/`join_any` is the PARENT of a
         // join_waiter — also suspended. Without this it was treated as finished,
         // so its process context (this_stack, locals) was dropped and the
@@ -75482,6 +75522,7 @@ impl Simulator {
             self.cond_waiter_conditions.remove(p);
         }
         self.inactive_queue.retain(|(p, _)| !to_kill.contains(p));
+        self.nba_region_waiters.retain(|(p, _)| !to_kill.contains(p));
         for q in self.mailbox_get_waiters.values_mut() {
             q.retain(|w| !to_kill.contains(&w.pid));
         }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -38869,6 +38869,9 @@ impl Simulator {
                                 // member/static resolution, with a null `this`.
                                 self.this_stack.push(None);
                                 self.class_context_stack.push(Some(mclass));
+                                self.method_local_base.push(
+                                    self.local_stack.len().saturating_sub(1),
+                                );
                                 cleanup.pushed_method_this = true;
                                 let saved_spec = self.current_spec.clone();
                                 if let Some((sb, ss)) = recv_spec {
@@ -98601,6 +98604,7 @@ impl Simulator {
         if c.pushed_method_this {
             self.this_stack.pop();
             self.class_context_stack.pop();
+            self.method_local_base.pop();
             self.current_spec = c.saved_spec;
         }
         self.ref_binding_stack.pop();
@@ -99263,6 +99267,15 @@ impl Simulator {
         cleanup.pushed_method_this = true;
         self.this_stack.push(handle_opt);
         self.class_context_stack.push(Some(mclass.clone()));
+        // §23 / §13.4: record the base of THIS method's own locals so
+        // `get_expr_type_name`'s `in_any_frame` check only sees the current
+        // inlined method's locals — not a caller's same-named local that
+        // leaked into the flat `var_class_types` map (e.g. a `uvm_sequence_base
+        // seq` local on the sequencer shadowing a sequence subclass's `seq`
+        // member, breaking virtual dispatch of `body()` in nested
+        // sequence-`start()` calls). The synchronous method path pushes this
+        // right after binding the locals frame; mirror it here.
+        self.method_local_base.push(self.local_stack.len().saturating_sub(1));
         if let Some(h) = handle_opt {
             if let Some(inst) = self.heap.get(h).and_then(|o| o.as_ref()) {
                 let cn = inst.class_name.clone();

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -34493,7 +34493,7 @@ impl Simulator {
             if !self.inactive_queue.is_empty() {
                 break;
             }
-            if self.cond_progress == prog_before {
+            if self.cond_progress == prog_before && self.ready_condition_waiters.is_empty() {
                 break;
             }
         }
@@ -34552,8 +34552,13 @@ impl Simulator {
             }
             // No waiter proceeded this round → the remainder are genuinely
             // blocked (future-time change); stop re-checking until the next
-            // tick.
-            if self.cond_progress == prog_before {
+            // tick. But a waiter newly moved to `ready_condition_waiters` by
+            // a same-tick write is forward progress whether or not
+            // `cond_progress` stepped (moving to ready does not itself fire
+            // the waiter's body), so it must be consumed before we can treat
+            // the set as blocked.
+            if self.cond_progress == prog_before && self.ready_condition_waiters.is_empty()
+            {
                 break;
             }
         }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -34437,6 +34437,62 @@ impl Simulator {
     /// before a `#0`-parked peer's continuation overwrites the value — and
     /// (b) at the end of the tick, after the NBA region has settled, to
     /// catch waiters satisfied by non-blocking/edge-propagated state.
+    /// Variant of `drain_condition_waiters` called in `run_one_tick` right BEFORE
+    /// the INACTIVE (`#0`) region is promoted:
+    /// 1. Does NOT commit NBA (IEEE 1800-2017 §4.5 places the NBA region strictly
+    ///    AFTER the Inactive region).
+    /// 2. If `#0` continuations are waiting in `inactive_queue`, stops after this
+    ///    round so those `#0` continuations execute in this delta rather than
+    ///    being starved by multi-generation cascades of condition waiters.
+    fn drain_condition_waiters_pre_inactive(&mut self) {
+        let mut guard = 0u32;
+        while (!self.condition_waiters.is_empty() || !self.ready_condition_waiters.is_empty())
+            && !self.finished
+            && !self.zero_delay_defer_pending
+        {
+            guard += 1;
+            if guard > 10000 {
+                break;
+            }
+            let prog_before = self.cond_progress;
+            let ready = std::mem::take(&mut self.ready_condition_waiters);
+            for (cpid, cont) in ready {
+                self.cond_waiter_reads.remove(&cpid);
+                self.cond_read_union_dirty = true;
+                self.cond_waiter_conditions.remove(&cpid);
+                self.event_queue.schedule(self.time, cpid, cont);
+            }
+            let parked = std::mem::take(&mut self.condition_waiters);
+            for (cpid, cont) in parked {
+                self.cond_waiter_reads.remove(&cpid);
+                self.cond_read_union_dirty = true;
+                self.cond_waiter_conditions.remove(&cpid);
+                self.event_queue.schedule(self.time, cpid, cont);
+            }
+            while self.event_queue.next_time() == Some(self.time)
+                && !self.finished
+                && !self.zero_delay_defer_pending
+            {
+                let Some((bpid, stmts)) = self.event_queue.pop_front(self.time) else {
+                    break;
+                };
+                self.run_scheduled_process(bpid, &stmts);
+                if !self.is_pid_suspended(bpid) {
+                    self.child_finished(bpid);
+                }
+            }
+            if self.dirty_any {
+                self.settle_combinatorial();
+            }
+            if !self.inactive_queue.is_empty() {
+                break;
+            }
+            if self.cond_progress == prog_before {
+                break;
+            }
+        }
+    }
+
     fn drain_condition_waiters(&mut self) {
         let mut guard = 0u32;
         while (!self.condition_waiters.is_empty() || !self.ready_condition_waiters.is_empty())
@@ -34633,7 +34689,7 @@ impl Simulator {
             // slave's `wait(state!=BEGIN_RESP)` wakes on the clobbered value).
             // The end-of-tick fixpoint alone is too late: the `#0` resume has
             // already committed the overwrite by then.
-            self.drain_condition_waiters();
+            self.drain_condition_waiters_pre_inactive();
             if self.promote_inactive_to_active()
                 && self.event_queue.next_time() == Some(self.time)
             {
@@ -83448,8 +83504,16 @@ impl Simulator {
     }
 
     /// Innermost-first overlay lookup for a frame-local's class type.
+    /// When inside a class method (`method_local_base` is populated), only
+    /// scans frames belonging to THIS method so a caller's same-named local
+    /// does not shadow an instance property of `this`.
     fn local_class_type_of(&self, name: &str) -> Option<String> {
-        self.local_type_stack
+        let frames = if let Some(&base) = self.method_local_base.last() {
+            self.local_type_stack.get(base..).unwrap_or(&[])
+        } else {
+            &self.local_type_stack[..]
+        };
+        frames
             .iter()
             .rev()
             .find_map(|(c, _)| c.get(name).cloned())
@@ -83462,7 +83526,12 @@ impl Simulator {
     /// declaration (`local_typedef_type_of` starts from the top of
     /// `local_type_stack`, which holds only the ACTIVE call frames).
     fn local_typedef_type_of(&self, name: &str) -> Option<String> {
-        self.local_type_stack
+        let frames = if let Some(&base) = self.method_local_base.last() {
+            self.local_type_stack.get(base..).unwrap_or(&[])
+        } else {
+            &self.local_type_stack[..]
+        };
+        frames
             .iter()
             .rev()
             .find_map(|(_, t)| t.get(name).cloned())
@@ -83544,6 +83613,18 @@ impl Simulator {
                 let base = c.split('#').next().unwrap_or(&c);
                 if self.module.classes.contains_key(base) {
                     return Some(c);
+                }
+            }
+        }
+        // Member of `this` (the current object) — IEEE 1800-2023 §8.14:
+        // inside a class method, properties of `this` take precedence over
+        // outer / unrelated procedural locals in `var_class_types`.
+        if let Some(h) = self.this_stack.last().copied().flatten() {
+            if let Some(cls) = self.heap.get(h).and_then(|o| o.as_ref()).map(|i| i.class_name.clone()) {
+                if let Some(tn) = self.class_prop_type_named(&cls, vname) {
+                    if self.module.classes.contains_key(&tn) || tn.contains('#') {
+                        return Some(tn);
+                    }
                 }
             }
         }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -252,3 +252,5 @@ mod field_init_once_in_order;
 mod caller_local_shadows_this_cast;
 #[path = "classes/condition_waiter_yields_to_inactive.rs"]
 mod condition_waiter_yields_to_inactive;
+#[path = "classes/package_class_nested_class.rs"]
+mod package_class_nested_class;

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -254,3 +254,5 @@ mod caller_local_shadows_this_cast;
 mod condition_waiter_yields_to_inactive;
 #[path = "classes/package_class_nested_class.rs"]
 mod package_class_nested_class;
+#[path = "classes/sqr_zero_time_loop.rs"]
+mod sqr_zero_time_loop;

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -248,3 +248,7 @@ mod enum_local_shadows_flat_maps;
 mod ref_formal_shadows_property;
 #[path = "classes/field_init_once_in_order.rs"]
 mod field_init_once_in_order;
+#[path = "classes/caller_local_shadows_this_cast.rs"]
+mod caller_local_shadows_this_cast;
+#[path = "classes/condition_waiter_yields_to_inactive.rs"]
+mod condition_waiter_yields_to_inactive;

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -181,6 +181,8 @@ mod struct_formal_and_config_foreach;
 mod typename_param_class;
 #[path = "classes/unpacked_struct_class_property_whole_value.rs"]
 mod unpacked_struct_class_property_whole_value;
+#[path = "classes/nested_seq_method_dispatch.rs"]
+mod nested_seq_method_dispatch;
 #[path = "classes/uvm_config_db_tests.rs"]
 mod uvm_config_db_tests;
 #[path = "classes/uvm_factory_linkage.rs"]

--- a/tests/classes/caller_local_shadows_this_cast.rs
+++ b/tests/classes/caller_local_shadows_this_cast.rs
@@ -1,0 +1,79 @@
+//! IEEE 1800-2023 §8.14: inside a class method, an unqualified property name
+//! resolves to `this.<prop>` (and its base classes), taking precedence over
+//! outer procedural locals or unrelated callers' local variables.
+//!
+//! REGRESSION: in `$cast(dest, src)`, `class_of_var` looked up `dest` in the
+//! global `var_class_types` flat map before checking properties of `this`.
+//! If a caller task declared a local variable with the same name as a callee's
+//! member property (e.g. `top_seq seq;` in `configure_phase` vs `leaf_seq seq;`
+//! in `mid_seq`), `$cast(seq, ...)` inside `mid_seq` resolved `seq`'s type to
+//! the caller's `top_seq` instead of `this.seq`'s `leaf_seq`, causing `$cast`
+//! to report an incompatible type error and fail.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/caller_local_cast_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SV_SRC: &str = r#"module top;
+  class base_c;
+  endclass
+
+  class leaf_c extends base_c;
+    int val = 42;
+  endclass
+
+  class other_c extends base_c;
+    int other = 99;
+  endclass
+
+  class mid_c;
+    leaf_c item; // property named 'item'
+    task automatic do_cast(base_c b);
+      // item must resolve to this.item (leaf_c), NOT caller's 'other_c item'
+      if ($cast(item, b)) begin
+        $display("CAST_SUCCESS val=%0d", item.val);
+      end else begin
+        $display("CAST_FAILED");
+      end
+    endtask
+  endclass
+
+  task automatic caller_task();
+    other_c item = new; // caller local named 'item' of conflicting type
+    mid_c m = new;
+    leaf_c l = new;
+    m.do_cast(l);
+  endtask
+
+  initial begin
+    caller_task();
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn caller_local_does_not_shadow_this_property_in_cast() {
+    let out = run(SV_SRC, "shadow_cast");
+    assert!(
+        out.contains("CAST_SUCCESS val=42"),
+        "expected $cast to resolve to this.item (leaf_c) and succeed, got:\n{out}"
+    );
+    assert!(!out.contains("CAST_FAILED"), "cast failed unexpectedly");
+}

--- a/tests/classes/condition_waiter_yields_to_inactive.rs
+++ b/tests/classes/condition_waiter_yields_to_inactive.rs
@@ -1,0 +1,70 @@
+//! IEEE 1800-2023 §4.5: within each timestep, the simulation cycle processes
+//! Active-region events, followed by Inactive-region (`#0` delay) events, then
+//! NBA events, then Reactive-region events.
+//!
+//! When an active-region write satisfies a level-sensitive `wait(cond)`, that
+//! condition waiter runs in the active region. However, if already-pending `#0`
+//! continuations exist in the Inactive region, a multi-generation cascade of
+//! newly-awakened condition waiters must not loop indefinitely and starve the
+//! Inactive region; `#0` continuations must be promoted and given their turn
+//! in each delta cycle before subsequent generations of condition-waiter cascades.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/cond_inactive_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SV_SRC: &str = r#"module top;
+  int stage = 0;
+  int queue[$];
+
+  task automatic background_worker();
+    while (1) begin
+      wait (queue.size() != 0);
+      void'(queue.pop_front());
+      // When 1st generation runs, push 2nd generation
+      if (stage == 0) begin
+        queue.push_back(1);
+      end
+      #0;
+    end
+  endtask
+
+  initial begin
+    fork
+      background_worker();
+    join_none
+
+    queue.push_back(0); // wake 1st generation of worker
+    #0;                 // Inactive region continuation
+    stage = 1;          // Must run before 2nd generation
+    $display("STAGE_COMPLETED stage=%0d", stage);
+    #1;
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn condition_waiter_cascade_yields_to_inactive_zero_delay() {
+    let out = run(SV_SRC, "cond_yield");
+    assert!(
+        out.contains("STAGE_COMPLETED stage=1"),
+        "expected #0 continuation to run before 2nd generation condition waiter, got:\n{out}"
+    );
+}

--- a/tests/classes/nested_seq_method_dispatch.rs
+++ b/tests/classes/nested_seq_method_dispatch.rs
@@ -1,0 +1,186 @@
+//! Nested sequence `body()` virtual dispatch regression (in-process UVM).
+//!
+//! UVM sequence callbacks (`body`, `pre_start`, `pre_do`, ...) must dispatch
+//! to the SUBCLASS's (e.g. `mid_seq::body` / `leaf_seq::body`) even when an
+//! enclosing task holds a *base-typed* variable of the same name (`seq`) —
+//! e.g. `uvm_sequencer_base::start_phase_sequence` declares a local
+//! `uvm_sequence_base seq` and calls `seq.start(...)`.
+//!
+//! Root cause (xezim): blocking methods are inlined into the running process
+//! via `run_process_stmts`, which did NOT push `method_local_base` (the
+//! synchronous method path does). With an empty `method_local_base`,
+//! `get_expr_type_name`'s `in_any_frame` fallback scanned ALL local frames
+//! and found the caller's base-typed `seq` local, so the member `seq` (a
+//! subclass) used for virtual dispatch was typed as the BASE →
+//! `mid_seq::body`/`leaf_seq::body` never ran (the base `uvm_sequence_base::body`
+//! is undefined → the "Body definition undefined" warning). Pushing
+//! `method_local_base` on the inline entry (and popping on unwind) scopes the
+//! in-any-frame scan to the inlined method's own locals, restoring correct
+//! virtual dispatch.
+//!
+//! Reference-verified (byte-for-byte on the assertion lines): with the fix the
+//! output is `TAG_TOP_BODY`, `TAG_MID_BODY`, `TAG_LEAF_BODY`, `TAG_DONE`;
+//! without it the nested bodies never run (`TAG_TOP_BODY`, `TAG_DONE` only).
+
+use xezim::simulate_multi;
+
+/// Root of a 1800.2 UVM checkout (the directory holding `src/uvm_pkg.sv`), or
+/// None when this machine has no copy. See `uvm_config_db_tests.rs`.
+fn find_uvm_root() -> Option<String> {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(home) = std::env::var("UVM_HOME") {
+        candidates.push(home);
+    }
+    for rel in ["../1800.2-2020.3.1", "../UVM/1800.2-2020", "../UVM/1800.2-2017"] {
+        candidates.push(format!("{}/{}", manifest, rel));
+    }
+    candidates
+        .into_iter()
+        .find(|root| std::path::Path::new(&format!("{}/src/uvm_pkg.sv", root)).is_file())
+}
+
+/// Run a UVM-using top module in-process and return the joined `$display`
+/// output. None when no UVM library is available — callers skip.
+fn run_in_process(src: &str) -> Option<String> {
+    let uvm_dir = find_uvm_root()?;
+    let uvm_pkg = std::fs::read_to_string(format!("{}/src/uvm_pkg.sv", uvm_dir))
+        .expect("uvm_pkg.sv vanished between probe and read");
+    let inc = format!("{}/src", uvm_dir);
+
+    let sim = simulate_multi(
+        &[uvm_pkg, src.to_string()],
+        50_000,
+        Some("top"),
+        &[inc],
+        &[],
+        None,
+        false,
+        None,
+        None,
+        &[],
+        &[],
+        None,
+        &[],
+        0,
+        u64::MAX,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+    )
+    .expect("simulation failed");
+
+    Some(
+        sim.output
+            .iter()
+            .map(|o| o.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+#[test]
+fn nested_sequence_body_dispatch_not_shadowed_by_base_seq_local() {
+    let src = r#"
+module top;
+  import uvm_pkg::*;
+
+  class trans extends uvm_sequence_item;
+    `uvm_object_utils(trans)
+    function new(string name = "");
+      super.new(name);
+    endfunction
+  endclass
+
+  class leaf_seq extends uvm_sequence#(trans);
+    `uvm_object_utils(leaf_seq)
+    function new(string name = "");
+      super.new(name);
+    endfunction
+    task body();
+      $display("TAG_LEAF_BODY");
+      #1;
+    endtask
+  endclass
+
+  class mid_seq extends uvm_sequence;
+    `uvm_object_utils(mid_seq)
+    leaf_seq seq;
+    function new(string name = "");
+      super.new(name);
+    endfunction
+    task body();
+      $display("TAG_MID_BODY");
+      `uvm_do(seq)
+    endtask
+  endclass
+
+  class top_seq extends uvm_sequence;
+    `uvm_object_utils(top_seq)
+    mid_seq seq;
+    function new(string name = "");
+      super.new(name);
+    endfunction
+    task body();
+      $display("TAG_TOP_BODY");
+      seq = new("seq");
+      seq.start(get_sequencer(), null);
+    endtask
+  endclass
+
+  uvm_sequencer#(trans) sqr;
+
+  task drive();
+    trans tr;
+    forever begin
+      sqr.get_next_item(tr);
+      sqr.item_done();
+      #1;
+    end
+  endtask
+
+  task fire();
+    // A base-typed local named `seq`, exactly the shape of
+    // `uvm_sequencer_base::start_phase_sequence`'s `uvm_sequence_base seq`
+    // (plus the top sequence cast into it): this must NOT hijack the
+    // subclass-typed `seq` member used for body() virtual dispatch.
+    automatic uvm_sequence_base seq;
+    automatic top_seq tp = new("tp");
+    seq = tp;
+    seq.start(sqr, null);
+  endtask
+
+  initial begin
+    sqr = new("sqr", null);
+    fork
+      drive();
+    join_none
+    fire();
+    #10;
+    $display("TAG_DONE");
+    $finish;
+  end
+endmodule
+"#;
+    let Some(out) = run_in_process(src) else {
+        eprintln!("[skip] nested_sequence_body_dispatch: no 1800.2 UVM library (set UVM_HOME)");
+        return;
+    };
+    println!("{}", out);
+    assert!(
+        out.contains("TAG_TOP_BODY") && out.contains("TAG_MID_BODY") && out.contains("TAG_LEAF_BODY")
+            && out.contains("TAG_DONE"),
+        "nested sequence bodies must all run and dispatch to their subclasses (reference-verified): {}",
+        out
+    );
+    assert!(
+        !out.contains("Body definition undefined"),
+        "body() must resolve to the subclass, not the base uvm_sequence_base stub: {}",
+        out
+    );
+}

--- a/tests/classes/package_class_nested_class.rs
+++ b/tests/classes/package_class_nested_class.rs
@@ -1,0 +1,62 @@
+//! IEEE 1800-2023 §8.23: nested classes.
+//! A class declared inside another class declared in a package or module
+//! must be accessible via both its scoped name `Outer::Inner` and unqualified
+//! within the enclosing class scope.
+//!
+//! REGRESSION: during elaboration, `register_nested_classes` was called only
+//! for root-level `Definition::Class`, skipping classes declared inside packages
+//! and modules. When a nested class was instantiated, `elab.classes` did not
+//! contain it, causing construction to fail or fall back to the enclosing class.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/nested_pkg_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SV_SRC: &str = r#"package p;
+  class outer;
+    class inner;
+      int val = 123;
+    endclass
+    function inner make();
+      inner i = new;
+      return i;
+    endfunction
+  endclass
+endpackage
+
+module top;
+  import p::*;
+  initial begin
+    outer o = new;
+    outer::inner i = o.make();
+    if (i.val == 123) $display("PASS val=%0d", i.val);
+    else $display("FAIL");
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn package_class_nested_class_instantiation() {
+    let out = run(SV_SRC, "test");
+    assert!(
+        out.contains("PASS val=123"),
+        "expected nested class inside package class to instantiate properly, got:\n{out}"
+    );
+}

--- a/tests/classes/sqr_zero_time_loop.rs
+++ b/tests/classes/sqr_zero_time_loop.rs
@@ -1,0 +1,216 @@
+//! uvm_sequencer_base `m_select_sequence` zero-time-loop arbitration.
+//!
+//! REGRESSION: xezim's `drain_condition_waiters` drained the parked
+//! level-sensitive waiters each round, then bailed if `cond_progress` had not
+//! advanced — even when a same-round blocking write had moved a waiter into
+//! `ready_condition_waiters`. A driver whose arbitration fork child re-parks on
+//! `wait(m_is_relevant_completed > 0)` while a sibling fork child writes the
+//! flag therefore got *stranded*: the readied waiter was never run, the
+//! `join_any` never released the driver, and the zero-time arbitration loop
+//! ran only once instead of spinning to the sequencer's `SEQRELEVANTLOOP`
+//! fatal.
+//!
+//! This runs a real 1800.2 UVM sequencer whose sequence has a *non-blocking*
+//! `wait_for_relevant` and an `is_relevant()` that stays 0, so the arbitration
+//! must spin in zero time at t=1 until `uvm_sequencer_base`'s zero-time-loop
+//! detector raises `SEQRELEVANTLOOP`. A report catcher turns the fatal into a
+//! PASS. Reference simulators produce the same initial fatal at the same time
+//! with the same "passed wait_for_relevant 11 times" count.
+
+use std::process::Command;
+
+/// Locate the compiled `xezim` binary next to this test binary.
+fn xezim_bin() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn find_uvm_root() -> Option<String> {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(home) = std::env::var("UVM_HOME") {
+        candidates.push(home);
+    }
+    for rel in [
+        "../1800.2-2020.3.1",
+        "../UVM/1800.2-2020",
+        "../UVM/1800.2-2017",
+    ] {
+        candidates.push(format!("{}/{}", manifest, rel));
+    }
+    candidates
+        .into_iter()
+        .find(|root| std::path::Path::new(&format!("{}/src/uvm_pkg.sv", root)).is_file())
+}
+
+/// Locate a stored UVM DPI shared library in the crate root.
+fn find_dpi_lib() -> Option<String> {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    for name in ["uvm-2020.3.1.so", "uvm-2020-2.0.so"] {
+        let p = format!("{}/{}", manifest, name);
+        if std::path::Path::new(&p).is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+const SV_SRC: &str = r#"`include "uvm_macros.svh"
+module top;
+  import uvm_pkg::*;
+
+  class my_item extends uvm_sequence_item;
+    `uvm_object_utils(my_item)
+    function new(string name = "my_item_");
+      super.new(name);
+    endfunction
+  endclass
+
+  typedef class my_sequencer;
+  typedef class my_driver;
+
+  class my_sequence extends uvm_sequence #(my_item);
+    `uvm_object_utils(my_sequence)
+    `uvm_declare_p_sequencer(my_sequencer)
+    int loop_counter = 0;
+    function new(string name = "my_sequence");
+      super.new(name);
+    endfunction
+    function bit is_relevant();
+      // Never relevant: drives the arbitration zero-time loop.
+      return p_sequencer.rel_var;
+    endfunction
+    task wait_for_relevant();
+      // Non-blocking — "forgot" to wait for the relevant flag to change.
+      loop_counter++;
+    endtask
+    task body();
+      `uvm_do(req)
+      $display("** UVM TEST FAILED **");
+    endtask
+  endclass
+
+  class my_sequencer extends uvm_sequencer #(my_item);
+    bit rel_var = 0;
+    `uvm_component_utils(my_sequencer)
+    function new(string name, uvm_component parent);
+      super.new(name, parent);
+    endfunction
+  endclass
+
+  class my_driver extends uvm_driver #(my_item);
+    `uvm_component_utils(my_driver)
+    function new(string name, uvm_component parent);
+      super.new(name, parent);
+    endfunction
+    task run_phase(uvm_phase phase);
+      phase.raise_objection(this);
+      #1;
+      seq_item_port.get_next_item(req);
+      if (req != null) begin
+        seq_item_port.item_done();
+      end else begin
+        $display("** UVM TEST FAILED **");
+      end
+      phase.drop_objection(this);
+    endtask
+  endclass
+
+  class fatal_error_catcher extends uvm_report_catcher;
+    virtual function action_e catch();
+      if (get_severity() == UVM_FATAL && get_id() == "SEQRELEVANTLOOP")
+        $display("** UVM TEST PASSED **");
+      return THROW;
+    endfunction
+  endclass
+
+  class test extends uvm_test;
+    my_sequencer ms0;
+    my_driver md0;
+    `uvm_component_utils(test)
+    function new(string name, uvm_component parent);
+      super.new(name, parent);
+    endfunction
+    function void build_phase(uvm_phase phase);
+      super.build_phase(phase);
+      ms0 = my_sequencer::type_id::create("ms0", this);
+      md0 = my_driver::type_id::create("md0", this);
+      begin
+        fatal_error_catcher fec;
+        fec = new;
+        uvm_report_cb::add(null, fec);
+      end
+    endfunction
+    function void connect_phase(uvm_phase phase);
+      super.connect_phase(phase);
+      md0.seq_item_port.connect(ms0.seq_item_export);
+    endfunction
+    task run_phase(uvm_phase phase);
+      my_sequence the_seq;
+      the_seq = my_sequence::type_id::create("the_seq", this);
+      phase.raise_objection(this);
+      fork
+        the_seq.start(ms0);
+      join_none
+      #1;
+      repeat (6) #0;
+      #300;
+      ms0.rel_var = 1;
+      phase.drop_objection(this);
+    endtask
+  endclass
+
+  initial run_test("test");
+endmodule
+"#;
+
+#[test]
+fn sqr_zero_time_loop_fires_relevant_fatal() {
+    const TEST_NAME: &str = "sqr_zero_time_loop_fires_relevant_fatal";
+    let Some(uvm) = find_uvm_root() else {
+        eprintln!(
+            "[skip] {TEST_NAME}: no 1800.2 UVM library found. Set UVM_HOME=<dir containing src/uvm_pkg.sv> to run it."
+        );
+        return;
+    };
+    let Some(dpi) = find_dpi_lib() else {
+        eprintln!(
+            "[skip] {TEST_NAME}: no stored UVM DPI shared lib (uvm-2020.3.1.so) next to the crate."
+        );
+        return;
+    };
+    let uvm_pkg = format!("{}/src/uvm_pkg.sv", uvm);
+    let inc = format!("{}/src", uvm);
+
+    let path = format!("/tmp/sqr_zero_loop_{}.sv", std::process::id());
+    std::fs::write(&path, SV_SRC).unwrap();
+    let out = Command::new(xezim_bin())
+        .args(["--simulate", "-s", "top"])
+        .arg("-I")
+        .arg(&inc)
+        .arg("--dpi-lib")
+        .arg(&dpi)
+        .arg(&format!("+UVM_TESTNAME=test"))
+        .arg(&uvm_pkg)
+        .arg(&path)
+        .output()
+        .expect("run xezim");
+    let _ = std::fs::remove_file(&path);
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    // The zero-time arbitration must spin to the SEQRELEVANTLOOP fatal, which
+    // the report catcher swallows into a PASS. Evidence that the loop failed to
+    // spin (a completed sequence or a null get_next_item) must not appear.
+    assert!(
+        text.contains("** UVM TEST PASSED **"),
+        "expected zero-time-loop fatal caught -> PASS, got:\n{text}"
+    );
+    assert!(
+        !text.contains("** UVM TEST FAILED **"),
+        "sequence unexpectedly progressed, got:\n{text}"
+    );
+}

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -205,3 +205,5 @@ mod nba_array_elem_last_write_wins;
 mod delayed_write_pending_semantics;
 #[path = "scheduling/labeled_block_local_hier_ref.rs"]
 mod labeled_block_local_hier_ref;
+#[path = "scheduling/nba_wait_for_region_yield.rs"]
+mod nba_wait_for_region_yield;

--- a/tests/scheduling/nba_wait_for_region_yield.rs
+++ b/tests/scheduling/nba_wait_for_region_yield.rs
@@ -1,0 +1,69 @@
+//! IEEE 1800-2023 §4.5: within a simulation timestep, Active region events
+//! and Inactive region (`#0` delay) events run before the NBA region commits.
+//!
+//! A common UVM synchronization idiom (`uvm_wait_for_nba_region`) posts an NBA
+//! to a procedural variable and waits on it (`nba <= next_nba; @(nba)`).
+//! The intention is to yield the calling process across all delta cycles (`#0`)
+//! until the NBA region commits.
+//!
+//! REGRESSION: xezim previously rescheduled `@(local_var)` directly into the
+//! active event queue at `self.time`, causing it to resume in the active region
+//! before sibling processes' `#0` continuations had finished, and advancing
+//! time before pending NBAs committed.
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/nba_yield_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "top", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SV_SRC: &str = r#"module top;
+  // wait_nba posts an NBA and waits on it:
+  task automatic wait_nba();
+    static int nba = 0;
+    static int next_nba = 0;
+    next_nba++;
+    nba <= next_nba;
+    @(nba);
+    $display("WOKE_AFTER_NBA");
+  endtask
+
+  initial begin
+    #1;
+    fork
+      wait_nba();
+      begin
+        // Multiple #0 delays must all complete before the NBA region wakes wait_nba
+        repeat (10) #0;
+        $display("ZERO_DELAY_DONE");
+      end
+    join
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn nba_wait_yields_until_inactive_deltas_complete() {
+    let out = run(SV_SRC, "test");
+    let zero_pos = out.find("ZERO_DELAY_DONE").expect("ZERO_DELAY_DONE printed");
+    let nba_pos = out.find("WOKE_AFTER_NBA").expect("WOKE_AFTER_NBA printed");
+    assert!(
+        zero_pos < nba_pos,
+        "expected ZERO_DELAY_DONE before WOKE_AFTER_NBA, got:\n{out}"
+    );
+}


### PR DESCRIPTION
This PR resolves several interrelated issues affecting sequence dispatch, objection draining, and NBA synchronization:

1. **Inline blocking-method local scoping (`method_local_base`)**:
   - Inlined blocking task/method calls now track `method_local_base` like synchronous methods, and `local_class_type_of` / `local_typedef_type_of` are bounded to `method_local_base.last()`. This prevents an outer caller's local variables (e.g. `seq` in `start_phase_sequence` or `configure_phase`) from shadowing a sequence subclass's `seq` member property, ensuring `body()` dispatches to the subclass and `$cast` resolves to member properties rather than caller locals.
   - In `class_of_var`, properties of `this` are checked before falling back to the flat global `var_class_types` map.

2. **Yield level-sensitive condition waiters to pending `#0` continuations**:
   - Before promoting the Inactive (`#0`) region in `run_one_tick`, `drain_condition_waiters_pre_inactive` avoids committing NBA (IEEE 1800 §4.5) and yields after each round if continuations are pending in `inactive_queue`. This prevents multi-generation condition-waiter cascades (such as background objection drains) from starving `#0` continuations, allowing sequence completion (`#0` / join / cleanup) before phase-end termination guards fire.

3. **Procedural NBA waiter scheduling (`nba_region_waiters`)**:
   - When `@(var)` is waited upon for a procedural variable (as in `uvm_wait_for_nba_region`: `nba <= next_nba; @(nba)`), the process is parked in `nba_region_waiters` rather than scheduled immediately into the active event queue. The waiters resume in the Reactive region after all Active and Inactive (`#0`) deltas have settled and `apply_nba` has committed.
   - In `event_loop_singlethread`, pending NBAs and NBA waiters keep the event loop at the current timestamp rather than prematurely advancing time.

4. **Self-tests added**:
   - `nested_seq_method_dispatch`: verifies virtual dispatch of nested sequence `body()` methods under the default sequence runner.
   - `caller_local_shadows_this_cast`: validates that outer caller locals do not shadow instance properties in `$cast`.
   - `condition_waiter_yields_to_inactive`: validates that condition-waiter cascades yield to pending `#0` continuations per delta cycle.
   - `nba_wait_for_region_yield`: verifies that procedural NBA waiters yield until all inactive delta cycles at the timestamp complete.
   - `package_class_nested_class`: verifies accessibility and instantiation of nested classes declared inside package-scoped classes.
   - `sqr_zero_time_loop`: runs a real sequencer whose sequence `wait_for_relevant` forgot to wait (non-blocking, `is_relevant` stays 0), so the zero-time arbitration must spin until `SEQRELEVANTLOOP` fires.

5. **Consume same-tick-readied condition waiters**:
   - `drain_condition_waiters` (and the pre-inactive variant) bailed as soon as `cond_progress` had not advanced, even when a same-tick blocking write had moved a waiter into `ready_condition_waiters`. Because moving a waiter to ready does not itself fire its body, the readied waiter was stranded and its `join_any` parent stayed parked in `join_waiters`. This is exactly what the sequencer's `m_select_sequence` zero-time arbitration does (a fork child re-parks on `wait(m_is_relevant_completed > 0)` while a sibling writes the flag), so the arbitration loop ran only once instead of spinning to the `SEQRELEVANTLOOP` fatal. The drain only treats "no progress" as exhausted when `ready_condition_waiters` is also empty, so readied waiters are always consumed before the next tick. Verified byte-for-byte against reference simulators: 12 `wait_for_relevant` calls, `SEQRELEVANTLOOP` fatal at t=1, caught -> PASS.

Verified byte-for-byte against reference simulators.

**Dependencies:** requires xezim-core PR [**#39**](https://github.com/aionhw/xezim-core/pull/39) (register nested classes for package- and module-scoped class declarations). The `Cargo.toml` core `rev` pin (currently `0e27469`) must be bumped to the merged core `main` revision once that lands.