### PR TITLE
fix: carry method_local_base through ProcessContext context swaps (and address PR #149 review notes)

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -2583,6 +2583,14 @@ struct ProcessContext {
     // `push_queue_frame`/`pop_and_restore_queue_frame`.
     local_dyn: Vec<Vec<(String, String)>>,
     static_local_syncs: Vec<(String, Vec<(String, String)>)>,
+    // Base index into `local_stack`/`local_type_stack` of THIS method's own
+    // locals frame, so that after a process parks inside an inlined blocking
+    // method and its `local_stack` is swapped into its `ProcessContext`, the
+    // bounds for `local_class_type_of`/`local_typedef_type_of`/`in_any_frame`
+    // follow the frame rather than leaking a foreign index from whichever
+    // process runs next. Kept in `ProcessContext` (like `local_stack` itself)
+    // precisely because the base is only meaningful against that stack.
+    method_local_base: Vec<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -36767,6 +36775,7 @@ impl Simulator {
             task_cleanup: self.task_cleanup.clone(),
             local_dyn: self.local_dyn.clone(),
             static_local_syncs: self.static_local_syncs.clone(),
+            method_local_base: self.method_local_base.clone(),
         }
     }
 
@@ -36793,6 +36802,7 @@ impl Simulator {
             task_cleanup: std::mem::take(&mut self.task_cleanup),
             local_dyn: std::mem::take(&mut self.local_dyn),
             static_local_syncs: std::mem::take(&mut self.static_local_syncs),
+            method_local_base: std::mem::take(&mut self.method_local_base),
         }
     }
 
@@ -36813,6 +36823,7 @@ impl Simulator {
         self.task_cleanup = ctx.task_cleanup;
         self.local_dyn = ctx.local_dyn;
         self.static_local_syncs = ctx.static_local_syncs;
+        self.method_local_base = ctx.method_local_base;
     }
 
     fn inherit_current_process_context(&mut self, pid: usize) {
@@ -102311,6 +102322,7 @@ impl Simulator {
                                 task_cleanup: Vec::new(),
                                 local_dyn: Vec::new(),
                                 static_local_syncs: Vec::new(),
+                                method_local_base: Vec::new(),
                             },
                         );
                         self.event_queue.schedule(self.time, pid, t.items.clone().into());

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -33078,7 +33078,10 @@ impl Simulator {
     /// ends by --max-time without $finish, and (abbreviated) with
     /// XEZIM_PROGRESS ticks.
     fn report_parked_waiters(&mut self, max_n: usize) {
-        if self.event_waiters.is_empty() && self.condition_waiters.is_empty() {
+        if self.event_waiters.is_empty()
+            && self.condition_waiters.is_empty()
+            && self.nba_region_waiters.is_empty()
+        {
             return;
         }
         let mut order: Vec<usize> = (0..self.event_waiters.len()).collect();
@@ -33155,6 +33158,21 @@ impl Simulator {
                 .unwrap_or_else(|| "<unknown location>".to_string());
             eprintln!(
                 "[xezim][hang-report]   pid {} blocked in wait(condition) — resumes at {}",
+                pid, loc
+            );
+        }
+        // §15.5: a process parked on `@(procedural_var)` for a procedural
+        // NBA-region variable (e.g. `uvm_wait_for_nba_region`'s `nba <= next_nba;
+        // @(nba)`) lingers in `nba_region_waiters` until the Reactive region's
+        // NBA commit — flush that lane before declaring a hang so a spin parked
+        // there is not reported as an unexplained block.
+        for (pid, cont) in self.nba_region_waiters.iter().take(max_n) {
+            let loc = cont
+                .first()
+                .and_then(|st| self.span_file_line_in(st.span, None))
+                .unwrap_or_else(|| "<unknown location>".to_string());
+            eprintln!(
+                "[xezim][hang-report]   pid {} parked on @(procedural-var) for the NBA region — resumes at {}",
                 pid, loc
             );
         }
@@ -34458,7 +34476,20 @@ impl Simulator {
     /// 2. If `#0` continuations are waiting in `inactive_queue`, stops after this
     ///    round so those `#0` continuations execute in this delta rather than
     ///    being starved by multi-generation cascades of condition waiters.
-    fn drain_condition_waiters_pre_inactive(&mut self) {
+    /// Drain level-sensitive `wait(expr)` waiters until none can proceed at
+    /// the current timestamp, re-resuming any that a same-tick write newly
+    /// moved into `ready_condition_waiters` even when `cond_progress` did not
+    /// step (moving to ready does not itself fire the waiter's body).
+    ///
+    /// `pre_inactive` selects the two behaviors that differ between the two
+    /// call sites:
+    ///   * `true`  — the pre-INACTIVE(`#0`) drain: do NOT apply NBA (the NBA
+    ///     region stays strictly after the inactive region, IEEE 1800-2017
+    ///     §4.5) and yield as soon as a `#0` continuation is pending, so a
+    ///     multi-generation condition-waiter cascade cannot starve it.
+    ///   * `false` — the end-of-active drain: flush any pending NBA before
+    ///     settling, and run to the full same-time fixpoint.
+    fn drain_condition_waiters(&mut self, pre_inactive: bool) {
         let mut guard = 0u32;
         while (!self.condition_waiters.is_empty() || !self.ready_condition_waiters.is_empty())
             && !self.finished
@@ -34495,68 +34526,25 @@ impl Simulator {
                     self.child_finished(bpid);
                 }
             }
-            if self.dirty_any {
-                self.settle_combinatorial();
-            }
-            if !self.inactive_queue.is_empty() {
-                break;
-            }
-            if self.cond_progress == prog_before && self.ready_condition_waiters.is_empty() {
-                break;
-            }
-        }
-    }
-
-    fn drain_condition_waiters(&mut self) {
-        let mut guard = 0u32;
-        while (!self.condition_waiters.is_empty() || !self.ready_condition_waiters.is_empty())
-            && !self.finished
-            && !self.zero_delay_defer_pending
-        {
-            guard += 1;
-            if guard > 10000 {
-                break;
-            }
-            let prog_before = self.cond_progress;
-            let ready = std::mem::take(&mut self.ready_condition_waiters);
-            for (cpid, cont) in ready {
-                self.cond_waiter_reads.remove(&cpid);
-                self.cond_read_union_dirty = true;
-                self.cond_waiter_conditions.remove(&cpid);
-                self.event_queue.schedule(self.time, cpid, cont);
-            }
-            let parked = std::mem::take(&mut self.condition_waiters);
-            for (cpid, cont) in parked {
-                self.cond_waiter_reads.remove(&cpid);
-                self.cond_read_union_dirty = true;
-                self.cond_waiter_conditions.remove(&cpid);
-                self.event_queue.schedule(self.time, cpid, cont);
-            }
-            while self.event_queue.next_time() == Some(self.time)
-                && !self.finished
-                && !self.zero_delay_defer_pending
-            {
-                let Some((bpid, stmts)) = self.event_queue.pop_front(self.time) else {
-                    break;
-                };
-                self.run_scheduled_process(bpid, &stmts);
-                if !self.is_pid_suspended(bpid) {
-                    self.child_finished(bpid);
-                }
-            }
-            if !self.nba_fast.is_empty()
-                || !self.nba_queue.is_empty()
-                // §15.5.2: a bare `->>` (deferred trigger) must flush with the
-                // NBA region even when no NBA DATA is queued.
-                || !self.pending_nba_triggers.is_empty()
-                || !self.packed_nba.is_empty()
-                || !self.pending_nba_instance_triggers.is_empty()
-                || self.delayed_nba_due()
+            if !pre_inactive
+                && (!self.nba_fast.is_empty()
+                    || !self.nba_queue.is_empty()
+                    // §15.5.2: a bare `->>` (deferred trigger) must flush with the
+                    // NBA region even when no NBA DATA is queued.
+                    || !self.pending_nba_triggers.is_empty()
+                    || !self.packed_nba.is_empty()
+                    || !self.pending_nba_instance_triggers.is_empty()
+                    || self.delayed_nba_due())
             {
                 self.apply_nba();
             }
             if self.dirty_any {
                 self.settle_combinatorial();
+            }
+            // Pre-inactive: yield to a pending `#0` continuation rather than
+            // running more cascade generations ahead of it.
+            if pre_inactive && !self.inactive_queue.is_empty() {
+                break;
             }
             // No waiter proceeded this round → the remainder are genuinely
             // blocked (future-time change); stop re-checking until the next
@@ -34708,7 +34696,7 @@ impl Simulator {
             // slave's `wait(state!=BEGIN_RESP)` wakes on the clobbered value).
             // The end-of-tick fixpoint alone is too late: the `#0` resume has
             // already committed the overwrite by then.
-            self.drain_condition_waiters_pre_inactive();
+            self.drain_condition_waiters(true);
             if self.promote_inactive_to_active()
                 && self.event_queue.next_time() == Some(self.time)
             {
@@ -34837,7 +34825,7 @@ impl Simulator {
         self.dump_write_changes();
 
         // Condition-waiter fixpoint (level-sensitive `wait(expr)` resume).
-        self.drain_condition_waiters();
+        self.drain_condition_waiters(false);
 
         // `#0` continuations parked during the POST-active stages of this
         // tick (edge cascades, reactive work) resume in the next same-time
@@ -83676,9 +83664,12 @@ impl Simulator {
         // Member of `this` (the current object) — IEEE 1800-2023 §8.14:
         // inside a class method, properties of `this` take precedence over
         // outer / unrelated procedural locals in `var_class_types`.
+        // Borrow the instance's class name (no heap allocation per lookup)
+        // so the probe in `class_prop_type_named` stays cheap on hot
+        // class-method paths.
         if let Some(h) = self.this_stack.last().copied().flatten() {
-            if let Some(cls) = self.heap.get(h).and_then(|o| o.as_ref()).map(|i| i.class_name.clone()) {
-                if let Some(tn) = self.class_prop_type_named(&cls, vname) {
+            if let Some(inst) = self.heap.get(h).and_then(|o| o.as_ref()) {
+                if let Some(tn) = self.class_prop_type_named(&inst.class_name, vname) {
                     if self.module.classes.contains_key(&tn) || tn.contains('#') {
                         return Some(tn);
                     }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -45,6 +45,9 @@ mod explicit_param_static_coll_read;
 mod typename_p_subroutine_locals;
 #[path = "classes/blocking_task_super_dispatch.rs"]
 mod blocking_task_super_dispatch;
+
+#[path = "classes/blocking_method_keyed_method_local_base.rs"]
+mod blocking_method_keyed_method_local_base;
 #[path = "classes/class_field_named_event.rs"]
 mod class_field_named_event;
 #[path = "classes/this_chain_edge_sensitivity.rs"]

--- a/tests/classes/blocking_method_keyed_method_local_base.rs
+++ b/tests/classes/blocking_method_keyed_method_local_base.rs
@@ -1,0 +1,68 @@
+//! REGRESSION: `method_local_base` (the index into `local_stack` that bounds
+//! `local_class_type_of` / `local_typedef_type_of` / `in_any_frame` to THIS
+//! inlined method's own frames) was simulator-global and not part of
+//! `ProcessContext`. When a process parked (`#5`) inside an inlined blocking
+//! method, its `local_stack` was swapped into its `ProcessContext` while its
+//! base stayed on the simulator, so whichever process ran next left a foreign
+//! base index behind. On resume the parker bounded its one-frame stack with
+//! that stale index, `in_any_frame` turned false, and a method-local `Right
+//! obj` resolved to the module-scope net `Wrong obj` — constructing the wrong
+//! class (tag 111 instead of 222).
+use std::process::Command;
+
+fn xezim() -> String {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("xezim").to_string_lossy().into_owned()
+}
+
+fn run(src: &str, tag: &str) -> String {
+    let path = format!("/tmp/blocking_method_base_{tag}.sv");
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(xezim())
+        .args(["--simulate", "-s", "tb", &path])
+        .output()
+        .expect("run xezim");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const SV_SRC: &str = r#"module tb;
+  class Wrong; int tag; function new(); tag = 111; endfunction endclass
+  class Right; int tag; function new(); tag = 222; endfunction endclass
+
+  class Parker;
+    task blocking_wait();
+      Right obj;          // method-local shadows the module-scope Wrong obj
+      #5;                 // parks: base pushed, context swapped away
+      obj = new();
+      $display("PARKER tag=%0d (expect 222)", obj.tag);
+    endtask
+  endclass
+
+  class Deep; task go(); #20; endtask endclass
+
+  Wrong obj;              // module-scope net of a DIFFERENT class
+  Parker p = new;
+  Deep   d = new;
+
+  task automatic lvl2(); d.go(); endtask   // entered with 2 caller frames below
+  task automatic lvl1(); lvl2(); endtask
+
+  initial p.blocking_wait();
+  initial lvl1();
+  initial #40 $finish;
+endmodule
+"#;
+
+#[test]
+fn method_local_base_follows_process_through_context_swap() {
+    let out = run(SV_SRC, "mlb");
+    assert!(
+        out.contains("PARKER tag=222"),
+        "method-local `Right obj` must resolve ahead of the module-scope `Wrong obj` even after the process parks and resumes (base must travel with ProcessContext); got:\n{out}"
+    );
+    assert!(!out.contains("PARKER tag=111"), "resolved to module-scope Wrong obj; got:\n{out}");
+}


### PR DESCRIPTION
Addresses the review of xezim PR [**#149**](https://github.com/aionhw/xezim/pull/149): the requested change plus the three non-blocking notes.

### 1. Requested change — `method_local_base` was not part of `ProcessContext` (fixed)

`method_local_base` records the index into `local_stack`/`local_type_stack` that bounds `local_class_type_of` / `local_typedef_type_of` / `in_any_frame` to the current inlined method's own frames. It lived on the simulator globally while every other per-call frame walked with `local_stack` inside `ProcessContext`. When a process parked (`#5`) inside an inlined blocking method, its `local_stack` was `mem::take`n into its `ProcessContext` but its base stayed behind, so whichever process ran next left a foreign base index behind. On resume the parker bounded its restored one-frame stack with that stale index, `in_any_frame` turned false, and a method-local `Right obj` resolved to a same-named module-scope net of a *different* class — constructing the wrong type.

```systemverilog
class Wrong; int tag; function new(); tag = 111; endfunction endclass
class Right; int tag; function new(); tag = 222; endfunction endclass
class Parker;
  task blocking_wait();
    Right obj; // method-local shadows the module-scope Wrong obj
    #5;        // parks: base pushed, context swapped away
    obj = new();
    $display("PARKER tag=%0d (expect 222)", obj.tag);
  endtask
endclass
class Deep; task go(); #20; endtask endclass
module tb;
  Wrong obj; Parker p = new; Deep d = new;
  task automatic lvl2(); d.go(); endtask
  task automatic lvl1(); lvl2(); endtask
  initial p.blocking_wait();
  initial lvl1();
  initial #40 $finish;
endmodule
```

Reference simulator: `PARKER tag=222`. Before: **`111`**. After: `222`. **Fix:** move `method_local_base` into `ProcessContext` (snapshot/take/restore), mirroring `static_local_syncs` from #148. Adds regression self-test `blocking_method_keyed_method_local_base`.

### 2. Note 2 — dedup `drain_condition_waiters` (no more drifting copies)

`drain_condition_waiters_pre_inactive` duplicated ~50 lines of `drain_condition_waiters`, and the "consume readied waiters" fix already had to be landed in both copies (that was the drift starting). Collapsed into one `drain_condition_waiters(pre_inactive: bool)` that selects the two genuinely-different behaviors: the pre-INACTIVE(`#0`) drain skips the NBA flush (§4.5 — the NBA region stays strictly after the inactive region) and yields to a pending `#0` continuation; the end-of-active drain flushes pending NBA and runs the full same-time fixpoint.

### 3. Note 3 — `report_parked_waiters` now reports the `nba_region_waiters` lane

The `--max-time` hang report didn't include the `nba_region_waiters` lane, so a hang with a process parked on `@(procedural_var)` for the NBA region (e.g. `uvm_wait_for_nba_region`'s `nba <= next_nba; @(nba)`) printed nothing. Now counted in the early-return guard and reported per parked pid.

### 4. Note 1 — drop the `this`-property probe's per-lookup `String` clone

`class_of_var`'s `this`-property probe cloned the instance's class name on every lookup (`i.class_name.clone()`), ~0.35% `String::clone` on the axi4 AVIP. Borrow `&inst.class_name` instead, so `class_prop_type_named` allocates nothing on the hot class-method path.


Depends on xezim-core PR for the `register_nested_classes` single-elaboration change (so the core rev pin in `Cargo.toml` can be bumped together); a local-core-patched build passes `package_class_nested_class` and the full suite.