### PR TITLE
Report concurrent cover properties as covers, not as failing asserts

### DIFF
--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -2473,6 +2473,12 @@ struct SvaClockedSite {
     /// and swapped in while this site's predicate is evaluated, so the
     /// property samples pre-edge values (see `eval_sva_sampled`).
     sampled_ids: Vec<usize>,
+    /// LRM §16.5 assertion kind, same u8 tagging the immediate path uses:
+    /// 0 assert, 1 assume, 2 cover. Carried here because the tally is
+    /// written long after the statement is gone, and a `cover property`
+    /// recorded as an assert both mislabels the site and counts a cycle
+    /// that simply did not hit as a failure.
+    kind: u8,
 }
 
 #[derive(Debug, Clone)]
@@ -63918,6 +63924,11 @@ impl Simulator {
                                 pass_action: a.action.as_deref().cloned(),
                                 fail_action: a.else_action.as_deref().cloned(),
                                 sampled_ids,
+                                kind: match a.kind {
+                                    AssertionKind::Assert => 0,
+                                    AssertionKind::Assume => 1,
+                                    AssertionKind::Cover => 2,
+                                },
                             });
                         }
                         return;
@@ -69430,6 +69441,11 @@ impl Simulator {
             // LRM §16.5.1: the referenced-signal ids whose Preponed samples
             // this fire's predicates must read (see eval_sva_sampled).
             let sampled_ids = self.sva_sites[i].sampled_ids.clone();
+            // LRM §16.5: tally under the kind the source actually wrote.
+            // Every stat below used to be created as `assert`, so a
+            // `cover property` was reported as an assertion -- and a clock
+            // where it simply did not hit was reported as a FAILURE.
+            let site_kind = self.sva_sites[i].kind;
             // 1) Drain pending consequents whose counter is 1 (they're
             //    due this cycle), decrement the rest.
             let mut due: Vec<Expression> = Vec::new();
@@ -69459,7 +69475,7 @@ impl Simulator {
                         .assertion_stats
                         .entry(span_key_for_evt)
                         .or_insert_with(|| AssertionStat {
-                            kind: 0,
+                            kind: site_kind,
                             pass_count: 0,
                             fail_count: 0,
                         });
@@ -69483,11 +69499,15 @@ impl Simulator {
                         .assertion_stats
                         .entry(span_key_for_evt)
                         .or_insert_with(|| AssertionStat {
-                            kind: 0,
+                            kind: site_kind,
                             pass_count: 0,
                             fail_count: 0,
                         });
-                    stat.fail_count += 1;
+                    if site_kind != 2 {
+                        // See above: a cover does not fail, it just does
+                        // not hit.
+                        stat.fail_count += 1;
+                    }
                     self.fire_sva_action(i, false);
                 }
             }
@@ -69498,13 +69518,17 @@ impl Simulator {
                     .assertion_stats
                     .entry(span_key)
                     .or_insert_with(|| AssertionStat {
-                        kind: 0, /* assert */
+                        kind: site_kind,
                         pass_count: 0,
                         fail_count: 0,
                     });
                 if v {
                     stat.pass_count += 1;
-                } else {
+                } else if site_kind != 2 {
+                    // LRM §16.12: a cover property has hits, not verdicts.
+                    // A clock where it did not hit is simply not a hit --
+                    // counting it as a failure turns an uncovered property
+                    // into a red regression.
                     stat.fail_count += 1;
                 }
                 self.fire_sva_action(i, v);
@@ -69612,6 +69636,9 @@ impl Simulator {
         body: &Expression,
         sampled_ids: &[usize],
     ) {
+        // Same reason as in tick_sva_sites: tally under the kind the
+        // source wrote, so a `cover property` is not filed as an assert.
+        let site_kind = self.sva_sites[site_idx].kind;
         // LRM §16.6 `disable iff (g)` wrapper. The parser encodes the
         // clause as `Binary{LogAnd, !g, inner_body}`. When `g` is true
         // (so `!g` is false), the property is suppressed for this
@@ -69695,7 +69722,7 @@ impl Simulator {
                         self.assertion_stats
                         .entry(span_key)
                         .or_insert_with(|| AssertionStat {
-                            kind: 0,
+                            kind: site_kind,
                             pass_count: 0,
                             fail_count: 0,
                         });
@@ -69724,13 +69751,17 @@ impl Simulator {
                     .assertion_stats
                     .entry(span_key)
                     .or_insert_with(|| AssertionStat {
-                        kind: 0,
+                        kind: site_kind,
                         pass_count: 0,
                         fail_count: 0,
                     });
                 if outcome {
                     stat.pass_count += 1;
-                } else {
+                } else if site_kind != 2 {
+                    // LRM §16.12: a cover property has hits, not verdicts.
+                    // A clock where it did not hit is simply not a hit --
+                    // counting it as a failure turns an uncovered property
+                    // into a red regression.
                     stat.fail_count += 1;
                 }
                 self.fire_sva_action(site_idx, outcome);
@@ -69742,13 +69773,17 @@ impl Simulator {
                     .assertion_stats
                     .entry(span_key)
                     .or_insert_with(|| AssertionStat {
-                        kind: 0,
+                        kind: site_kind,
                         pass_count: 0,
                         fail_count: 0,
                     });
                 if outcome {
                     stat.pass_count += 1;
-                } else {
+                } else if site_kind != 2 {
+                    // LRM §16.12: a cover property has hits, not verdicts.
+                    // A clock where it did not hit is simply not a hit --
+                    // counting it as a failure turns an uncovered property
+                    // into a red regression.
                     stat.fail_count += 1;
                 }
                 self.fire_sva_action(site_idx, outcome);


### PR DESCRIPTION
A `cover property` is recorded as an assertion, and every clock where it
does not hit is tallied as a **failure**. Two covers and nothing else:

```
[COV] assertions: 2 sites (assert=2, assume=0, cover=0) — 3 passes, 3 fails
```

Both halves are wrong. The second is the one that bites: an uncovered
property is not a failing property, so a coverage report built from
`xezim_cov.json` reads a healthy run as a regression.

## Cause

`SvaClockedSite` carries no kind, so every `AssertionStat` created while
evaluating a clocked property is built with `kind: 0 /* assert */`
hardcoded — six such sites across `tick_sva_sites` and `tick_sva_body` —
even though the immediate path already maps `a.kind` onto the same `u8`
tag correctly a few hundred lines away. The concurrent-cover probe path
notes the gap in a comment: *"reuse the immediate-cover tag for
concurrent-cover probes (no dedicated tag yet)"*.

## Fix

Carry the source kind on the site, set from `a.kind` at construction with
the mapping the immediate path already uses, and tally under it. Then
guard the fail increments: for kind 2 a non-hit increments nothing, since
a cover has hits rather than verdicts (LRM §16.12).

## Result

```
cover only              assert=0 cover=2  —  3 passes,  0 fails
3 asserts + 2 covers    assert=3 cover=2  — 13 passes,  5 fails
always-false assertion  assert=1 cover=0  —  0 passes,  4 fails
```

The last line is the control: real assertion failures still count and
still fire their `else` actions.

## Scope

Behaviour is unchanged — only the tallies move. Verified across a battery
of immediate asserts, implication failures (`a |=> b`), `disable iff`,
`$rose`, multi-cycle sequences, and `cover property` action blocks: every
one behaves exactly as before, and `xezim_cov.json` entries now carry
`"kind": "cover"` with `fail: 0`.

Built and tested on current `main`.
