### PR TITLE
Five write-path and scheduling fixes

### DIFF
--- a/src/compiler/aot.rs
+++ b/src/compiler/aot.rs
@@ -1014,7 +1014,15 @@ fn emit_insn_rust(
         }
         BlockingAssignBitDyn(sig, idx_r, val) => {
             let sig = sref(*sig);
-            let _ = writeln!(w, "(br().blk_range)(sim, {sig}, r{idx_r}v, r{idx_r}v, r{val}v, r{val}x);");
+            // §11.5.1: an x/z index modifies no bits. The x plane never
+            // reached the bridge and the value plane has x bits masked to
+            // zero, so an unknown index arrived as bit 0. Hand the bridge a
+            // deliberately out-of-range index instead; it already drops those.
+            let _ = writeln!(
+                w,
+                "let bi{idx_r} = if r{idx_r}x != 0 {{ u64::MAX }} else {{ r{idx_r}v }};\n\
+                 (br().blk_range)(sim, {sig}, bi{idx_r}, bi{idx_r}, r{val}v, r{val}x);"
+            );
         }
         NbaAssignConst(sig, v, width) => {
             let sig = sref(*sig);
@@ -1037,7 +1045,12 @@ fn emit_insn_rust(
         }
         NbaAssignBitDyn(sig, idx_r, val) => {
             let sig = sref(*sig);
-            let _ = writeln!(w, "(br().nba_bit)(sim, {sig}, r{idx_r}v, r{val}v, r{val}x);");
+            // §11.5.1, as for the blocking form above.
+            let _ = writeln!(
+                w,
+                "let bi{idx_r} = if r{idx_r}x != 0 {{ u64::MAX }} else {{ r{idx_r}v }};\n\
+                 (br().nba_bit)(sim, {sig}, bi{idx_r}, r{val}v, r{val}x);"
+            );
         }
         LoadArrayElem(d, arr, idx_reg) => {
             let ArrayOperand::Dense { first_id, lo, hi, .. } = arr.as_ref() else {

--- a/src/compiler/jit.rs
+++ b/src/compiler/jit.rs
@@ -1953,9 +1953,7 @@ mod enabled {
             BlockingAssignBitDyn(sig_id, idx_reg, val_reg) => {
                 let (v, x) = ld2(builder, pointer_type, regs, xz, *val_reg);
                 let id = builder.ins().iconst(types::I32, *sig_id as i64);
-                let idx = builder
-                    .ins()
-                    .stack_load(pointer_type, types::I64, regs[*idx_reg as usize], 0);
+                let idx = dyn_bit_index_or_oob(builder, pointer_type, regs, xz, *idx_reg);
                 // A 1-bit write at [idx:idx] — same semantics, same bridge.
                 builder
                     .ins()
@@ -2099,9 +2097,7 @@ mod enabled {
             NbaAssignBitDyn(sig_id, idx_reg, val_reg) => {
                 let (v, x) = ld2(builder, pointer_type, regs, xz, *val_reg);
                 let id = builder.ins().iconst(types::I32, *sig_id as i64);
-                let idx = builder
-                    .ins()
-                    .stack_load(pointer_type, types::I64, regs[*idx_reg as usize], 0);
+                let idx = dyn_bit_index_or_oob(builder, pointer_type, regs, xz, *idx_reg);
                 builder.ins().call(nba_bit_ref, &[sim_ptr, id, idx, v, x]);
             }
             // NbaAssignRangeDyn / NbaAssignBitDyn still left out — they
@@ -2908,6 +2904,26 @@ mod enabled {
     }
 
     /// Load both planes of a VM register.
+    /// §11.5.1: the index operand of a dynamic bit-store, with an x/z index
+    /// turned into a deliberately OUT-OF-RANGE one. The store bridges already
+    /// drop an out-of-range index, so this makes "unknown index writes
+    /// nothing" fall out of the path that is already there. The x plane never
+    /// reached the bridge, and the value plane has x bits masked to zero, so
+    /// an unknown index arrived as a perfectly ordinary bit 0.
+    fn dyn_bit_index_or_oob(
+        builder: &mut FunctionBuilder,
+        pointer_type: Type,
+        regs: &[StackSlot],
+        xz: &[StackSlot],
+        r: u16,
+    ) -> Value {
+        let (iv, ix) = ld2(builder, pointer_type, regs, xz, r);
+        let zero = builder.ins().iconst(types::I64, 0);
+        let oob = builder.ins().iconst(types::I64, -1);
+        let unknown = builder.ins().icmp(IntCC::NotEqual, ix, zero);
+        builder.ins().select(unknown, oob, iv)
+    }
+
     fn ld2(
         builder: &mut FunctionBuilder,
         pointer_type: Type,

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -42062,6 +42062,56 @@ impl Simulator {
         false
     }
 
+    /// LRM §25.8 — resolve `vif.member` (or `this.vif.member`) to the FLAT
+    /// name of the bound interface signal, `"<iface_instance>.<member>"`.
+    ///
+    /// `resolve_nba_target` asks the same question but only ever returns a
+    /// registered signal id, which is no use to a caller that needs the NAME
+    /// — to look up the member's packed dimensions, say. The binding lives
+    /// either in `local_iface_aliases` (a vif passed as a task formal) or in
+    /// `virtual_iface_bindings` keyed by the current `this`; both lookups are
+    /// the ones that arm already does.
+    fn vif_member_flat_name(&self, expr: &Expression) -> Option<String> {
+        let ExprKind::MemberAccess { expr: base, member } = &expr.kind else {
+            return None;
+        };
+        let prop = match &base.kind {
+            ExprKind::Ident(hier) if hier.path.len() == 1 => {
+                hier.path[0].name.name.as_str()
+            }
+            ExprKind::MemberAccess {
+                expr: inner,
+                member: vprop,
+            } if matches!(&inner.kind, ExprKind::This) => vprop.name.as_str(),
+            _ => return None,
+        };
+        if let Some(bound) = self
+            .local_iface_aliases
+            .last()
+            .and_then(|frame| frame.get(prop))
+        {
+            return Some(format!("{}.{}", bound, member.name));
+        }
+        let this_h = self.this_stack.last().copied().flatten()?;
+        let cls_name = self
+            .heap
+            .get(this_h)
+            .and_then(|o| o.as_ref())
+            .map(|i| i.class_name.as_str())?;
+        if !self
+            .module
+            .classes
+            .get(cls_name)
+            .is_some_and(|cd| cd.virtual_iface_properties.contains_key(prop))
+        {
+            return None;
+        }
+        let (bound_name, _modport) = self
+            .virtual_iface_bindings
+            .get(&(this_h, prop.to_string()))?;
+        Some(format!("{}.{}", bound_name, member.name))
+    }
+
     fn resolve_nba_target(&mut self, lhs: &Expression) -> Option<usize> {
         match &lhs.kind {
             ExprKind::Ident(hier) => {
@@ -75857,8 +75907,20 @@ impl Simulator {
                     depth += 1;
                     cur = inner.as_ref();
                 }
-                if let ExprKind::Ident(h) = &cur.kind {
-                    let n = self.resolve_hier_name(h);
+                // §25.8: for `vif.member[i]` the root is a MemberAccess, not an
+                // Ident, so the whole block below was skipped and the lvalue
+                // fell through to width 1 — an NBA then resized its RHS to ONE
+                // BIT before queueing it, and `vif.data[p] <= flit` wrote the
+                // flit's LSB. Resolve the binding to the interface signal's
+                // flat name and ask the same width questions about it.
+                let root_name: Option<std::borrow::Cow<'_, str>> = match &cur.kind {
+                    ExprKind::Ident(h) => Some(self.resolve_hier_name(h)),
+                    ExprKind::MemberAccess { .. } => {
+                        self.vif_member_flat_name(cur).map(std::borrow::Cow::Owned)
+                    }
+                    _ => None,
+                };
+                if let Some(n) = root_name {
                     if depth == 1 {
                         if let Some((_, _, w)) = self.module.arrays.get(&*n) {
                             return *w;

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -48518,6 +48518,33 @@ impl Simulator {
         None
     }
 
+    /// The registered packed-struct base of a dotted member lvalue, as
+    /// `(base_name, bit_offset, width)` of the selected member within it.
+    ///
+    /// `packed_struct_fields[base]` is FLATTENED — a nested member is a key in
+    /// its own right (`"hdr.d.x"`), and no entry exists for an intermediate
+    /// member on its own (`packed_struct_fields["f.hdr"]` is None). So the
+    /// single split at the last dot only ever resolved a DEPTH-1 member, and
+    /// `f.hdr.d = v` inside a subroutine — where the lvalue parses as
+    /// MemberAccess rather than a dotted Ident — matched nothing and was
+    /// silently dropped. Walk the split points LONGEST BASE FIRST, exactly as
+    /// `resolve_packed_struct_target` does for assignment patterns (which is
+    /// why the same write with a `'{...}` RHS always worked): the base may
+    /// itself be instance-scoped (`u.r2`), so the first-dot split is wrong too.
+    fn packed_struct_member_slice(&mut self, lvalue: &Expression) -> Option<(String, u32, u32)> {
+        let flat = self.flat_member_name(lvalue)?;
+        for (i, _) in flat.match_indices('.').collect::<Vec<_>>().into_iter().rev() {
+            let (base, prefix) = (&flat[..i], &flat[i + 1..]);
+            let Some(layout) = self.module.packed_struct_fields.get(base) else {
+                continue;
+            };
+            if let Some((_, o, w)) = layout.iter().find(|(k, _, _)| k == prefix) {
+                return Some((base.to_string(), *o, *w));
+            }
+        }
+        None
+    }
+
     /// Resolve a packed-struct lvalue to `(base_signal, field_prefix, layout,
     /// base_offset, width)` for assignment-pattern packing. `layout` is the
     /// base signal's flattened `(dotted_field, offset, width)` list; `prefix`
@@ -52354,27 +52381,21 @@ impl Simulator {
                 }
                 // A nested PACKED struct member inside an unpacked aggregate
                 // (`arr[i].tag.vlan`): slice the parent's own signal.
-                if let Some(pflat) = self.flat_member_name(expr) {
-                    if let Some(fields) = self.module.packed_struct_fields.get(&pflat).cloned() {
-                        if let Some((_, off, w)) =
-                            fields.iter().find(|(m, _, _)| *m == member.name).cloned()
-                        {
-                            // The container may be a procedural LOCAL: a packed
-                            // struct declared inside a task lives in the call
-                            // frame, not the signal table, so a member write
-                            // reached nothing and the struct read back as X.
-                            if let Some(cur_sig) = self.get_local_or_signal(&pflat) {
-                                let total_w = cur_sig.width;
-                                let mut cur = cur_sig.resize(total_w);
-                                let piece = val.resize(w);
-                                for i in 0..w {
-                                    cur.set_bit((off + i) as usize, piece.get_bit(i as usize));
-                                }
-                                let changed = cur != cur_sig;
-                                self.set_local_or_signal(&pflat, cur);
-                                return changed;
-                            }
+                if let Some((base, off, w)) = self.packed_struct_member_slice(lhs) {
+                    // The container may be a procedural LOCAL: a packed
+                    // struct declared inside a task lives in the call
+                    // frame, not the signal table, so a member write
+                    // reached nothing and the struct read back as X.
+                    if let Some(cur_sig) = self.get_local_or_signal(&base) {
+                        let total_w = cur_sig.width;
+                        let mut cur = cur_sig.resize(total_w);
+                        let piece = val.resize(w);
+                        for i in 0..w {
+                            cur.set_bit((off + i) as usize, piece.get_bit(i as usize));
                         }
+                        let changed = cur != cur_sig;
+                        self.set_local_or_signal(&base, cur);
+                        return changed;
                     }
                 }
                 // LRM §25.10 — `vif_arr[i].member = ...` (indexed

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -3050,6 +3050,24 @@ fn bytecode_array_elem_width(
         .max(1)
 }
 
+/// §11.5.1: the effective index of a DYNAMIC bit-select. `None` when the index
+/// contains x or z, in which case a WRITE must be discarded ("no bits shall be
+/// modified") and a read yields x.
+///
+/// `Value::to_u64` masks x bits to ZERO and returns `Some(0)` rather than
+/// `None`, so it cannot answer this question. Every dynamic bit-store used
+/// `to_u64().unwrap_or(0)` and therefore wrote BIT 0 whenever the index was
+/// unknown. Out-of-range indices need no help here: `Value::set_bit` already
+/// drops them. Same defect, and same fix, as the `LoadArrayElem` x-index
+/// sentinel on the read side.
+#[inline]
+fn dyn_bit_index(v: &Value) -> Option<usize> {
+    if v.has_xz() {
+        return None;
+    }
+    Some(v.to_u64().unwrap_or(0) as usize)
+}
+
 fn resolve_bytecode_array_elem(
     array: &super::bytecode::ArrayOperand,
     idx: i64,
@@ -23120,23 +23138,25 @@ impl Simulator {
                 }
                 Insn::NbaAssignBitDyn(sig_id, idx_reg, val_reg) => {
                     let sig_id = &(*sig_id as usize);
-                    let idx = vm_regs[*idx_reg as usize].to_u64().unwrap_or(0) as usize;
-                    let bit = vm_regs[*val_reg as usize].get_bit(0);
-                    let existing = nba_out.iter().rposition(|n| n.signal_id == *sig_id);
-                    if let Some(i) = existing {
-                        let mut new_val = nba_out[i].value.clone();
-                        new_val.set_bit(idx, bit);
-                        nba_out[i].value = new_val;
-                    } else {
-                        let cur = &signal_table[*sig_id];
-                        if cur.get_bit(idx) != bit {
-                            let mut new_val = cur.clone();
+                    // §11.5.1: an x/z index modifies no bits.
+                    if let Some(idx) = dyn_bit_index(&vm_regs[*idx_reg as usize]) {
+                        let bit = vm_regs[*val_reg as usize].get_bit(0);
+                        let existing = nba_out.iter().rposition(|n| n.signal_id == *sig_id);
+                        if let Some(i) = existing {
+                            let mut new_val = nba_out[i].value.clone();
                             new_val.set_bit(idx, bit);
-                            nba_out.push(NbaFast {
-                                signal_id: *sig_id,
-                                value: new_val,
-                                block_index,
-                            });
+                            nba_out[i].value = new_val;
+                        } else {
+                            let cur = &signal_table[*sig_id];
+                            if cur.get_bit(idx) != bit {
+                                let mut new_val = cur.clone();
+                                new_val.set_bit(idx, bit);
+                                nba_out.push(NbaFast {
+                                    signal_id: *sig_id,
+                                    value: new_val,
+                                    block_index,
+                                });
+                            }
                         }
                     }
                 }
@@ -23820,13 +23840,15 @@ impl Simulator {
                 }
                 Insn::BlockingAssignBitDyn(sig_id, idx_reg, val_reg) => {
                     let sig_id = &(*sig_id as usize);
-                    let idx = vm_regs[*idx_reg as usize].to_u64().unwrap_or(0) as usize;
-                    let bit = vm_regs[*val_reg as usize].get_bit(0);
-                    if view[*sig_id].get_bit(idx) != bit {
-                        let mut new_val = view[*sig_id].clone();
-                        new_val.set_bit(idx, bit);
-                        view[*sig_id] = new_val;
-                        dirtied.push(*sig_id as u32);
+                    // §11.5.1: an x/z index modifies no bits.
+                    if let Some(idx) = dyn_bit_index(&vm_regs[*idx_reg as usize]) {
+                        let bit = vm_regs[*val_reg as usize].get_bit(0);
+                        if view[*sig_id].get_bit(idx) != bit {
+                            let mut new_val = view[*sig_id].clone();
+                            new_val.set_bit(idx, bit);
+                            view[*sig_id] = new_val;
+                            dirtied.push(*sig_id as u32);
+                        }
                     }
                 }
                 Insn::BlockingAssignRangeDyn(sig_id, hi_reg, lo_reg, val_reg) => {
@@ -23968,21 +23990,23 @@ impl Simulator {
                 }
                 Insn::NbaAssignBitDyn(sig_id, idx_reg, val_reg) => {
                     let sig_id = &(*sig_id as usize);
-                    let idx = vm_regs[*idx_reg as usize].to_u64().unwrap_or(0) as usize;
-                    let bit = vm_regs[*val_reg as usize].get_bit(0);
-                    let existing = nba_out.iter().rposition(|n| n.signal_id == *sig_id);
-                    if let Some(i) = existing {
-                        let mut new_val = nba_out[i].value.clone();
-                        new_val.set_bit(idx, bit);
-                        nba_out[i].value = new_val;
-                    } else if view[*sig_id].get_bit(idx) != bit {
-                        let mut new_val = view[*sig_id].clone();
-                        new_val.set_bit(idx, bit);
-                        nba_out.push(NbaFast {
-                            signal_id: *sig_id,
-                            value: new_val,
-                            block_index,
-                        });
+                    // §11.5.1: an x/z index modifies no bits.
+                    if let Some(idx) = dyn_bit_index(&vm_regs[*idx_reg as usize]) {
+                        let bit = vm_regs[*val_reg as usize].get_bit(0);
+                        let existing = nba_out.iter().rposition(|n| n.signal_id == *sig_id);
+                        if let Some(i) = existing {
+                            let mut new_val = nba_out[i].value.clone();
+                            new_val.set_bit(idx, bit);
+                            nba_out[i].value = new_val;
+                        } else if view[*sig_id].get_bit(idx) != bit {
+                            let mut new_val = view[*sig_id].clone();
+                            new_val.set_bit(idx, bit);
+                            nba_out.push(NbaFast {
+                                signal_id: *sig_id,
+                                value: new_val,
+                                block_index,
+                            });
+                        }
                     }
                 }
                 Insn::NbaAssignArray(array_name, idx_reg, val_reg, width) => {
@@ -25230,25 +25254,27 @@ impl Simulator {
                 }
                 Insn::NbaAssignBitDyn(sig_id, idx_reg, val_reg) => {
                     let sig_id = &(*sig_id as usize);
-                    let idx = self.vm_regs[*idx_reg as usize].to_u64().unwrap_or(0) as usize;
-                    let bit = self.vm_regs[*val_reg as usize].get_bit(0);
-                    let id = *sig_id;
-                    if let Some(i) = self.nba_fast_index.get(id) {
-                        self.nba_fast[i].value.set_bit(idx, bit);
-                    } else {
-                        // Single-bit elision: if the bit is already what
-                        // we're about to write, skip the queue push.
-                        if self.signal_table[id].get_bit(idx) == bit {
-                            self.prof_nba_elided += 1;
+                    // §11.5.1: an x/z index modifies no bits.
+                    if let Some(idx) = dyn_bit_index(&self.vm_regs[*idx_reg as usize]) {
+                        let bit = self.vm_regs[*val_reg as usize].get_bit(0);
+                        let id = *sig_id;
+                        if let Some(i) = self.nba_fast_index.get(id) {
+                            self.nba_fast[i].value.set_bit(idx, bit);
                         } else {
-                            let mut new_val = self.signal_table[id].clone();
-                            new_val.set_bit(idx, bit);
-                            self.nba_fast_index.insert(id, self.nba_fast.len());
-                            self.nba_fast.push(NbaFast {
-                                block_index: 0,
-                                signal_id: id,
-                                value: new_val,
-                            });
+                            // Single-bit elision: if the bit is already what
+                            // we're about to write, skip the queue push.
+                            if self.signal_table[id].get_bit(idx) == bit {
+                                self.prof_nba_elided += 1;
+                            } else {
+                                let mut new_val = self.signal_table[id].clone();
+                                new_val.set_bit(idx, bit);
+                                self.nba_fast_index.insert(id, self.nba_fast.len());
+                                self.nba_fast.push(NbaFast {
+                                    block_index: 0,
+                                    signal_id: id,
+                                    value: new_val,
+                                });
+                            }
                         }
                     }
                 }
@@ -25374,22 +25400,26 @@ impl Simulator {
                     // this dominated allocator + memcpy time. Now: read
                     // current bit, skip the write if it matches; otherwise
                     // set in-place and mark dirty.
-                    let idx = self.vm_regs[*idx_reg as usize].to_u64().unwrap_or(0) as usize;
-                    let bit = self.vm_regs[*val_reg as usize].get_bit(0);
-                    let id = *sig_id;
-                    if idx < self.signal_widths[id] as usize {
-                        let cur = self.signal_table[id].get_bit(idx);
-                        if cur != bit {
-                            self.signal_table[id].set_bit(idx, bit);
-                            self.sync_mirror(id);
-                            self.signal_table[id].is_signed = self.signal_signed[id];
-                            if !self.dirty_signals[id] {
-                                self.dirty_signals[id] = true;
-                                self.dirty_list.push(id);
+                    // §11.5.1: an x/z index modifies no bits. `to_u64` masks
+                    // x bits to zero, so this cannot be folded into the range
+                    // check below -- an unknown index looked like bit 0.
+                    if let Some(idx) = dyn_bit_index(&self.vm_regs[*idx_reg as usize]) {
+                        let bit = self.vm_regs[*val_reg as usize].get_bit(0);
+                        let id = *sig_id;
+                        if idx < self.signal_widths[id] as usize {
+                            let cur = self.signal_table[id].get_bit(idx);
+                            if cur != bit {
+                                self.signal_table[id].set_bit(idx, bit);
+                                self.sync_mirror(id);
+                                self.signal_table[id].is_signed = self.signal_signed[id];
+                                if !self.dirty_signals[id] {
+                                    self.dirty_signals[id] = true;
+                                    self.dirty_list.push(id);
+                                }
+                                self.dirty_any = true;
+                                self.table_modified = true;
+                                self.after_signal_write(id);
                             }
-                            self.dirty_any = true;
-                            self.table_modified = true;
-                            self.after_signal_write(id);
                         }
                     }
                 }

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -60341,6 +60341,30 @@ impl Simulator {
                 // spread, not collapsed into one packed value. This is also
                 // what makes a DECLARATION initializer work — elaboration
                 // lowers `T v[int] = '{...}` to `v = '{...}` in an initial block.
+                // §10.9.2: a whole-ARRAY pattern on a CLASS PROPERTY whose
+                // elements are unpacked structs — expand per element so each
+                // lands in the cells the READ path uses, by the same store rule
+                // as the whole-element write above. Must precede the spread
+                // below: `assign_class_fixed_array_pattern` writes the
+                // instance-scoped SIGNAL names (`<h>#arr[i].<m>`) that nothing
+                // reads back, which is what left every element 0.
+                if let ExprKind::AssignmentPattern(items) = &rvalue.kind {
+                    if let Some((_, _, su)) = self.class_unpacked_array_prop_of(lvalue) {
+                        let probe0 = Self::index_expr(lvalue, 0);
+                        if self.class_unpacked_elem_is_heap_owned(&probe0) {
+                            let ord: Vec<Expression> =
+                                self.pattern_ordered(items).into_iter().cloned().collect();
+                            if !ord.is_empty() {
+                                for (i, item) in ord.iter().enumerate() {
+                                    let elem = Self::index_expr(lvalue, i as i64);
+                                    self.assign_class_unpacked_elem(&elem, item, &su);
+                                }
+                                self.settle_after_proc_write();
+                                return;
+                            }
+                        }
+                    }
+                }
                 if let ExprKind::AssignmentPattern(items) = &rvalue.kind {
                     let spread = self.assign_class_fixed_array_pattern(lvalue, items)
                         || self.assign_class_collection_pattern(lvalue, items)
@@ -60685,6 +60709,27 @@ impl Simulator {
                 // generic arm below can't resolve the container (`p_elem_type`
                 // only knows module-scope names), so the copy fell to a packed
                 // store and every member of the element stayed blank.
+                // §7.2/§18.4: ...unless the READ path owns this element's
+                // leaves. A CLASS PROPERTY that is a fixed array of unpacked
+                // structs is resolved on the read side by `class_unpacked_leaf`
+                // into the instance property map (`arr[i].<m>`) — which is also
+                // where a per-leaf write (`arr[i].m = v`) and a scalar-struct
+                // property write land. Only the whole-element path below routed
+                // to the instance-scoped SIGNAL name `<h>#arr[i].<m>`, so the
+                // value was written and then unreachable and every such element
+                // read back 0. Ask the read resolver where the leaves live and
+                // decompose into the same cells. A genuine queue/dynamic/assoc
+                // element is NOT claimed by it and keeps the signal-name copy
+                // below (UVM uvm_hdl_path_concat::add_slice).
+                if self.queue_pop_call(rvalue).is_none()
+                    && self.class_unpacked_elem_is_heap_owned(lvalue)
+                {
+                    if let Some((_, _, su)) = self.class_unpacked_array_prop_of(lvalue) {
+                        self.assign_class_unpacked_elem(lvalue, rvalue, &su);
+                        self.settle_after_proc_write();
+                        return;
+                    }
+                }
                 if self.queue_pop_call(rvalue).is_none() {
                     if let Some(dst) = self.flat_member_name(lvalue) {
                         // Only a BARE element lvalue (`slices[i] = ...`) — a
@@ -87281,6 +87326,103 @@ impl Simulator {
         params
     }
 
+    /// `(handle, prop, elem_struct)` when `lvalue` — with any trailing element
+    /// select stripped — names a CLASS PROPERTY whose element type is an
+    /// unpacked struct. Drives a member-wise decomposition of a whole-element
+    /// write into the same cells `class_unpacked_leaf` reads back.
+    fn class_unpacked_array_prop_of(
+        &mut self,
+        lvalue: &Expression,
+    ) -> Option<(usize, String, crate::ast::types::StructUnionType)> {
+        if self.no_class_objects() {
+            return None;
+        }
+        let recv = match self.class_prop_receiver(lvalue) {
+            Some(r) => Some(r),
+            None => match &lvalue.kind {
+                ExprKind::Index { expr, .. } => self.class_prop_receiver(expr),
+                ExprKind::Ident(h) if h.path.len() == 1 && !h.path[0].selects.is_empty() => {
+                    let bare = crate::ast::expr::HierarchicalIdentifier {
+                        root: None,
+                        path: vec![crate::ast::expr::HierPathSegment {
+                            name: h.path[0].name.clone(),
+                            selects: Vec::new(),
+                        }],
+                        span: h.span,
+                        cached_signal_id: std::cell::Cell::new(None),
+                        cached_resolved_name: std::cell::OnceCell::new(),
+                    };
+                    let e = Expression::new(ExprKind::Ident(bare), lvalue.span);
+                    self.class_prop_receiver(&e)
+                }
+                _ => None,
+            },
+        };
+        let (handle, prop) = recv?;
+        let su = self.class_prop_struct(handle, &prop)?;
+        Self::spreads_member_wise(&su).then_some((handle, prop, su))
+    }
+
+    /// True when the READ path (`class_unpacked_leaf`) owns this element's
+    /// leaves — i.e. they live in the instance property map as
+    /// `<prop>[i].<member>`, not under an instance-scoped SIGNAL name. Used to
+    /// keep whole-element / whole-array writes in the same store the reads use.
+    fn class_unpacked_elem_is_heap_owned(&mut self, lvalue: &Expression) -> bool {
+        let Some((_, _, su)) = self.class_unpacked_array_prop_of(lvalue) else {
+            return false;
+        };
+        let Some(m0) = su
+            .members
+            .first()
+            .and_then(|m| m.declarators.first())
+            .map(|d| d.name.name.clone())
+        else {
+            return false;
+        };
+        let probe = Self::append_member_expr(lvalue, &m0);
+        self.class_unpacked_leaf(&probe).is_some()
+    }
+
+    /// Write one unpacked-struct value into a class-property element's leaf
+    /// cells, member by member, so each lands via the (working) per-leaf path.
+    fn assign_class_unpacked_elem(
+        &mut self,
+        lvalue: &Expression,
+        rvalue: &Expression,
+        su: &crate::ast::types::StructUnionType,
+    ) {
+        let items: Option<Vec<&Expression>> = match &rvalue.kind {
+            ExprKind::AssignmentPattern(its) => {
+                let ord = self.pattern_ordered(its);
+                (!ord.is_empty()).then_some(ord)
+            }
+            _ => None,
+        };
+        let mut k = 0usize;
+        for m in &su.members {
+            for md in &m.declarators {
+                let mn = md.name.name.as_str();
+                let lhs_f = Self::append_member_expr(lvalue, mn);
+                let v = match &items {
+                    // Ordered pattern: item k belongs to the k-th declared member.
+                    Some(its) => match its.get(k) {
+                        Some(e) => {
+                            let e = (*e).clone();
+                            self.eval_expr(&e)
+                        }
+                        None => continue,
+                    },
+                    None => {
+                        let rhs_f = Self::append_member_expr(rvalue, mn);
+                        self.eval_expr(&rhs_f)
+                    }
+                };
+                self.assign_value(&lhs_f, &v);
+                k += 1;
+            }
+        }
+    }
+
     /// `class_agg_member` for an already-split `<base>.<field>`.
     fn class_agg_member_parts(&mut self, base: &Expression, field: &str) -> Option<ClassAggRef> {
         if self.no_class_objects() {
@@ -99955,6 +100097,26 @@ impl Simulator {
 
     /// Build a member-access lvalue for the write-back of a struct formal.
     /// See `bind_unpacked_struct_arg` for why the `Ident` form is preferred.
+    /// `<base>[i]` as an expression, for driving per-element decomposition.
+    fn index_expr(base: &Expression, i: i64) -> Expression {
+        Expression::new(
+            ExprKind::Index {
+                expr: Box::new(base.clone()),
+                index: Box::new(Expression::new(
+                    ExprKind::Number(NumberLiteral::Integer {
+                        size: None,
+                        signed: true,
+                        base: NumberBase::Decimal,
+                        value: i.to_string(),
+                        cached_val: std::cell::Cell::new(None),
+                    }),
+                    base.span,
+                )),
+            },
+            base.span,
+        )
+    }
+
     fn struct_member_lvalue(base: &Expression, member: &str) -> Expression {
         if let ExprKind::Ident(hier) = &base.kind {
             let mut path = hier.path.clone();
@@ -104802,6 +104964,49 @@ impl Simulator {
                     let scoped = format!("{}#{}", handle, pname);
                     if let ExprKind::AssignmentPattern(items) = &init.kind {
                         let indices: Vec<i64> = (lo..=hi).collect();
+                        // §7.2/§18.4: an UNPACKED-STRUCT element has no single
+                        // cell — its members live as `<prop>[i].<m>` in the
+                        // instance property map, which is where the read path
+                        // (`class_unpacked_leaf`) looks. Storing the element as
+                        // one packed value under the signal name `<h>#<prop>[i]`
+                        // wrote something nothing reads, so every element of a
+                        // `localparam`/`const` array of unpacked structs came
+                        // back 0 — the shape a directed-stimulus table uses.
+                        // Decompose into the same cells the runtime element
+                        // write now uses.
+                        if let Some(su) = self.class_prop_struct(handle, &pname) {
+                            if Self::spreads_member_wise(&su) {
+                                let base = Expression::new(
+                                    ExprKind::Ident(crate::ast::expr::HierarchicalIdentifier {
+                                        root: None,
+                                        path: vec![crate::ast::expr::HierPathSegment {
+                                            name: crate::ast::Identifier {
+                                                name: pname.clone(),
+                                                span: crate::ast::Span::dummy(),
+                                            },
+                                            selects: Vec::new(),
+                                        }],
+                                        span: crate::ast::Span::dummy(),
+                                        cached_signal_id: std::cell::Cell::new(None),
+                                        cached_resolved_name: std::cell::OnceCell::new(),
+                                    }),
+                                    crate::ast::Span::dummy(),
+                                );
+                                let elems = self.pattern_elems(items, &indices);
+                                let owned: Vec<(usize, Option<Expression>)> = elems
+                                    .into_iter()
+                                    .map(|e| e.cloned())
+                                    .enumerate()
+                                    .collect();
+                                for (k, e) in owned {
+                                    if let Some(e) = e {
+                                        let elem = Self::index_expr(&base, indices[k]);
+                                        self.assign_class_unpacked_elem(&elem, &e, &su);
+                                    }
+                                }
+                                continue;
+                            }
+                        }
                         let elems = self.pattern_elems(items, &indices);
                         for (k, e) in elems.into_iter().enumerate() {
                             if let Some(e) = e {

--- a/src/compiler/simulator.rs
+++ b/src/compiler/simulator.rs
@@ -46309,7 +46309,9 @@ impl Simulator {
                 self.settle_triggered_list.push(eidx);
             }
         }
-        if self.time == 0 && !self.comb_time0_fired {
+        // See `settle_combinatorial_inner`: the one-shot must not retire on a
+        // static-init settle that runs before the comb graph is built.
+        if self.time == 0 && !self.comb_time0_fired && !self.comb_entries.is_empty() {
             for ti in 0..self.comb_time0_idx.len() {
                 let eidx = self.comb_time0_idx[ti];
                 if eidx < num_entries && !self.settle_triggered[eidx] {
@@ -47188,7 +47190,19 @@ impl Simulator {
         // at the same (or later) time rely on dirty propagation through the
         // worklist. The prior O(num_entries) scan per call was ~500μs on
         // c910 and dominated per-assign cost during memory-init loops.
-        if self.time == 0 && !self.comb_time0_fired {
+        //
+        // `num_entries > 0` keeps the one-shot from being CONSUMED before the
+        // comb graph exists. Class static initializers run during elaboration
+        // (the `registry spec static init` phase), long before
+        // `build combinational entries`; a blocking write in one of them
+        // reaches `settle_after_proc_write`, whose settle finds an empty
+        // entry list. Latching there seeded nothing yet retired the flag, so
+        // the real time-0 settle skipped `comb_time0_idx` entirely and every
+        // entry with an EMPTY READ SET — a constant-RHS continuous assign
+        // such as `assign a[i][v][j] = '0;` — never evaluated at all, leaving
+        // its net x for the whole run. UVM's parameterized-class registry
+        // makes that early static-init settle happen in any UVM testbench.
+        if self.time == 0 && !self.comb_time0_fired && num_entries > 0 {
             for &eidx in self.comb_time0_idx.iter() {
                 if eidx < num_entries && !triggered[eidx] {
                     triggered[eidx] = true;

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -13,6 +13,8 @@
 
 #[path = "classes/collection_of_handles_new.rs"]
 mod collection_of_handles_new;
+#[path = "classes/class_unpacked_struct_array_store.rs"]
+mod class_unpacked_struct_array_store;
 #[path = "classes/static_fixed_array_storage.rs"]
 mod static_fixed_array_storage;
 #[path = "classes/array_equality_class.rs"]

--- a/tests/classes/class_unpacked_struct_array_store.rs
+++ b/tests/classes/class_unpacked_struct_array_store.rs
@@ -1,0 +1,147 @@
+//! IEEE 1800-2017 §7.4.2 / §8.9: element writes to a CLASS-PROPERTY array of
+//! UNPACKED structs went to a different store than element reads.
+//!
+//!   class C;
+//!     typedef struct { int unsigned s; bit [1:0] x; } u_t;
+//!     u_t A [3];
+//!     function void go();
+//!       A = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };   // stored, then unreachable
+//!       $display("%0d", A[0].s);                    // 0
+//!     endfunction
+//!   endclass
+//!
+//! Two stores for one datum. `queue_elem_struct` matched a class property
+//! that is a FIXED ARRAY as though it were a queue, so a whole-ELEMENT write
+//! took the instance-scoped SIGNAL route queues legitimately use — while a
+//! fixed array's reads resolve through `class_unpacked_leaf` into the
+//! instance PROPERTY map. Caught by printing the two keys side by side:
+//!
+//!   [B22] SIGWRITE "1#BELEM[0].s" = 4
+//!         read consults heap[1].properties["BELEM[0].s"]
+//!
+//! The per-LEAF write (`arr[i].m = v`) and a scalar-struct property write
+//! both already used the property map, which is why those were the only forms
+//! that ever worked — and why the failure first looked like an initializer
+//! bug rather than a storage split.
+//!
+//! Three earlier framings were wrong and are recorded so they are not
+//! re-derived: it is not about unpacked-vs-packed element type (that
+//! comparison confounded element type with storage class), not about
+//! `localparam` (a plain runtime-assigned property fails identically), and
+//! not a hard `Value::zero` in the read path (the read path is correct
+//! throughout).
+//!
+//! Deliberately NOT covered here: a SCALAR unpacked-struct property written
+//! with a pattern (`u_t S; S = '{9,2'd1};`) still reads back 0. That is a
+//! separate defect on a separate path — it has no array element and never
+//! reaches any of the three sites below — and it predates this fix.
+//!
+//! The fix asks the READ resolver where the leaves live and writes there, at
+//! the three sites that were bypassing it. The guard is a QUESTION to the
+//! read path rather than a heuristic, so a genuine queue/dynamic/assoc
+//! element is not claimed and keeps its signal-name copy — which UVM's
+//! `uvm_hdl_path_concat::add_slice` depends on.
+
+use xezim::simulate;
+
+const SRC: &str = r#"
+module tb;
+  typedef struct { int unsigned s; bit [1:0] x; } u_t;
+
+  // MODULE scope: always worked, and is the control that isolates the fault
+  // to per-instance class storage rather than to unpacked structs.
+  u_t MVAR [3];
+  int m0, m1, m2;
+
+  class C;
+    u_t A  [3];                       // whole-ARRAY pattern
+    u_t B  [3];                       // whole-ELEMENT, pattern rhs
+    u_t D  [3];                       // whole-ELEMENT, value rhs
+    u_t E  [3];                       // per-LEAF (already worked)
+    localparam u_t LP [3] = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };
+    const     u_t KP [3] = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };
+
+    function void go();
+      u_t tmp;
+      A = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };
+      B[0] = '{4,2'd2}; B[1] = '{5,2'd1}; B[2] = '{6,2'd3};
+      tmp = '{7,2'd2};
+      D[1] = tmp;
+      E[0].s = 4; E[1].s = 5; E[2].s = 6;
+    endfunction
+  endclass
+
+  C c;
+  int a0, a1, a2, b0, b1, b2, d1, e0, e2;
+  int lp0, lp2, kp0, kp2, a0x, b2x;
+  initial begin
+    MVAR = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };
+    m0 = MVAR[0].s; m1 = MVAR[1].s; m2 = MVAR[2].s;
+
+    c = new();
+    c.go();
+    a0 = c.A[0].s; a1 = c.A[1].s; a2 = c.A[2].s;
+    b0 = c.B[0].s; b1 = c.B[1].s; b2 = c.B[2].s;
+    d1 = c.D[1].s;
+    e0 = c.E[0].s; e2 = c.E[2].s;
+    lp0 = c.LP[0].s; lp2 = c.LP[2].s;
+    kp0 = c.KP[0].s; kp2 = c.KP[2].s;
+    // The TRAILING member must land too, not just the first.
+    a0x = c.A[0].x; b2x = c.B[2].x;
+  end
+endmodule
+"#;
+
+fn i(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u64()
+        .unwrap_or_else(|| panic!("{} not u64-able", n))
+        & 0xFFFF_FFFF
+}
+
+#[test]
+fn whole_array_pattern_reaches_the_store_reads_use() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(i(&sim, "a0"), 4);
+    assert_eq!(i(&sim, "a1"), 5);
+    assert_eq!(i(&sim, "a2"), 6);
+}
+
+#[test]
+fn whole_element_writes_reach_it_with_either_rhs() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    // pattern rhs
+    assert_eq!(i(&sim, "b0"), 4);
+    assert_eq!(i(&sim, "b1"), 5);
+    assert_eq!(i(&sim, "b2"), 6);
+    // value rhs
+    assert_eq!(i(&sim, "d1"), 7);
+}
+
+#[test]
+fn every_member_lands_not_only_the_first() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(i(&sim, "a0x"), 2);
+    assert_eq!(i(&sim, "b2x"), 3);
+}
+
+#[test]
+fn class_localparam_and_const_arrays_read_back() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(i(&sim, "lp0"), 4);
+    assert_eq!(i(&sim, "lp2"), 6);
+    assert_eq!(i(&sim, "kp0"), 4);
+    assert_eq!(i(&sim, "kp2"), 6);
+}
+
+#[test]
+fn the_forms_that_already_worked_are_unchanged() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    // per-leaf writes and module scope
+    assert_eq!(i(&sim, "e0"), 4);
+    assert_eq!(i(&sim, "e2"), 6);
+    assert_eq!(i(&sim, "m0"), 4);
+    assert_eq!(i(&sim, "m1"), 5);
+    assert_eq!(i(&sim, "m2"), 6);
+}

--- a/tests/gates.rs
+++ b/tests/gates.rs
@@ -49,3 +49,5 @@ mod fst_time_table_breakeven;
 mod interrupt_finalizes_dumps;
 #[path = "gates/cont_assign_packed2d_unit_inner.rs"]
 mod cont_assign_packed2d_unit_inner;
+#[path = "gates/const_cont_assign_time0_seed.rs"]
+mod const_cont_assign_time0_seed;

--- a/tests/gates/const_cont_assign_time0_seed.rs
+++ b/tests/gates/const_cont_assign_time0_seed.rs
@@ -1,0 +1,120 @@
+//! A continuous assign with a CONSTANT right-hand side must drive its net.
+//!
+//! Such an entry has an EMPTY read set, so nothing ever marks it dirty: it
+//! reaches the settle worklist only through the one-shot `comb_time0_idx`
+//! seed, which the first settle at time 0 consumes before latching
+//! `comb_time0_fired`.
+//!
+//! A parameterized class with a `type_id` typedef has its statics initialized
+//! during elaboration ("registry spec static init"), which runs BEFORE
+//! "build combinational entries". A blocking write in one of those
+//! initializers reaches `settle_after_proc_write`, whose settle finds an
+//! EMPTY entry list — it seeded nothing, yet retired the one-shot anyway. The
+//! real time-0 settle then skipped `comb_time0_idx` entirely and every
+//! constant-driven net kept its x for the whole run.
+//!
+//! `uvm_object_registry` is exactly this shape, so ANY UVM testbench armed
+//! it: in a FlooNoC router the crossbar tie-offs (`assign masked_valid[out]
+//! [v][in] = '0;`) stayed x, the output arbiters saw an x valid, and the
+//! router never forwarded a flit.
+//!
+//! Expected values are the reference simulator's.
+
+use xezim::simulate;
+
+fn out(src: &str) -> String {
+    let sim = simulate(src, 200).expect("simulate failed");
+    sim.output
+        .iter()
+        .map(|o| o.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The regression itself: an elaboration-time static-init write must not
+/// retire the time-0 seed that the constant continuous assigns depend on.
+#[test]
+fn const_cont_assign_survives_static_init_settle() {
+    const SRC: &str = r#"
+module top;
+  logic [4:0] tied;
+  logic       poked;
+
+  class Poker #(int W = 1);
+    typedef Poker#(W) type_id;
+    static int dummy = poke();
+    static function int poke();
+      top.poked = 1'b1;
+      return W;
+    endfunction
+  endclass
+
+  Poker#(3) p3;
+
+  for (genvar i = 0; i < 5; i++) begin : g
+    assign tied[i] = '0;
+  end
+
+  initial begin
+    #1 $display("T %b", tied);
+    $finish;
+  end
+endmodule
+"#;
+    let o = out(SRC);
+    assert!(
+        o.contains("T 00000"),
+        "constant-RHS continuous assigns must drive:\n{}",
+        o
+    );
+}
+
+/// The same shape the FlooNoC crossbar uses: a packed 3-D net whose cells are
+/// split between a constant tie-off and a driven expression, with the static
+/// initializer in play. Only the tie-offs were lost, so a whole-vector check
+/// would have passed while half the net stayed x.
+#[test]
+fn packed_3d_tie_offs_and_driven_cells_agree() {
+    const SRC: &str = r#"
+module top;
+  logic [4:0][0:0][4:0] mv;
+  logic [4:0][0:0]      src;
+  logic                 poked;
+
+  class Poker #(int W = 1);
+    typedef Poker#(W) type_id;
+    static int dummy = poke();
+    static function int poke();
+      top.poked = 1'b1;
+      return W;
+    endfunction
+  endclass
+
+  Poker#(2) p2;
+
+  for (genvar o = 0; o < 5; o++) begin : go
+    for (genvar v = 0; v < 1; v++) begin : gv
+      for (genvar i = 0; i < 5; i++) begin : gi
+        if (o == i) begin : gen_no_conn
+          assign mv[o][v][i] = '0;
+        end else begin : gen_conn
+          assign mv[o][v][i] = src[i][v];
+        end
+      end
+    end
+  end
+
+  initial begin
+    src = '0;
+    #1 $display("M %b", mv);
+    $finish;
+  end
+endmodule
+"#;
+    let o = out(SRC);
+    assert!(
+        o.contains("M 0000000000000000000000000"),
+        "tied cells must resolve alongside the driven ones:\n{}",
+        o
+    );
+}

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -161,3 +161,5 @@ mod bind_with_parameters;
 mod ref_formal_same_name;
 #[path = "hierarchy/instance_block_locals_shadow_module_names.rs"]
 mod instance_block_locals_shadow_module_names;
+#[path = "hierarchy/vif_packed_array_elem_nba.rs"]
+mod vif_packed_array_elem_nba;

--- a/tests/hierarchy/vif_packed_array_elem_nba.rs
+++ b/tests/hierarchy/vif_packed_array_elem_nba.rs
@@ -1,0 +1,121 @@
+//! §25.8 / §7.4.1 — a NONBLOCKING write to an ELEMENT of a packed array
+//! reached through a virtual interface kept only the RHS's least significant
+//! bit.
+//!
+//! `infer_lhs_width`'s Index arm walks the chained index nodes down to a root
+//! and then asks the packed-dimension maps how wide the selected element is —
+//! but it only accepted an `Ident` root. For `vif.data[p]` the root is a
+//! `MemberAccess`, so the whole block was skipped and the lvalue fell through
+//! to the 1-bit default. The NBA scheduler resizes its value with
+//! `val.resize_for_assign(w)` BEFORE queueing, so the flit was truncated to
+//! one bit on the way into the queue and no amount of correctness at the
+//! commit site could recover it.
+//!
+//! Only this combination broke. The blocking form never consults
+//! `infer_lhs_width`; a module-scope array and a hierarchical `i0.d[i] <= ...`
+//! both have an `Ident` root and were always right. That is what made it look
+//! like a virtual-interface binding bug rather than a width-inference one.
+//!
+//! Found on a FlooNoC router UVM bench, where the driver's
+//! `vif.data_in[p] <= item.as_flit();` delivered an all-zero 81-bit flit. The
+//! router then routed every input to the same port (`dst_id` 0), which
+//! `XYRouteOpt` ties off, and nothing was ever forwarded.
+//!
+//! Expected values are the reference simulator's.
+
+use xezim::simulate;
+
+fn out(src: &str) -> String {
+    let sim = simulate(src, 400).expect("simulate failed");
+    sim.output
+        .iter()
+        .map(|o| o.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+const SRC: &str = r#"
+package p;
+  typedef struct packed { logic [7:0] a; logic [7:0] b; } s_t;
+endpackage
+
+interface itf;
+  import p::*;
+  logic [4:0][15:0] dl;   // packed 2-D
+  s_t   [4:0]       ds;   // packed array of a packed STRUCT, same bit count
+endinterface
+
+class Drv;
+  virtual itf vif;
+  function new(virtual itf v); vif = v; endfunction
+  task nba_dyn(int i, logic [15:0] val);
+    vif.dl[i] <= val;
+    vif.ds[i] <= val;
+  endtask
+  task nba_const(logic [15:0] val);
+    vif.dl[2] <= val;
+    vif.ds[2] <= val;
+  endtask
+  task blk_dyn(int i, logic [15:0] val);
+    vif.dl[i] = val;
+    vif.ds[i] = val;
+  endtask
+endclass
+
+module top;
+  itf i0();
+  logic [4:0][15:0] m;
+  int k = 2;
+  Drv d;
+  initial begin
+    d = new(i0);
+
+    i0.dl = '0; i0.ds = '0; #1; d.nba_dyn(2, 16'hbeef); #1;
+    $display("VIF_NBA_DYN %h %h", i0.dl, i0.ds);
+
+    i0.dl = '0; i0.ds = '0; #1; d.nba_const(16'hbeef); #1;
+    $display("VIF_NBA_CONST %h %h", i0.dl, i0.ds);
+
+    i0.dl = '0; i0.ds = '0; #1; d.blk_dyn(2, 16'hbeef); #1;
+    $display("VIF_BLK %h %h", i0.dl, i0.ds);
+
+    m = '0; #1; m[k] <= 16'hbeef; #1;
+    $display("MOD_NBA %h", m);
+
+    i0.dl = '0; #1; i0.dl[k] <= 16'hbeef; #1;
+    $display("HIER_NBA %h", i0.dl);
+    $finish;
+  end
+endmodule
+"#;
+
+/// The regression: an NBA through a vif must write the whole ELEMENT.
+#[test]
+fn vif_nba_element_write_keeps_its_full_width() {
+    let o = out(SRC);
+    assert!(
+        o.contains("VIF_NBA_DYN 00000000beef00000000 00000000beef00000000"),
+        "vif NBA with a dynamic index must write all 16 bits:\n{}",
+        o
+    );
+    assert!(
+        o.contains("VIF_NBA_CONST 00000000beef00000000 00000000beef00000000"),
+        "a constant index is the same lvalue shape:\n{}",
+        o
+    );
+}
+
+/// The forms that already worked must keep working — the width question is
+/// now asked about a name the vif path resolves, so a regression here would
+/// mean the Ident root stopped being answered.
+#[test]
+fn blocking_module_and_hierarchical_element_writes_are_unchanged() {
+    let o = out(SRC);
+    for expect in [
+        "VIF_BLK 00000000beef00000000 00000000beef00000000",
+        "MOD_NBA 00000000beef00000000",
+        "HIER_NBA 00000000beef00000000",
+    ] {
+        assert!(o.contains(expect), "expected {expect:?} in:\n{}", o);
+    }
+}

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -366,3 +366,5 @@ mod real_to_integral_local;
 mod system_function_result_width;
 #[path = "types/packed_member_select_name_collision.rs"]
 mod packed_member_select_name_collision;
+#[path = "types/bit_write_unknown_index_discarded.rs"]
+mod bit_write_unknown_index_discarded;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -27,6 +27,8 @@ mod ansi_port_name_with_unpacked_dim;
 mod array_element_declared_signedness;
 #[path = "types/array_parameter.rs"]
 mod array_parameter;
+#[path = "types/nested_packed_member_lvalue.rs"]
+mod nested_packed_member_lvalue;
 #[path = "types/array_query_multidim_packed.rs"]
 mod array_query_multidim_packed;
 #[path = "types/assoc_of_queue_enumeration.rs"]

--- a/tests/types/bit_write_unknown_index_discarded.rs
+++ b/tests/types/bit_write_unknown_index_discarded.rs
@@ -1,0 +1,138 @@
+//! §11.5.1 — a bit-select WRITE at an unknown or out-of-range index modifies
+//! no bits. The write-side sibling of `array_read_unknown_index_is_x`, and it
+//! had the same cause: `to_u64().unwrap_or(0)`.
+//!
+//! `Value::to_u64` returns `Some(val_bits & !xz_bits)` — it masks x bits to
+//! ZERO and never returns `None` — so every dynamic bit-store treated an
+//! unknown index as bit 0 and wrote there. Out-of-range indices were already
+//! handled, because `Value::set_bit` drops them, which is why a constant
+//! out-of-range index behaved correctly all along and hid the shape of the
+//! bug.
+//!
+//! An `initial` block and a task got this right, so the defect only showed
+//! from inside an always block. That is the shape a wormhole arbiter uses to
+//! build its per-input ready:
+//!
+//! ```systemverilog
+//! always_comb begin
+//!   ready_o = '0;
+//!   ready_o[selected_idx] = (|valid_i) ? ready_i : '0;
+//! end
+//! ```
+//!
+//! At reset `valid_i` is x, so `selected_idx` is x and bit 0 of `ready_o`
+//! picked up an x that the LRM says must never be written. Downstream that x
+//! reached a crossbar's ready and stalled the router forever.
+//!
+//! Note that Verilator cannot referee this: it is 2-state here, resolves the
+//! index to 0 and performs the write. The expected values below are the LRM's.
+
+use xezim::simulate;
+
+fn out(src: &str) -> String {
+    let sim = simulate(src, 200).expect("simulate failed");
+    sim.output
+        .iter()
+        .map(|o| o.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn unknown_index_bit_write_is_discarded() {
+    const SRC: &str = r#"
+module top;
+  logic [2:0] sel;            // never assigned -> stays x
+  logic [4:0] a, b, c, d;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  always_comb begin           // fill, then an x-index write
+    a = '0;
+    a[sel] = 1'b1;
+  end
+  always_comb begin           // x-index write with no fill: stays all-x
+    b[sel] = 1'b1;
+  end
+  always_ff @(posedge clk) begin
+    c <= '0;
+    c[sel] <= 1'b1;
+  end
+  initial begin               // the same write outside an always block
+    d = '0;
+    d[sel] = 1'b1;
+  end
+
+  initial begin
+    #12;
+    $display("A %b B %b C %b D %b", a, b, c, d);
+    $finish;
+  end
+endmodule
+"#;
+    let o = out(SRC);
+    assert!(
+        o.contains("A 00000 B xxxxx C 00000 D 00000"),
+        "an x index must modify no bits, in always_comb, always_ff and initial \
+         alike:\n{}",
+        o
+    );
+}
+
+/// The neighbouring index forms must keep working: a known in-range index
+/// still writes, and a constant out-of-range one is still dropped.
+#[test]
+fn known_and_out_of_range_indices_unchanged() {
+    const SRC: &str = r#"
+module top;
+  logic [4:0] e, f, g;
+  logic [2:0] two = 3'd2;
+  always_comb begin
+    e = '0;
+    e[two] = 1'b1;            // dynamic, known, in range
+  end
+  always_comb begin
+    f = '0;
+    f[3'd6] = 1'b1;           // constant, out of range
+  end
+  always_comb begin
+    g = '0;
+    g[3'd4] = 1'b1;           // constant, in range
+  end
+  initial begin
+    #1 $display("E %b F %b G %b", e, f, g);
+    $finish;
+  end
+endmodule
+"#;
+    let o = out(SRC);
+    assert!(o.contains("E 00100 F 00000 G 10000"), "index forms that already worked:\n{}", o);
+}
+
+/// The arbiter shape the bug was found in: once any input is valid the index
+/// resolves and the write lands normally, so the fix must not suppress the
+/// real write.
+#[test]
+fn arbiter_ready_resolves_once_valid_is_known() {
+    const SRC: &str = r#"
+module top;
+  logic [4:0] valid_i;
+  logic [2:0] sel;
+  logic [4:0] ready_o;
+  always_comb begin
+    ready_o = '0;
+    ready_o[sel] = (|valid_i) ? 1'b1 : '0;
+  end
+  initial begin
+    #1 $display("RESET %b", ready_o);       // valid_i and sel are x
+    valid_i = 5'b00100;
+    sel     = 3'd2;
+    #1 $display("VALID %b", ready_o);
+    $finish;
+  end
+endmodule
+"#;
+    let o = out(SRC);
+    assert!(o.contains("RESET 00000"), "no bit written while the index is x:\n{}", o);
+    assert!(o.contains("VALID 00100"), "the real write still lands:\n{}", o);
+}

--- a/tests/types/nested_packed_member_lvalue.rs
+++ b/tests/types/nested_packed_member_lvalue.rs
@@ -1,0 +1,175 @@
+//! IEEE 1800-2017 §7.2.2: a write to a NESTED packed-struct member through a
+//! `MemberAccess` lvalue was silently dropped.
+//!
+//!   typedef struct packed { logic [4:0] x, y; } id_t;
+//!   typedef struct packed { id_t d; logic last; } hdr_t;
+//!   function automatic f_t build();
+//!     f_t f; f = '0;
+//!     f.hdr.d = mk_id();      // vanished
+//!     f.pl    = 64'hface…;    // landed
+//!   endfunction
+//!
+//! `packed_struct_fields[<decl>]` is FLATTENED — every nested member is a key
+//! in its own right (`"hdr.d.x"` under `"f"`), and there is NO entry for an
+//! intermediate member on its own. The `MemberAccess` arm of
+//! `assign_value_inner` split the lvalue at exactly ONE dot, so `f.hdr.d`
+//! asked for `packed_struct_fields["f.hdr"]`, got `None`, declined, and the
+//! write fell through every remaining arm and disappeared. Only a DEPTH-1
+//! member ever resolved, which is why `f.pl` was the one line that survived.
+//!
+//! Two things about the original framing were wrong and are worth not
+//! re-deriving: it is NOT about subroutine-local storage (a task writing a
+//! module-scope signal fails identically — the discriminator is that inside a
+//! subroutine `m.hdr.d` parses as `MemberAccess`, where at module scope the
+//! same text is a dotted `Ident` on a path that already resolved), and READS
+//! were never broken at any depth.
+//!
+//! The fix walks the split points LONGEST BASE FIRST, the same candidate walk
+//! `resolve_packed_struct_target` already did for assignment patterns. That
+//! asymmetry explains the whole variant table below: the pattern RHS worked
+//! because its path had the walk, the value RHS did not.
+
+use xezim::simulate;
+
+const SRC: &str = r#"
+package p;
+  typedef struct packed { logic [4:0] x; logic [4:0] y; } id_t;   // 10 bits
+  typedef struct packed { id_t d; logic last; }          hdr_t;   // 11 bits
+  typedef struct packed { hdr_t hdr; logic [63:0] pl; }  f_t;     // 75 bits
+
+  function automatic id_t mk_id();
+    id_t i;
+    i = '0; i.x = 5'd2; i.y = 5'd1;
+    return i;
+  endfunction
+endpackage
+
+module tb;
+  import p::*;
+
+  // Depth-2 member, FUNCTION-CALL rhs — the form that was dropped.
+  function automatic f_t via_call();
+    f_t f; f = '0;
+    f.hdr.d = mk_id();
+    f.pl    = 64'hface000000000000;
+    return f;
+  endfunction
+
+  // Depth-2 member, assignment-PATTERN rhs — always worked; the control that
+  // localises the fault to the value path.
+  function automatic f_t via_pattern();
+    f_t f; f = '0;
+    f.hdr.d = '{x: 5'd2, y: 5'd1};
+    f.pl    = 64'hface000000000000;
+    return f;
+  endfunction
+
+  // Depth-2 ONE-BIT member, and depth THREE.
+  function automatic f_t via_onebit();
+    f_t f; f = '0;
+    f.hdr.last = 1'b1;
+    f.pl       = 64'hface000000000000;
+    return f;
+  endfunction
+  function automatic f_t via_deep();
+    f_t f; f = '0;
+    f.hdr.d.x = 5'd2;
+    f.hdr.d.y = 5'd1;
+    f.pl      = 64'hface000000000000;
+    return f;
+  endfunction
+
+  // A TASK writing a MODULE-scope signal: same MemberAccess lvalue shape, so
+  // it failed identically. This is what disproved "subroutine-local storage".
+  f_t m;
+  task automatic write_module_scope();
+    m = '0;
+    m.hdr.d = mk_id();
+    m.pl    = 64'hface000000000000;
+  endtask
+
+  // Reads were never broken — assert that explicitly so a future fix to the
+  // write path cannot quietly regress them.
+  int rd_x, rd_y, rd_last;
+
+  logic [74:0] r_call, r_pattern, r_onebit, r_deep, r_module;
+  initial begin
+    f_t probe;
+    r_call    = via_call();
+    r_pattern = via_pattern();
+    r_onebit  = via_onebit();
+    r_deep    = via_deep();
+    write_module_scope();
+    r_module  = m;
+
+    probe = '0;
+    probe.hdr.d.x = 5'd9;
+    probe.hdr.d.y = 5'd3;
+    probe.hdr.last = 1'b1;
+    rd_x    = probe.hdr.d.x;
+    rd_y    = probe.hdr.d.y;
+    rd_last = probe.hdr.last;
+  end
+endmodule
+"#;
+
+/// `{hdr{d{x=2,y=1}, last}, pl}` — x is the top 5 bits of `d`.
+/// d = 2<<5 | 1 = 0x41; hdr = d<<1 | last; f = hdr<<64 | pl.
+const D: u128 = (2u128 << 5) | 1;
+const PL: u128 = 0xface_0000_0000_0000;
+const EXP_NO_LAST: u128 = ((D << 1) << 64) | PL;
+const EXP_LAST: u128 = (((D << 1) | 1) << 64) | PL;
+const EXP_ONEBIT: u128 = (1u128 << 64) | PL;
+
+fn v(sim: &xezim::compiler::Simulator, n: &str) -> u128 {
+    sim.get_signal(n)
+        .unwrap_or_else(|| panic!("signal not found: {}", n))
+        .to_u128()
+}
+
+fn i(sim: &xezim::compiler::Simulator, n: &str) -> u64 {
+    sim.get_signal(n).unwrap().to_u64().unwrap() & 0xFFFF_FFFF
+}
+
+#[test]
+fn depth_two_member_write_with_a_value_rhs_lands() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(v(&sim, "r_call"), EXP_NO_LAST);
+}
+
+#[test]
+fn the_pattern_rhs_control_still_agrees() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(v(&sim, "r_pattern"), EXP_NO_LAST);
+}
+
+#[test]
+fn one_bit_and_depth_three_members_land() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(v(&sim, "r_onebit"), EXP_ONEBIT);
+    assert_eq!(v(&sim, "r_deep"), EXP_NO_LAST);
+}
+
+#[test]
+fn a_task_writing_a_module_scope_signal_lands_too() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(v(&sim, "r_module"), EXP_NO_LAST);
+}
+
+#[test]
+fn nested_member_reads_are_unaffected() {
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(i(&sim, "rd_x"), 9);
+    assert_eq!(i(&sim, "rd_y"), 3);
+    assert_eq!(i(&sim, "rd_last"), 1);
+}
+
+#[test]
+fn the_last_bit_and_the_id_share_the_header_correctly() {
+    // Guards the bit layout the other expectations are computed from: setting
+    // BOTH `hdr.d` and `hdr.last` must produce their OR, not one clobbering
+    // the other.
+    let sim = simulate(SRC, 100).expect("simulate failed");
+    assert_eq!(EXP_LAST, EXP_NO_LAST | (1u128 << 64));
+    assert_eq!(v(&sim, "r_onebit") & !PL, 1u128 << 64);
+}


### PR DESCRIPTION

Five commits, one per defect. Each stands alone and can be reverted on its
own. I grouped them because they all turned up the same way, bringing up a FlooNoC router UVM smoke bench that Verilator 5.050 passes, and because four of the five are the same kind of defect: a procedural write that resolved to the wrong storage, or to no storage at all, and disappeared without a diagnostic.


| # | Commit | Defect |
|---|---|---|
| 1 | `Discard a bit-select write whose index is x or z` | §11.5.1: an x/z index wrote bit 0 from inside an always block |
| 2 | `Don't retire the time-0 comb seed before the graph exists` | a constant-RHS continuous assign never evaluated in any UVM testbench |
| 3 | `Infer the element width of an indexed virtual-interface lvalue` | `vif.d[i] <= val` truncated to 1 bit |
| 4 | `Resolve a NESTED packed-struct member lvalue to its registered base` | `f.hdr.d = v` dropped; only depth-1 members resolved |
| 5 | `Write class unpacked-struct array elements to the store their reads use` | element writes and element reads used two different stores |

---

## 1. A bit-select write with an x/z index is not discarded

§11.5.1 says a bit-select write at an unknown or out-of-range index modifies
no bits. Out-of-range was already correct, because `Value::set_bit` drops it.
An x/z index wrote bit 0.

```systemverilog
logic [2:0] sel;        // never assigned, stays x
logic [4:0] a;
always_comb begin
  a = '0;
  a[sel] = 1'b1;        // before: 00001    LRM: 00000
end
```

`Value::to_u64` returns `Some(val_bits & !xz_bits)`. It masks x bits to zero
and never returns `None`, so the `to_u64().unwrap_or(0)` behind every dynamic
bit-store had no way to tell an unknown index from a genuine 0. An `initial`
block and a task were already correct, which is why this only showed up from
inside an always block.

A shared `dyn_bit_index` now returns `None` on `has_xz()`. It is used at all
five interpreter sites: the sequential, view and parallel executors, in both
the blocking and NBA forms. The JIT and AOT backends reach the same stores
through the `blk_range` and `nba_bit` bridges and were passing only the
index's value plane, so the x plane never arrived. Both now hand the bridge a
deliberately out-of-range index when the x plane is non-zero, which those
bridges already drop. The ABI is unchanged.

One caveat on the test: Verilator cannot referee this. It is 2-state here, so
it resolves the index to 0, performs the write, and prints `00001` for the
broken cases. The expected values in the test come from the LRM.

## 2. A constant-RHS continuous assign never drives in a UVM testbench

`assign a[i] = '0;` never evaluated and its net kept `x` for the whole run, in
any design that also has a parameterized class with a `type_id` typedef. That
is to say, in every UVM testbench.

An entry whose RHS is constant has an empty read set, so nothing ever marks it
dirty. It reaches the settle worklist through exactly one path: the one-shot
`comb_time0_idx` seed in `settle_combinatorial_inner`, which the first settle
at time 0 consumes before latching `comb_time0_fired`.

`settle_after_proc_write` runs a settle after every procedural blocking write.
A parameterized class with a `type_id` typedef has its statics initialized in
the `registry spec static init` elaboration phase, which runs before `build
combinational entries`. So that settle finds an empty entry list. It seeds
nothing and retires the one-shot anyway. The real time-0 settle then skips
`comb_time0_idx`, and every constant-driven net in the design goes
unevaluated: 251 of them in the bench.

The fix is to require a non-empty entry list before the one-shot is consumed,
in both `settle_combinatorial_inner` and `settle_combinatorial_bsp`.

The step that cracked it was odd enough to be worth passing on. A 50-line
non-UVM harness instantiating the DUT directly does not reproduce. Adding
`uvm_pkg.sv` to the compile alone, with UVM still never instantiated, does. A
design that changes because an unused package got compiled is a global table
or a global one-shot, never the RTL.

## 3. An NBA to a packed-array element through a virtual interface keeps only the LSB

```systemverilog
task nba(int i, logic [15:0] val); vif.d[i] <= val; endtask   // wrote 0x0001
```

Exactly one combination breaks, NBA plus virtual interface. The blocking form
is fine, a module-scope array is fine, and a hierarchical interface reference
(`i0.d[k] <= ...`) is fine.

`infer_lhs_width`'s `ExprKind::Index` arm walks the chained index nodes down
to a root and then asks the dimension maps how wide the selected element is,
but it accepted only an `Ident` root. `vif.d[i]` has a `MemberAccess` root, so
the whole block was skipped and the lvalue fell through to the trailing `1`.

That width is applied at schedule time, in the `resize_for_assign` that runs
before the entry is queued. The value was already one bit wide before anything
at the commit site could see it. Hence the blocking form being unaffected: it
never consults `infer_lhs_width`. Hence also an `Ident`-rooted array always
being right.

A new helper, `vif_member_flat_name`, resolves `vif.member` and
`this.vif.member` to the bound interface signal's flat name, which is what the
packed-dimension maps are keyed by. It is the same lookup `resolve_nba_target`
already does. The width logic itself is untouched; the arm just reaches it for
one more root shape.

I spent a while on the wrong patch first, which may save someone else the
trip. My first attempt went into `assign_value`'s §25.8 vif arm, which does
write bit `i` unconditionally and looks exactly like the culprit. It changed
nothing, because that arm is not on this path. The truncation only showed up
after following the NBA queue back to its schedule site.

## 4. A nested packed-struct member write is dropped when the lvalue is a MemberAccess

`f.hdr.d = mk_id();` vanished. `f.pl = 64'hface...;` in the same function
landed.

`packed_struct_fields[<decl>]` is flattened. Every nested member is a key in
its own right (`"hdr.d.x"` under `"f"`), and there is no entry for an
intermediate member on its own. The `MemberAccess` arm of `assign_value_inner`
split the lvalue at exactly one dot, so `f.hdr.d` asked for
`packed_struct_fields["f.hdr"]`, got `None`, declined, and the write fell
through every remaining arm. Only a depth-1 member ever resolved.

A new `packed_struct_member_slice` walks the split points longest base first,
which is the same candidate walk `resolve_packed_struct_target` already does
for assignment patterns. That asymmetry explains the whole variant table:
`f.hdr.d = '{x:2, y:1}` worked because the pattern path had the walk, and
`f.hdr.d = mk_id()` failed because the value path did not. The first candidate
tried is the old behaviour, so existing resolutions are unchanged.

Two things about my original framing were wrong, and the commit records them
so nobody re-derives them. This is not about subroutine-local storage: a task
writing a module-scope signal fails identically, and the real discriminator is
the lvalue shape. And reads were never broken, at any depth.

Known gap, left in deliberately: a class property base still drops the write.
The member now resolves, but `get_local_or_signal` reaches only the frame and
the signal table, not heap properties, so the arm declines at the storage step
instead of the lookup step. That wants a separate storage-routing patch.

## 5. Class unpacked-struct array elements: writes and reads used two stores

```systemverilog
class C;
  u_t A [3];
  function void go();
    A = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };   // stored, then unreachable
    $display("%0d", A[0].s);                    // 0
  endfunction
endclass
```

`queue_elem_struct` matched a class property that is a fixed array as though
it were a queue, so a whole-element write took the instance-scoped signal
route that queues legitimately use. A fixed array's reads resolve through
`class_unpacked_leaf` into the instance property map. Printing the two keys
side by side is what caught it:

```
SIGWRITE "1#BELEM[0].s" = 4
read consults heap[1].properties["BELEM[0].s"]
```

One rule at three sites: ask the read resolver where the leaves live, and
write there. The sites are the whole-element write (both RHS forms), the
whole-array pattern, hooked above the `spread` block that was consuming it,
and `localparam`/`const` construction. The guard is a question put to the read
path rather than a heuristic, so a genuine queue, dynamic array or associative
element is not claimed and keeps its signal-name copy, which UVM's
`uvm_hdl_path_concat::add_slice` depends on.

Three earlier framings were wrong here too, and the commit records them:
"unpacked vs packed element type" confounded element type with storage class,
"a `localparam` array reads back all-zero" had the wrong factor since
`localparam` is not involved, and "`coll_assoc_struct_elem` returns a hard
`Value::zero(w)`" was simply not what happened, since that probe never fired
and the read path is correct throughout.

One thing this does not fix. A scalar unpacked-struct property written with a
pattern (`u_t S; S = '{9,2'd1};`) still reads back 0. It has no array element
and reaches none of the three sites. I built the parent commit to check, and
it fails there too, so this PR is not the cause.

---

## Tests

Each commit carries its own, placed next to the existing siblings:

- `tests/types/bit_write_unknown_index_discarded.rs`, beside the read-side
  `array_read_unknown_index_is_x.rs`. It covers the x-index write in
  `always_comb`, `always_ff` and `initial`, the index forms that already
  worked so the fix cannot suppress a real write, and the arbiter shape
  itself.
- `tests/gates/const_cont_assign_time0_seed.rs`
- `tests/hierarchy/vif_packed_array_elem_nba.rs`
- `tests/types/nested_packed_member_lvalue.rs`
- `tests/classes/class_unpacked_struct_array_store.rs`

The last two are new in this submission, and I checked both the way round that
actually matters: each one fails on the parent commit of its fix and passes
with it, while its control assertions (reads unaffected, the pattern-RHS
control, the forms that already worked) pass in both states.

## Verification

`cargo test --release --features libffi/system --no-fail-fast`, on `main` at
`a00eb8b` against the stock pinned core, since this PR takes no core change:
2538 passed, 11 failed. All 11 are the pre-existing macOS `cc -shared`
DPI/VPI linker failures. They fail in `cc` before xezim runs, and the same
set fails on stock `main`.

End to end, with these five plus the companion core PR, the FlooNoC router UVM
smoke bench goes from a t=50000 watchdog timeout with 0 flits delivered to
TEST PASSED: 25 accepted, 25 delivered, 25 matched, 0 mismatches, 0 UVM_ERROR,
matching the Verilator reference. Its three fault-injection self-tests still
fail as designed, so the checkers are not vacuous.

https://claude.ai/code/session_01VNpHRwfUC38QkpLUmW3PJd
