### PR TITLE
Fix unterminated string literal in tests/misc: main does not compile

### DIFF
--- a/tests/misc/elaboration_shape_fixes.rs
+++ b/tests/misc/elaboration_shape_fixes.rs
@@ -37,7 +37,9 @@ endmodule",
 #[test]
 fn struct_pattern_elements_with_module_scope_typedef() {
     let msgs = messages(
-        "module tb;
+        // Raw string: this case is the one in the file whose SV contains a
+        // `$display("...")`, and a plain literal ends at that inner quote.
+        r#"module tb;
   typedef struct packed { bit [31:0] s; bit [1:0] x; } p_t;
   typedef struct { int s; bit [1:0] x; } u_t;
   localparam p_t LP [3] = '{ '{4,2'd2}, '{5,2'd1}, '{6,2'd3} };
@@ -47,7 +49,7 @@ fn struct_pattern_elements_with_module_scope_typedef() {
     $display("LP=%0d %0d %0d LL=%0d %0d LU=%0d %0d", LP[0].s, LP[1].s, LP[2].s, LL[0].s, LL[1].s, LU[0].s, LU[1].s);
     $finish;
   end
-endmodule",
+endmodule"#,
     );
     assert!(msgs.iter().any(|m| m == "LP=4 5 6 LL=4 5 LU=9 10"), "{msgs:?}");
 }


### PR DESCRIPTION
`main` does not compile. `cargo test` fails to build the `misc` test binary, so every PR opened against `main` right now inherits a red CI — which is how I found it.

```
error: expected expression, found `%`
  --> tests/misc/elaboration_shape_fixes.rs:47:18
   |
47 |     $display("LP=%0d %0d %0d LL=%0d %0d LU=%0d %0d", LP[0].s, ...
   |                  ^ expected expression

error: could not compile `xezim` (test "misc") due to 1 previous error
```

## Cause

`struct_pattern_elements_with_module_scope_typedef` passes its SV as a plain `"..."` literal, and its snippet is the only one in the file that contains a `$display("...")`. The Rust string ends at that inner quote, and the rest of the SV is then parsed as Rust.

The file's other two cases use plain literals as well and are fine — neither contains an inner quote. That is why the problem is confined to this one test rather than the file.

## Fix

Make it a raw string, which is what the rest of the suite uses for SV, plus a one-line comment saying why this case in particular needs one. No change to the SV or the assertion.

The test is sound; it passes as soon as it builds:

```
test elaboration_shape_fixes::struct_pattern_elements_with_module_scope_typedef ... ok
misc: 837 passed; 0 failed; 6 ignored
```

## Confirming it is pre-existing

| commit | CI |
|---|---|
| `ba8d123` | success |
| `90b730c` (current `main`) | **failure** |

That error is the only one in the failing run.

Branched from `main` and kept to this one file, deliberately: I have a separate PR (#162) that is currently red for exactly this reason, and folding an unrelated fix into it would have muddied both. This way it unblocks anyone else in the same position too.
