### PR TITLE
Regression tests: whole-struct member expansion (named patterns, nettype drivers)

### DIFF
--- a/tests/types.rs
+++ b/tests/types.rs
@@ -370,3 +370,7 @@ mod system_function_result_width;
 mod packed_member_select_name_collision;
 #[path = "types/bit_write_unknown_index_discarded.rs"]
 mod bit_write_unknown_index_discarded;
+#[path = "types/nettype_struct_variable_driver.rs"]
+mod nettype_struct_variable_driver;
+#[path = "types/struct_named_pattern_continuous_assign.rs"]
+mod struct_named_pattern_continuous_assign;

--- a/tests/types/nettype_struct_variable_driver.rs
+++ b/tests/types/nettype_struct_variable_driver.rs
@@ -1,0 +1,170 @@
+//! §6.6.7 + §10.3: a user-defined nettype net driven from a struct VARIABLE.
+//!
+//! A nettype whose data type is an unpacked struct is stored as one signal
+//! per member, so a whole-struct value has to be expanded member-wise. The
+//! WRITE side did that already. The driver side did not: drivers were packed
+//! into the resolution-function call as written.
+//!
+//! A driver that is already an assignment pattern survives, because it is
+//! member-wise as authored:
+//!
+//!     assign n = '{i: 3.0e-3, v: 0.0};        // resolved correctly
+//!
+//! A driver naming a struct variable has no whole-struct value to read, so
+//! the resolver received uninitialised members -- nan, or zero once a later
+//! pass defaulted them:
+//!
+//!     nd_t t;  always_comb t = ...;
+//!     assign n = t;                           // members arrived empty
+//!
+//! Both are legal. §10.3 gives `net_assignment ::= net_lvalue = expression`
+//! and an expression may name a variable; the only restriction the clause
+//! puts on a user-defined nettype is on the LEFT-hand side ("shall not
+//! contain any indexing or select"). So the driver is expanded member-wise,
+//! not rejected.
+//!
+//! WHY IT MATTERS beyond the clause. A SPICE node is bidirectional: current
+//! is injected into it and a voltage is present on it, both properties of
+//! one net. Carrying that needs an aggregate nettype -- IEEE 1800-2017
+//! 6.6.7(d), and the LRM's own example in that clause is exactly a
+//! `{real; bit;}` struct. Without it, a real-number model must split every
+//! analog node into two ports, and cannot be instantiated against the
+//! netlist's own hierarchy.
+//!
+//! The values are asserted, not just the fact that resolution ran. The
+//! failing mode produced a resolver that WAS called, with the right driver
+//! count, and members that were quietly empty -- a test that checked only
+//! "did it resolve" would have passed against the bug.
+
+use xezim::simulate;
+
+fn notes(src: &str) -> Vec<String> {
+    let sim = simulate(src, 10_000_000).expect("simulate failed");
+    sim.output
+        .iter()
+        .map(|o| o.message.trim().to_string())
+        .filter(|l| l.starts_with("NOTE:"))
+        .collect()
+}
+
+const PKG: &str = r#"
+package p;
+  typedef struct { real i; real v; bit drives_v; } nd_t;
+  function automatic nd_t res(input nd_t drivers[]);
+    nd_t r;
+    r.i = 0.0;
+    r.v = 0.0;
+    r.drives_v = 1'b0;
+    foreach (drivers[k]) begin
+      r.i += drivers[k].i;
+      if (drivers[k].drives_v) begin
+        r.v = drivers[k].v;
+        r.drives_v = 1'b1;
+      end
+    end
+    return r;
+  endfunction
+  nettype nd_t nd with res;
+endpackage
+"#;
+
+/// Two drivers, each staged through a struct VARIABLE. Currents must sum and
+/// the voltage must come from the one driver claiming to own it.
+#[test]
+fn struct_nettype_driven_from_a_variable_resolves() {
+    let src = format!(
+        "{PKG}
+module drv import p::*; #(parameter real I = 0.0, parameter real V = 0.0,
+                          parameter bit OWNS = 1'b0) (inout nd o);
+  nd_t t;
+  always_comb begin
+    t.i = I;
+    t.v = V;
+    t.drives_v = OWNS;
+  end
+  assign o = t;
+endmodule
+
+module top;
+  p::nd n;
+  drv #(.I(3.0e-3), .V(0.0),    .OWNS(1'b0)) a (n);
+  drv #(.I(-1.0e-3), .V(1.8086), .OWNS(1'b1)) b (n);
+  initial begin
+    #1;
+    $display(\"NOTE: i=%0.4f v=%0.4f owner=%0b\", n.i * 1e3, n.v, n.drives_v);
+    $finish;
+  end
+endmodule
+"
+    );
+    // 3.0 mA and -1.0 mA sum to 2.0 mA; the voltage is b's, not a's zero,
+    // and not an average of the two.
+    assert_eq!(notes(&src), vec!["NOTE: i=2.0000 v=1.8086 owner=1"]);
+}
+
+/// The assignment-pattern form was already correct and must stay so -- it is
+/// the form that worked, and the fix must not disturb it.
+#[test]
+fn struct_nettype_driven_from_a_pattern_still_resolves() {
+    let src = format!(
+        "{PKG}
+module drv import p::*; #(parameter real I = 0.0, parameter real V = 0.0,
+                          parameter bit OWNS = 1'b0) (inout nd o);
+  assign o = '{{i: I, v: V, drives_v: OWNS}};
+endmodule
+
+module top;
+  p::nd n;
+  drv #(.I(3.0e-3), .V(0.0),    .OWNS(1'b0)) a (n);
+  drv #(.I(-1.0e-3), .V(1.8086), .OWNS(1'b1)) b (n);
+  initial begin
+    #1;
+    $display(\"NOTE: i=%0.4f v=%0.4f owner=%0b\", n.i * 1e3, n.v, n.drives_v);
+    $finish;
+  end
+endmodule
+"
+    );
+    assert_eq!(notes(&src), vec!["NOTE: i=2.0000 v=1.8086 owner=1"]);
+}
+
+/// The shape this exists for: one element OWNS the node voltage while
+/// another reads that voltage and drives a current back onto the same net.
+/// That is a SPICE node, and it is what a single port per node requires.
+#[test]
+fn a_node_can_be_read_and_driven_through_one_port() {
+    let src = format!(
+        "{PKG}
+module pump import p::*; #(parameter real G = 2.0e-3) (inout nd dra);
+  nd_t t;
+  always_comb begin
+    t.i = G * (3.3 - dra.v);
+    t.v = 0.0;
+    t.drives_v = 1'b0;
+  end
+  assign dra = t;
+endmodule
+
+module filt import p::*; #(parameter real C = 1.0e-9) (inout nd dra);
+  real state = 0.0;
+  always #1 state = state + (dra.i * 1.0e-9 / C);
+  assign dra = '{{i: 0.0, v: state, drives_v: 1'b1}};
+endmodule
+
+module top;
+  p::nd dra;
+  pump u_p (dra);
+  filt u_f (dra);
+  initial begin
+    #200000;
+    $display(\"NOTE: settled v=%0.2f i_small=%0b\", dra.v, dra.i < 1.0e-3);
+    $finish;
+  end
+endmodule
+"
+    );
+    // The pump's current falls as the node it drives against rises, so the
+    // node charges to the supply and the current goes to nothing. Staged
+    // through a variable on purpose: that is the form that used to fail.
+    assert_eq!(notes(&src), vec!["NOTE: settled v=3.30 i_small=1"]);
+}

--- a/tests/types/struct_named_pattern_continuous_assign.rs
+++ b/tests/types/struct_named_pattern_continuous_assign.rs
@@ -1,0 +1,136 @@
+//! §10.9.2: a NAMED assignment pattern in a CONTINUOUS whole-struct assign.
+//!
+//! The PROCEDURAL form already worked and is covered by
+//! `struct_named_patterns.rs` (`s = '{x: 5, y: 8'h22};` inside an
+//! initial block). This is the continuous form, which takes a different
+//! path -- `expand_whole_struct_continuous_assigns` -> 
+//! `emit_struct_member_assigns` -- and did not handle named items at all.
+//!
+//! An unpacked struct is stored one signal per member, so
+//! `assign s = <pattern>` is expanded member-wise. That expansion took the
+//! pattern apart only when every item was ORDERED:
+//!
+//!     assign s = '{3.0e-3, 1.8086};        // positional -- worked
+//!     assign s = '{i: 3.0e-3, v: 1.8086};  // named      -- wrote ZEROS
+//!
+//! The map returned None for a named item and `collect::<Option<Vec<_>>>`
+//! short-circuits the whole pattern on the first one, so the fallback ran:
+//! member-selecting the literal, `'{i: ..., v: ...}.i`, which the expansion's
+//! own comment already identifies as having no evaluation path and yielding
+//! 0. The guard was written for that hazard and then reached from the other
+//! side.
+//!
+//! Silent, and the failure is a struct of zeros -- not an error, not an X.
+//! §10.9.2 gives both forms equal standing, and named is what anyone writes
+//! for a struct whose member order is not self-evident.
+//!
+//! These assert VALUES. A test that only checked "the assign happened" would
+//! have passed against the bug: it did happen, onto members that stayed zero.
+
+use xezim::simulate;
+
+fn notes(src: &str) -> Vec<String> {
+    let sim = simulate(src, 10_000_000).expect("simulate failed");
+    sim.output
+        .iter()
+        .map(|o| o.message.trim().to_string())
+        .filter(|l| l.starts_with("NOTE:"))
+        .collect()
+}
+
+/// The two forms must agree. Ordered was correct before and must stay so.
+#[test]
+fn named_and_ordered_patterns_agree() {
+    let src = r#"
+module top;
+  typedef struct { real i; real v; } nd_t;
+  nd_t ord;
+  nd_t nam;
+  assign ord = '{3.0e-3, 1.8086};
+  assign nam = '{i: 3.0e-3, v: 1.8086};
+  initial begin
+    #1;
+    $display("NOTE: ord i=%0.4f v=%0.4f", ord.i * 1e3, ord.v);
+    $display("NOTE: nam i=%0.4f v=%0.4f", nam.i * 1e3, nam.v);
+    $finish;
+  end
+endmodule
+"#;
+    assert_eq!(
+        notes(src),
+        vec!["NOTE: ord i=3.0000 v=1.8086", "NOTE: nam i=3.0000 v=1.8086"]
+    );
+}
+
+/// Named items bind by NAME, so writing them out of declaration order must
+/// still land on the right members. Position-mapping a named pattern would
+/// pass the test above and fail this one.
+#[test]
+fn named_items_bind_by_name_not_position() {
+    let src = r#"
+module top;
+  typedef struct { real i; real v; } nd_t;
+  nd_t s;
+  assign s = '{v: 1.8086, i: 3.0e-3};   // deliberately reversed
+  initial begin
+    #1;
+    $display("NOTE: i=%0.4f v=%0.4f", s.i * 1e3, s.v);
+    $finish;
+  end
+endmodule
+"#;
+    assert_eq!(notes(src), vec!["NOTE: i=3.0000 v=1.8086"]);
+}
+
+/// Mixed member types, and a nested struct, since the expansion recurses.
+#[test]
+fn named_pattern_with_mixed_and_nested_members() {
+    let src = r#"
+module top;
+  typedef struct { real v; bit ok; } inner_t;
+  typedef struct { real i; inner_t sub; } outer_t;
+  outer_t s;
+  assign s = '{i: 2.5e-3, sub: '{v: 1.8086, ok: 1'b1}};
+  initial begin
+    #1;
+    $display("NOTE: i=%0.4f v=%0.4f ok=%0b", s.i * 1e3, s.sub.v, s.sub.ok);
+    $finish;
+  end
+endmodule
+"#;
+    assert_eq!(notes(src), vec!["NOTE: i=2.5000 v=1.8086 ok=1"]);
+}
+
+/// A named pattern feeding a module port -- the shape that made this look
+/// like a struct-PORT defect. The port was always fine; the value reaching
+/// it was already zeros.
+#[test]
+fn named_pattern_survives_a_module_port() {
+    let src = r#"
+package p;
+  typedef struct { real i; real v; } nd_t;
+endpackage
+module child import p::*; (input nd_t d);
+  initial begin
+    #2;
+    $display("NOTE: child i=%0.4f v=%0.4f", d.i * 1e3, d.v);
+  end
+endmodule
+module top;
+  import p::*;
+  nd_t s;
+  assign s = '{i: 3.0e-3, v: 1.8086};
+  child c (.d(s));
+  initial begin
+    #1;
+    $display("NOTE: parent i=%0.4f v=%0.4f", s.i * 1e3, s.v);
+    #3;
+    $finish;
+  end
+endmodule
+"#;
+    assert_eq!(
+        notes(src),
+        vec!["NOTE: parent i=3.0000 v=1.8086", "NOTE: child i=3.0000 v=1.8086"]
+    );
+}


### PR DESCRIPTION
Pin whole-struct member expansion: named patterns, and nettype drivers

Regression tests for aionhw/xezim-core#44. Two files, both in the types
group, both asserting VALUES rather than that something resolved -- each
failing mode produced a struct of zeros with no diagnostic, so a test that
checked only "did the assign happen" would have passed against it. It did
happen, onto members that stayed zero.

struct_named_pattern_continuous_assign.rs -- 4 cases

  * named and ordered forms must agree;
  * named items bind by NAME, not position. The pattern is written in
    reverse member order on purpose: an implementation that mapped named
    items position-wise would pass the first case and fail this one;
  * mixed and nested members, since the expansion recurses;
  * a named pattern reaching a module port.

  The PROCEDURAL form is already covered by struct_named_patterns.rs and
  always worked. This is the CONTINUOUS path, which is a different one --
  expand_whole_struct_continuous_assigns -> emit_struct_member_assigns --
  and the file's name and header say so, so the two are not confused later.

nettype_struct_variable_driver.rs -- 3 cases

  * a nettype net driven from a struct VARIABLE resolves: currents sum to
    2.0 mA and the voltage is the owner's 1.8086, not zero and not an
    average of the two;
  * the assignment-pattern form still resolves -- it always worked, and the
    fix must not disturb it;
  * one element owns a node's voltage while another reads that voltage and
    drives a current back through the SAME port. That is a SPICE node, and
    it is the shape that makes a single port per analog node possible at
    all: without it a real-number model splits every node in two and cannot
    be instantiated against the netlist's own hierarchy.

VERIFIED TO FAIL without the fixes, by stashing them and rebuilding. The
failures are asymmetric, which is the argument for the shape:

    nettype   1 passed, 2 failed   (pattern-driven still passes)
    named     0 passed, 4 failed

In each pair the form that always worked keeps working. A test covering only
that form would have gone green alongside the bug.

Full suite with the fixes in: 2585 passed, 0 failed across all ten groups
plus the core units -- the wide run is deliberate, since the named-pattern
fix changes how every whole-struct continuous assign is expanded.

These need the core `rev` bump from #44 to go green.

Refs: aionhw/xezim-core#44

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014eLBkW9EERLgZ9jU8TcRSg
