### PR TITLE
Un-escape the quotes inside the raw string again; the misc test group does not compile

### DIFF
--- a/tests/misc/elaboration_shape_fixes.rs
+++ b/tests/misc/elaboration_shape_fixes.rs
@@ -46,7 +46,7 @@ fn struct_pattern_elements_with_module_scope_typedef() {
   localparam p_t LL [2] = '{ 34'h13, 34'h15 };
   localparam u_t LU [2] = '{ '{9,2'd1}, '{10,2'd2} };
   initial begin
-    $display(\"LP=%0d %0d %0d LL=%0d %0d LU=%0d %0d\", LP[0].s, LP[1].s, LP[2].s, LL[0].s, LL[1].s, LU[0].s, LU[1].s);
+    $display("LP=%0d %0d %0d LL=%0d %0d LU=%0d %0d", LP[0].s, LP[1].s, LP[2].s, LL[0].s, LL[1].s, LU[0].s, LU[1].s);
     $finish;
   end
 endmodule"#,


### PR DESCRIPTION
`main` does not compile the `misc` test group.

#163 fixed this case by making the SV source a **raw** string, so the inner `$display` quotes stand as themselves. 2486c17 (in #164, "test quote escaping") then re-escaped them — but inside `r#"..."#` a backslash is a literal backslash, so the emitted SV becomes

```
$display(\"LP=%0d ...\", LP[0].s, ...)
```

and the parser reports 41 errors on it. The test *panics* rather than failing cleanly, because the panic is inside `simulate().expect()`:

```
thread 'elaboration_shape_fixes::struct_pattern_elements_with_module_scope_typedef' panicked at
tests/misc/elaboration_shape_fixes.rs:10:36:
simulate failed: "Parse errors in '<unnamed>' (file 1 of 1):
error: expected RParen, found Identifier 'd' (at byte 322..323) ..."
```

**Only the one site inside the raw string changes.** The other three `\"` in this file sit in ordinary string literals, where the escape is correct and removing it would break them — which is the trap that makes this easy to "fix" in the wrong direction.

This restores the requirement #163 landed rather than adding coverage: the escaping rules differ between the two string forms, and a file that mixes both needs each site read in its own context.

After: `cargo test --test misc` → 842 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eLBkW9EERLgZ9jU8TcRSg
