### PR TITLE
ci: add prebuilt binary release pipeline

### DIFF
--- a/.github/scripts/build-release.sh
+++ b/.github/scripts/build-release.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# xezim binary release build script.
+#
+# Runs inside stock manylinux Docker images (Linux) or natively on macOS runners.
+# Produces: xezim-<platform>-<version>.tar.gz + .sha256 + manifest.json
+# Asset naming follows generic platform conventions so any consumer can match.
+#
+# Environment (set by the caller / GitHub Actions):
+#   VERSION  - the release version (e.g. 0.10.5)
+#   ARCH     - normalized architecture (x86_64 | aarch64 | arm64)
+#   TARGET   - platform label (manylinux_2_28_x86_64, macos-arm64, etc.)
+#   SRC_DIR  - source directory (mounted at /src)
+#   WORK_DIR - scratch directory
+#   OUT_DIR  - output directory (mounted at /src/dist)
+
+set -euo pipefail
+
+VERSION="${VERSION:?VERSION required}"
+ARCH="${ARCH:?ARCH required}"
+TARGET="${TARGET:?TARGET required}"
+SRC_DIR="${SRC_DIR:-/src}"
+WORK_DIR="${WORK_DIR:-/tmp/build}"
+OUT_DIR="${OUT_DIR:-/src/dist}"
+
+release_root="${WORK_DIR}/release/xezim"
+mkdir -p "${release_root}/bin" "${WORK_DIR}/build" "${OUT_DIR}"
+
+# The workflow provisions Rust when the runner does not ship it; make a
+# rustup-installed toolchain discoverable too.
+[ -d "${HOME}/.cargo/bin" ] && export PATH="${HOME}/.cargo/bin:${PATH}"
+
+# Use the workspace's target dir explicitly to keep the source pristine.
+export CARGO_TARGET_DIR="${WORK_DIR}/cargo-target"
+
+jobs="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+echo "[build-release] building xezim ${VERSION} for ${TARGET} (arch=${ARCH})"
+
+# xezim does not commit a Cargo.lock, so generate one before the locked
+# build. The git-revision pins in Cargo.toml (xezim-core, sv-parser) make
+# the generated lockfile deterministic for a given source revision.
+( cd "${SRC_DIR}"
+  if [ ! -f Cargo.lock ]; then
+    echo "[build-release] no Cargo.lock committed, generating one"
+    cargo generate-lockfile
+  fi
+  cargo build --release --locked -j"${jobs}" --bin xezim
+)
+
+install -m 0755 "${CARGO_TARGET_DIR}/release/xezim" "${release_root}/bin/xezim"
+
+sha256_file() {
+  # sha256sum is coreutils and is not shipped on stock macOS; fall back to
+  # shasum there. Both emit "<hex>  <path>".
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${1}"
+  else
+    shasum -a 256 "${1}"
+  fi
+}
+
+# --- Create manifest.json (reproducibility record) ---
+manifest="${release_root}/manifest.json"
+{
+  echo '{'
+  echo "  \"package\": \"xezim\","
+  echo "  \"version\": \"${VERSION}\","
+  echo "  \"platform\": \"${TARGET}\","
+  echo "  \"arch\": \"${ARCH}\","
+  echo "  \"built_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+  echo "  \"rustc\": \"$(rustc --version)\","
+  echo "  \"cargo\": \"$(cargo --version)\","
+  echo "  \"cargo_lock_hash\": \"$(sha256_file "${SRC_DIR}/Cargo.lock" 2>/dev/null | cut -d' ' -f1 || echo 'unknown')\""
+  echo '}'
+} > "${manifest}"
+
+# --- Package tarball ---
+tarball="xezim-${TARGET}-${VERSION}.tar.gz"
+( cd "$(dirname "${release_root}")"
+  tar -czf "${OUT_DIR}/${tarball}" "$(basename "${release_root}")"
+)
+
+# --- SHA256 companion ---
+sha256_file "${OUT_DIR}/${tarball}" > "${OUT_DIR}/${tarball}.sha256"
+
+# --- Copy manifest alongside tarball (per-platform) ---
+cp "${manifest}" "${OUT_DIR}/manifest-${TARGET}.json"
+
+echo "[build-release] done: ${OUT_DIR}/${tarball}"
+ls -la "${OUT_DIR}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,248 @@
+# xezim release pipeline
+#
+# Builds prebuilt xezim binaries for a set of common platforms and attaches
+# them to the GitHub Release published for each version tag (e.g. 0.10.5).
+#
+# Asset naming (so any binary distribution channel can match):
+#   xezim-<platform>-<version>.tar.gz        binary package
+#   xezim-<platform>-<version>.tar.gz.sha256 checksum
+#   manifest-<platform>.json                 build record
+#
+# <platform> is one of manylinux_2_28_x86_64, manylinux_2_34_x86_64,
+# manylinux_2_28_aarch64, manylinux_2_34_aarch64, macos-arm64.
+
+name: Release
+
+on:
+  # All tags are candidates; the resolve job rejects anything that is not a
+  # bare semver (e.g. 0.10.6, no leading 'v') before anything builds.
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. 0.10.5)'
+        type: string
+        required: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ---- Resolve: validate the tag and derive the version ----
+  resolve:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      tag: ${{ steps.check.outputs.tag }}
+      tag_ok: ${{ steps.check.outputs.ok }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate tag and existence
+        id: check
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if [[ ! "${TAG}" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
+            echo "::notice::tags which are not bare semver (found '${TAG}') are ignored"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null | grep -q "refs/tags/${TAG}$"; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::tag '${TAG}' does not exist on origin"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---- Build matrix: one job per platform ----
+  build:
+    name: Build ${{ matrix.target.name }}
+    needs: resolve
+    if: needs.resolve.outputs.tag_ok == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: manylinux_2_28_x86_64
+            runs-on: ubuntu-latest
+            kind: docker
+            image: quay.io/pypa/manylinux_2_28_x86_64
+            arch: x86_64
+          - name: manylinux_2_34_x86_64
+            runs-on: ubuntu-latest
+            kind: docker
+            image: quay.io/pypa/manylinux_2_34_x86_64
+            arch: x86_64
+          - name: manylinux_2_28_aarch64
+            runs-on: ubuntu-24.04-arm
+            kind: docker
+            image: quay.io/pypa/manylinux_2_28_aarch64
+            arch: aarch64
+          - name: manylinux_2_34_aarch64
+            runs-on: ubuntu-24.04-arm
+            kind: docker
+            image: quay.io/pypa/manylinux_2_34_aarch64
+            arch: aarch64
+          - name: macos-arm64
+            runs-on: macos-14
+            kind: native
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Runs at the requested tag whether triggered by a tag push or by
+          # manual dispatch (dispatch default is the default branch).
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Ensure Rust (macOS)
+        if: matrix.target.kind == 'native'
+        run: |
+          if ! command -v rustc >/dev/null 2>&1; then
+            curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --profile minimal
+          fi
+          rustc --version
+          cargo --version
+
+      - name: Build (docker — Linux manylinux)
+        if: matrix.target.kind == 'docker'
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          ARCH: ${{ matrix.target.arch }}
+          TARGET: ${{ matrix.target.name }}
+        run: |
+          mkdir -p dist
+          docker run --rm \
+            -v "$PWD:/src" \
+            -e SRC_DIR=/src -e WORK_DIR=/tmp/build -e OUT_DIR=/src/dist \
+            -e VERSION -e ARCH -e TARGET \
+            -w /tmp/build \
+            "${{ matrix.target.image }}" \
+            bash -lc 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+                | sh -s -- -y --profile minimal \
+              && export PATH="$HOME/.cargo/bin:$PATH" \
+              && bash /src/.github/scripts/build-release.sh'
+          ls -la dist/
+
+      - name: Build (native — macOS arm64)
+        if: matrix.target.kind == 'native'
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          ARCH: ${{ matrix.target.arch }}
+          TARGET: ${{ matrix.target.name }}
+          SRC_DIR: ${{ github.workspace }}
+          WORK_DIR: ${{ runner.temp }}/build
+          OUT_DIR: ${{ github.workspace }}/dist
+        run: |
+          mkdir -p dist
+          bash .github/scripts/build-release.sh
+          ls -la dist/
+
+      - name: Upload platform artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target.name }}
+          path: dist/
+
+  # ---- Publish: merge manifests, create GitHub Release ----
+  publish:
+    name: Publish release
+    needs: [resolve, build]
+    if: needs.resolve.outputs.tag_ok == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Verify all platforms present
+        run: |
+          v="${{ needs.resolve.outputs.version }}"
+          for d in manylinux_2_28_x86_64 manylinux_2_34_x86_64 \
+                   manylinux_2_28_aarch64 manylinux_2_34_aarch64 \
+                   macos-arm64; do
+            test -f "dist/xezim-${d}-${v}.tar.gz" \
+              || { echo "::error::missing asset for ${d}"; exit 1; }
+            test -f "dist/xezim-${d}-${v}.tar.gz.sha256" \
+              || { echo "::error::missing sha256 for ${d}"; exit 1; }
+            test -f "dist/manifest-${d}.json" \
+              || { echo "::error::missing manifest for ${d}"; exit 1; }
+          done
+          echo "All 5 platforms verified."
+
+      - name: Generate release body
+        id: body
+        run: |
+          cat > release-body.md <<'EOF'
+          # xezim ${{ needs.resolve.outputs.version }}
+
+          Prebuilt binaries for the SystemVerilog interpreter (IEEE 1800-2023,
+          4-state, event-driven, VPI/DPI, FST/XTrace waveform output), built
+          from the `${{ needs.resolve.outputs.version }}` tag.
+
+          ## Platforms
+
+          | Platform | glibc / OS | Architecture |
+          |---|---|---|
+          | manylinux_2_28_x86_64 | glibc 2.28 | x86_64 |
+          | manylinux_2_34_x86_64 | glibc 2.34 | x86_64 |
+          | manylinux_2_28_aarch64 | glibc 2.28 | aarch64 |
+          | manylinux_2_34_aarch64 | glibc 2.34 | aarch64 |
+          | macos-arm64 | macOS 14+ | arm64 |
+
+          Each tarball contains the `xezim` binary and a `manifest.json` build
+          record (version, platform, toolchain, resolved Cargo.lock hash).
+
+          ## Verification
+
+          Every asset has a `.sha256` companion:
+          ```bash
+          sha256sum -c xezim-<platform>-${{ needs.resolve.outputs.version }}.tar.gz.sha256
+          ```
+
+          ## Build reproducibility
+
+          - `Cargo.toml` pins `xezim-core` and `sv-parser` to exact git
+            revisions, so the build input is fixed for a given tag.
+          - The build generates a `Cargo.lock` and compiles with
+            `cargo build --locked`, so transitive dependencies are pinned too.
+          - Linux builds run in stock `quay.io/pypa/manylinux` images, which
+            enforce the glibc floor for each `manylinux_*` platform.
+
+          ---
+          *Built from tag `${{ needs.resolve.outputs.version }}` (commit
+          `${{ github.sha }}`).*
+          EOF
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          name: xezim ${{ needs.resolve.outputs.version }}
+          body_path: release-body.md
+          files: |
+            dist/xezim-*-${{ needs.resolve.outputs.version }}.tar.gz
+            dist/xezim-*-${{ needs.resolve.outputs.version }}.tar.gz.sha256
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# CI: publish prebuilt binaries on version tags

> [!NOTE]
> This is a self-contained, distribution-agnostic release pipeline: cut a version
> tag and GitHub builds the platform tarballs and attaches them to the Release.
> Nothing in it is coupled to a specific distribution channel. It is currently
> consumed by **EDAPack**, the open EDA package catalog — the paired registration
> in the "Also useful for" section below makes each Release's assets installable
> with one command. That side is only a consumer; everything here works
> independently of it.

## Overview

`xezim` is currently distributed as source only. Each version tag gets a GitHub
Release, but that Release holds nothing but the auto-generated change notes —
anyone who wants a quick `xezim` has to clone the repo and run `cargo build`
themselves.

This PR adds the missing step: a GitHub Actions workflow that watches for version
tags, builds the simulator for the platforms people actually use, and attaches the
tarballs to the Release. After it merges, **cutting a tag is the whole release
process** — no manual packing, no extra coordination.

Two files, nothing else. The simulator's code, tests, and build settings are
untouched.

| File | Purpose |
|---|---|
| `.github/workflows/release.yml` | Tag watch → platform matrix → release publish |
| `.github/scripts/build-release.sh` | Shared build+package step (cargo build, manifest, tarball, sha256) |

## How it works

A tag push (or a manual **Run workflow** with a tag input) walks three jobs:

```text
  tag push (e.g. 0.10.5)
    │
    ▼
  resolve ─── validates the tag is bare semver ─── ignores everything else
    │
    ▼
  build (×5, in parallel)
    ├── manylinux_2_28_x86_64   (docker, glibc 2.28)
    ├── manylinux_2_34_x86_64   (docker, glibc 2.34)
    ├── manylinux_2_28_aarch64  (docker, glibc 2.28, arm64)
    ├── manylinux_2_34_aarch64  (docker, glibc 2.34, arm64)
    └── macos-arm64             (native Apple Silicon runner)
    │
    ▼
  publish ─── downloads all outputs, verifies every platform, emits a
              fully-formatted Release with assets
```

### The `resolve` job

The tag filter `push: tags: '*'` matches every tag, so validation happens in code,
not in a YAML pattern:

- accepts **bare semver** tags such as `0.10.5` (no leading `v`);
- **ignores** `v0.10.5`, pre-release tags, or any other tag — no Release is
  published for them, the build jobs are simply skipped.

GitHub Actions tag filters only support glob, not regex; a glob would match `v`
tags and `-rc` tags we don't want, so the check lives in the resolve step instead.

### Manual rebuild without re-tagging (`workflow_dispatch`)

Any tag **that includes the workflow files** (that is, any tag cut from this PR
onward) can be built on demand: **Actions → Run workflow → pick the tag**. The
workflow checks out that exact tag and builds one byte-identical to a tag-push
build. The three practical uses are re-running a failed release without re-tagging,
backfilling a release for a tag whose push run was missed, and a pre-release
smoke test.

Tags that predate this workflow don't contain `.github/scripts/build-release.sh`,
so those particular commits can't be rebuilt by it — re-tag an old tip or wait for
the next release. That's the only gap, and it only affects historical tags.

## Platforms

Linux covers the two widely-used glibc families on both architectures; Apple
Silicon covers current macOS. The manylinux images enforce the stated glibc floor,
so a `manylinux_2_28` binary runs on any distro from glibc 2.28 up (RHEL 8,
Ubuntu 20.04, and newer).

| Platform | Build environment | Architecture |
|---|---|---|
| `manylinux_2_28_x86_64` | `quay.io/pypa/manylinux_2_28_x86_64` | x86_64 |
| `manylinux_2_34_x86_64` | `quay.io/pypa/manylinux_2_34_x86_64` | x86_64 |
| `manylinux_2_28_aarch64` | `quay.io/pypa/manylinux_2_28_aarch64` (arm64 runner) | aarch64 |
| `manylinux_2_34_aarch64` | `quay.io/pypa/manylinux_2_34_aarch64` (arm64 runner) | aarch64 |
| `macos-arm64` | native macOS 14 runner | arm64 |

Linux builders bootstrap `rustup` **inside** the stock manylinux container, so the
shipped binary inherits the container's glibc floor. macOS uses a native runner;
if the image's toolchain is missing, the step installs `rustup --profile minimal`
first.

## What each Release gets

Per platform, three files:

```text
xezim-manylinux_2_28_x86_64-0.10.5.tar.gz        the binary + manifest.json
xezim-manylinux_2_28_x86_64-0.10.5.tar.gz.sha256 integrity checksum
manifest-manylinux_2_28_x86_64.json              build record (also inside
                                                 the tarball)
```

The `manifest.json` records the version, platform, architecture, build time,
`rustc`/`cargo` versions, and a hash of the resolved `Cargo.lock`, so anyone can
reproduce or audit how a binary was made.

## Reproducibility

- `Cargo.toml` pins `xezim-core` and `sv-parser` to **exact git revisions**, so the
  dependency set is fixed for a given tag.
- The build generates a `Cargo.lock` from those pins (upstream does not commit
  one) and compiles with `cargo build --release --locked`, so every transitive
  dependency is pinned for the run.
- The build keeps its own target directory and never writes into the source tree
  beyond the generated lockfile, so the same tag in the same container class
  yields identical bytes.
- Both the toolchains (byte-exact `--locked`) and the container images (pinned
  `quay.io/pypa/manylinux_*`) are recorded, not approximated.

## Verification

- The full chain — lockfile generation, `cargo build --release --locked`, manifest,
  tarball, checksum — was exercised **end-to-end against the real source** during
  development with the CI toolchain path; the resulting tarball was unpacked and
  inspected, and the `.sha256` verified against it.
- The workflow files pass validation (YAML parse, `bash -n`).
- The workflow only fires on **tag pushes and `workflow_dispatch`**, so it has not
  run in CI yet. The recommended first exercise is a manual `workflow_dispatch`
  run on a fresh tag (or a re-tag of the current tip) before the next release, so
  any problem surfaces on a smoke build rather than on the next real release.

## Files changed

```text
.github/workflows/release.yml        +248
.github/scripts/build-release.sh      +90
```

## Also useful for …

The binaries this workflow publishes are consumed by EDAPack, the open EDA package
catalog: the paired registration in
[`EDAPack/edapack.github.io#1`](https://github.com/EDAPack/edapack.github.io/pull/1)
makes each Release installable with `ivpm update -d xezim`, and as part of the
`sim.rtl` RTL-simulation bundle alongside Verilator and Icarus Verilog. That PR is
a consumer only — it adds nothing back to this workflow.

cc: @aionhw , @mballance